### PR TITLE
ENGDESK-4206: Parse fingerprint from global sdp attribute

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5814,6 +5814,8 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					maxptime = dmaxptime = atoi(attr->a_value);
 				} else if (!strcasecmp(attr->a_name, "group")) {
 					switch_channel_set_variable(session->channel, "rtp_group", attr->a_value);
+				} else if (!strcasecmp(attr->a_name, "fingerprint") && !zstr(attr->a_value)) {
+					got_crypto = 1;
 				}
 			}
 


### PR DESCRIPTION
Firefox puts fingerprint as global attributes. We have added this global attribute in switch_core_media_validate_common_audio_sdp function (see https://github.com/team-telnyx/freeswitch/commit/66fb2f62e13c8f1721baef56ecf01ae6e90a101e#diff-57a89cb34e86ccb4471a86094b8722dc) but we need to apply this as well on switch_core_media_negotiate_sdp function.