### PR TITLE
TELOPS-725: Handle possible nua status code when adding phrase suffix

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -586,8 +586,10 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 
 				if (tech_pvt->respond_phrase) {
 					phrase = su_strdup(nua_handle_home(tech_pvt->nh), tech_pvt->respond_phrase);
-				} else {
+				} else if (sip_cause >= 400 && sip_cause < 700) {
 					phrase = sip_status_phrase(sip_cause);
+				} else {
+					phrase = sip_status_phrase(500);
 				}
 
 				if (sip_cause >= 500) {

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -586,7 +586,7 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 
 				if (tech_pvt->respond_phrase) {
 					phrase = su_strdup(nua_handle_home(tech_pvt->nh), tech_pvt->respond_phrase);
-				} else if (sip_cause >= 400 && sip_cause < 700) {
+				} else if (sip_cause >= 300 && sip_cause < 700) {
 					phrase = sip_status_phrase(sip_cause);
 				} else {
 					phrase = sip_status_phrase(500);


### PR DESCRIPTION
They are cases where sip_cause may contain range value of >900. This error is coming from nua stack and when we retrieve the sip status phrase from this value it returns null. The crash happens when we try to add a suffix tv1 on error phrase. 

The fix is to make sure phrase don't contain null value. The sip_status_phrase will only return null if sip cause is less than 100 or greater than 699. If sip cause is a custom sip error code sip_status_phrase will return empty string otherwise it will return the sip error phrase. If this is a nua error code >900, we consider this as internal server error.