### PR TITLE
ENGDESK-4596: Add channel variables in sofia::notify_refer

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -708,7 +708,8 @@ void sofia_handle_sip_i_notify(switch_core_session_t *session, int status,
 			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "subscription-expires", sip->sip_subscription_state->ss_expires);
 		}
 		if (session) {
-			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "UniqueID", switch_core_session_get_uuid(session));
+			switch_channel_event_set_data(channel, s_event);
+			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "Unique-ID", switch_core_session_get_uuid(session));
 		}
 		switch_event_fire(&s_event);
 	}

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -709,7 +709,7 @@ void sofia_handle_sip_i_notify(switch_core_session_t *session, int status,
 		}
 		if (session) {
 			switch_channel_event_set_data(channel, s_event);
-			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "Unique-ID", switch_core_session_get_uuid(session));
+			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "UniqueID", switch_core_session_get_uuid(session));
 		}
 		switch_event_fire(&s_event);
 	}


### PR DESCRIPTION
Adding channel variables for event sofia::notify_refer and rename UniqueID variable to Unique-ID