### PR TITLE
ENGDESK-5043: Add new response for failed audio playback

### DIFF
--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -3126,6 +3126,12 @@ SWITCH_STANDARD_APP(playback_function)
 	case SWITCH_STATUS_NOTFOUND:
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
 		break;
+	case SWITCH_STATUS_GENERR:
+		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "UNABLE TO PLAY FILE");
+		break;
+	case SWITCH_STATUS_FALSE:
+		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "MEDIA NOT READY");
+		break;
 	default:
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR");
 		break;
@@ -3156,6 +3162,12 @@ SWITCH_STANDARD_APP(endless_playback_function)
 		break;
 	case SWITCH_STATUS_NOTFOUND:
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
+		break;
+	case SWITCH_STATUS_GENERR:
+		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "UNABLE TO PLAY FILE");
+		break;
+	case SWITCH_STATUS_FALSE:
+		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "MEDIA NOT READY");
 		break;
 	default:
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR");
@@ -3205,6 +3217,12 @@ SWITCH_STANDARD_APP(loop_playback_function)
 		break;
 	case SWITCH_STATUS_NOTFOUND:
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
+		break;
+	case SWITCH_STATUS_GENERR:
+		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "UNABLE TO PLAY FILE");
+		break;
+	case SWITCH_STATUS_FALSE:
+		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "MEDIA NOT READY");
 		break;
 	default:
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR");

--- a/src/switch_ivr_play_say.c
+++ b/src/switch_ivr_play_say.c
@@ -1954,6 +1954,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_play_file(switch_core_session_t *sess
 			} else {
 				switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Playback-Status", "done");
 			}
+			switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Playback-Status-Code", "%d", status);
 			if (fh->params) {
 				switch_event_merge(event, fh->params);
 			}


### PR DESCRIPTION
- Handle possible status code for playing audio file and set that as "current_application_response"
- Add new "Playback-Status-Code" in PLAYBACK_STOP event