### PR TITLE
TEL-4487: Add method to cancel group schedule task based on desc

### DIFF
--- a/src/include/switch_scheduler.h
+++ b/src/include/switch_scheduler.h
@@ -76,6 +76,14 @@ SWITCH_DECLARE(uint32_t) switch_scheduler_get_total_task();
 SWITCH_DECLARE(uint32_t) switch_scheduler_del_task_id(uint32_t task_id);
 
 /*!
+  \brief Delete a scheduled task based on the desc
+  \param group the group name
+  \param desc the task desc
+  \return the number of jobs deleted
+*/
+SWITCH_DECLARE(uint32_t) switch_scheduler_del_task_group_desc(const char *group, const char *desc);
+
+/*!
   \brief Delete a scheduled task based on the group name
   \param group the group name
   \return the number of jobs deleted

--- a/src/switch_scheduler.c
+++ b/src/switch_scheduler.c
@@ -305,6 +305,45 @@ SWITCH_DECLARE(uint32_t) switch_scheduler_del_task_id(uint32_t task_id)
 	return delcnt;
 }
 
+SWITCH_DECLARE(uint32_t) switch_scheduler_del_task_group_desc(const char *group, const char *desc)
+{
+	switch_scheduler_task_container_t *tp;
+	uint32_t delcnt = 0;
+	switch_ssize_t hlen = -1;
+	unsigned long hash = 0;
+
+	if (zstr(group) || zstr(desc)) {
+		return 0;
+	}
+
+	hash = switch_ci_hashfunc_default(group, &hlen);
+
+	switch_mutex_lock(globals.task_mutex);
+	for (tp = globals.task_list; tp; tp = tp->next) {
+		if (tp->destroyed) {
+			continue;
+		}
+		if (hash == tp->task.hash && !strcmp(tp->task.group, group) && !strcmp(tp->desc, desc)) {
+			if (switch_test_flag(tp, SSHF_NO_DEL)) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Attempt made to delete undeletable task #%u (group %s)(desc %s)\n",
+								  tp->task.task_id, group, desc);
+				continue;
+			}
+			if (tp->running) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Attempt made to delete running task #%u (group %s)(desc %s)\n",
+								  tp->task.task_id, tp->task.group, tp->desc);
+				tp->destroy_requested++;
+			} else {
+				tp->destroyed++;
+			}
+			delcnt++;
+		}
+	}
+	switch_mutex_unlock(globals.task_mutex);
+
+	return delcnt;
+}
+
 SWITCH_DECLARE(uint32_t) switch_scheduler_del_task_group(const char *group)
 {
 	switch_scheduler_task_container_t *tp;


### PR DESCRIPTION
Add a new method in scheduler to cancel a schedule group based on the description. Most of the sched app commands such as sched_broadcast, sched_hangup, sched_api etc are using the switch_func as the description. By using this new method, we can cancel only a specific sched commands.