### PR TITLE
ENGDESK-5722: Publish speak done events for conference call

### DIFF
--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -542,6 +542,8 @@ void conference_member_add_file_data(conference_member_t *member, int16_t *data,
 
 		if (member->fnode->type != NODE_TYPE_SPEECH) {
 			conference_file_close(member->conference, member->fnode);
+		} else {
+			conference_speak_flush(member->conference, member->fnode);
 		}
 
 		fnode = member->fnode;
@@ -1586,6 +1588,7 @@ switch_status_t conference_member_say(conference_member_t *member, char *text, u
 	fnode->type = NODE_TYPE_SPEECH;
 	fnode->leadin = leadin;
 	fnode->pool = pool;
+	fnode->member_id = member->id;
 
 	
 	if (params) {

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -727,6 +727,8 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 			switch_mutex_lock(conference->file_mutex);
 			if (conference->fnode->type != NODE_TYPE_SPEECH) {
 				conference_file_close(conference, conference->fnode);
+			} else {
+				conference_speak_flush(conference, conference->fnode);
 			}
 
 			if (conference->canvases[0] && conference->fnode->layer_id > -1 ) {

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -1000,6 +1000,7 @@ void conference_event_call_setup_handler(switch_event_t *event);
 void conference_member_add_file_data(conference_member_t *member, int16_t *data, switch_size_t file_data_len);
 void conference_send_notify(conference_obj_t *conference, const char *status, const char *call_id, switch_bool_t final);
 switch_status_t conference_file_close(conference_obj_t *conference, conference_file_node_t *node);
+switch_status_t conference_speak_flush(conference_obj_t *conference, conference_file_node_t *node);
 void *SWITCH_THREAD_FUNC conference_record_thread_run(switch_thread_t *thread, void *obj);
 switch_status_t conference_close_open_files(conference_obj_t *conference);
 void conference_al_gen_arc(conference_obj_t *conference, switch_stream_handle_t *stream);


### PR DESCRIPTION
This is to support for publishing speak done events for conference.

Issues in this implementation is we reach the max EFLAGS to support suppressing events for speak done, for now EFLAG_PLAY_FILE_DONE will suppressed both play and speak done events. Alternative to fix this is to disable pedantic or treat include file for mod_conference as isystem which will both suppressed the warning `restricts enumerator values to range of 'int'`. FS are stricts to warning and treat it as errors, disabling this just to support extending enum flags seems not to adhere to FS coding guidelines. 