### PR TITLE
ENGDESK-4000: Set session member prior to invoking feed_tts

### DIFF
--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -1636,6 +1636,8 @@ switch_status_t conference_member_say(conference_member_t *member, char *text, u
 	}
 
 	fnode->sh = member->sh;
+	member->sh->session = member->session;
+	
 	/* Begin Generation */
 	switch_sleep(200000);
 


### PR DESCRIPTION
  - Conference does not set the session making mod_polly crash