### PR TITLE
ENGDESK-5777: Support rejecting ipv6 in sdp

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -74,6 +74,7 @@ typedef enum {
 	SCMF_MULTI_ANSWER_AUDIO,
 	SCMF_MULTI_ANSWER_VIDEO,
 	SCMF_RECV_SDP,
+	SCMF_REJECT_IPV6,
 	SCMF_MAX
 } switch_core_media_flag_t;
 

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -5560,6 +5560,12 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 						} else {
 							sofia_clear_media_flag(profile, SCMF_REWRITE_TIMESTAMPS);
 						}
+					} else if (!strcasecmp(var, "sdp-reject-ipv6")) {
+						if (switch_true(val)) {
+							sofia_set_media_flag(profile, SCMF_REJECT_IPV6);
+						} else {
+							sofia_clear_media_flag(profile, SCMF_REJECT_IPV6);
+						}
 					} else if (!strcasecmp(var, "auth-calls")) {
 						if (switch_true(val)) {
 							sofia_set_pflag(profile, PFLAG_AUTH_CALLS);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4999,6 +4999,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_validate_common_audio_sdp(switch_core_
 	uint32_t remote_codec_rate = 0, fmtp_remote_codec_rate = 0;
 	int m_idx = 0;
 	int nm_idx = 0;
+	const char *val;
 
 	switch_assert(session);
 
@@ -5111,6 +5112,15 @@ SWITCH_DECLARE(uint8_t) switch_core_media_validate_common_audio_sdp(switch_core_
 			if (!connection) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Cannot find a c= line in the sdp at media or session level!\n");
 				return 0;
+			}
+
+			if (connection->c_addrtype == sdp_addr_ip6) {
+				if(switch_media_handle_test_media_flag(smh, SCMF_REJECT_IPV6)
+					|| ((val = switch_channel_get_variable(session->channel, "sdp_reject_ipv6")) && switch_true(val))) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Reject IPv6 media address: %s!\n"
+						, connection->c_address ? connection->c_address : "<MISSING>");
+					return 0;
+				}
 			}
 
 			for (map = m->m_rtpmaps; map; map = map->rm_next) {
@@ -5962,6 +5972,16 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Cannot find a c= line in the sdp at media or session level!\n");
 				match = 0;
 				break;
+			}
+
+			if (connection->c_addrtype == sdp_addr_ip6) {
+				if(switch_media_handle_test_media_flag(smh, SCMF_REJECT_IPV6)
+					|| ((val = switch_channel_get_variable(session->channel, "sdp_reject_ipv6")) && switch_true(val))) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Reject IPv6 media address: %s!\n"
+						, connection->c_address ? connection->c_address : "<MISSING>");
+					match = 0;
+					break;
+				}
 			}
 
 			x = 0;


### PR DESCRIPTION
Added media flag to enable rejecting ipv6 during sdp negotiation