### PR TITLE
TEL-4516: Reset ringback mux buffer length during failover

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -4017,6 +4017,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 			} else if (ringback.audio_buffer) {
 				teletone_destroy_session(&ringback.ts);
 				switch_safe_free(ringback.mux_buf);
+				ringback.mux_buflen = 0;
 				switch_buffer_destroy(&ringback.audio_buffer);
 			}
 


### PR DESCRIPTION
During failover, FS always cleanup the ringback resources including mux_buf:

https://github.com/team-telnyx/freeswitch/blob/telnyx/telephony/master/src/switch_ivr_originate.c#L4017

But FS never reset the mux_buflen which would prevent allocating mux_buf if wrote buffer size is less than mux_buflen in teletone_handler callback:

https://github.com/team-telnyx/freeswitch/blob/telnyx/telephony/master/src/switch_ivr_originate.c#L870

So when it did the memcpy, mux_buf is already been deleted and that would cause the crash on FS.

