### PR TITLE
TEL-4343:  Add a new channel variable to always auto adjust RTP

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1106,6 +1106,7 @@ static void handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *d
 				//char bufa[50];
 				char bufb[50];
 				char adj_port[6];
+				const char *rtp_auto_adjust_always = NULL;
 				switch_channel_t *channel = NULL;
 
 
@@ -1115,6 +1116,10 @@ static void handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *d
 
 				if (rtp_session->session) {
 					channel = switch_core_session_get_channel(rtp_session->session);
+				}
+				
+				if (channel) {
+					rtp_auto_adjust_always = switch_channel_get_variable(channel, "rtp_auto_adjust_always");
 				}
 
 				//ice->ice_params->cands[ice->ice_params->chosen][ice->proto].priority;
@@ -1175,7 +1180,7 @@ static void handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *d
 								return;
 							}
 
-							if ((rtp_session->rtp_bugs & RTP_BUG_ALWAYS_AUTO_ADJUST)) {
+							if ((!zstr(rtp_auto_adjust_always) && switch_true(rtp_auto_adjust_always)) || (rtp_session->rtp_bugs & RTP_BUG_ALWAYS_AUTO_ADJUST)) {
 								switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_AUTOADJ);
 							} else {
 								switch_rtp_clear_flag(rtp_session, SWITCH_RTP_FLAG_AUTOADJ);
@@ -7733,6 +7738,10 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 #endif
 
 		if (bytes && rtp_session->flags[SWITCH_RTP_FLAG_AUTOADJ] && switch_sockaddr_get_port(rtp_session->rtp_from_addr)) {
+			const char *rtp_auto_adjust_always = NULL;
+			if (channel) {
+				rtp_auto_adjust_always = switch_channel_get_variable(channel, "rtp_auto_adjust_always");
+			}
 			if (!switch_cmp_addr(rtp_session->rtp_from_addr, rtp_session->remote_addr)) {
 				if (++rtp_session->autoadj_tally >= rtp_session->autoadj_threshold) {
 					const char *err;
@@ -7770,7 +7779,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 					}
 					rtp_session->auto_adj_used = 1;
 					switch_rtp_set_remote_address(rtp_session, tx_host, switch_sockaddr_get_port(rtp_session->rtp_from_addr), 0, SWITCH_FALSE, &err);
-					if ((rtp_session->rtp_bugs & RTP_BUG_ALWAYS_AUTO_ADJUST)) {
+					if ((!zstr(rtp_auto_adjust_always) && switch_true(rtp_auto_adjust_always)) || (rtp_session->rtp_bugs & RTP_BUG_ALWAYS_AUTO_ADJUST)) {
 						switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_AUTOADJ);
 						switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_RTCP_AUTOADJ);
 					} else {
@@ -7781,7 +7790,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 					}
 				}
 			} else {
-				if ((rtp_session->rtp_bugs & RTP_BUG_ALWAYS_AUTO_ADJUST)) {
+				if ((!zstr(rtp_auto_adjust_always) && switch_true(rtp_auto_adjust_always)) || (rtp_session->rtp_bugs & RTP_BUG_ALWAYS_AUTO_ADJUST)) {
 					switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_AUTOADJ);
 					switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_RTCP_AUTOADJ);
 				} else {


### PR DESCRIPTION
  Right now, once either the port is confirmed or auto adjust
  has been performed, auto adjust flag is automatically cleared.
  a new channel variable rtp_auto_adjust_always has been introduced
  to disable this behavior