### PR TITLE
TEL-4600: Support retry on http get failure

### DIFF
--- a/src/include/switch_module_interfaces.h
+++ b/src/include/switch_module_interfaces.h
@@ -371,6 +371,7 @@ struct switch_file_handle {
 	const char *prefix;
 	int max_samples;
 	switch_event_t *params;
+	switch_event_t *event;
 	uint32_t cur_channels;
 	uint32_t cur_samplerate;
 	char *stream_name;

--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -3130,7 +3130,7 @@ SWITCH_STANDARD_APP(playback_function)
 			}
 	}
 
-	
+	switch_event_create_plain(&fh.event, SWITCH_EVENT_CHANNEL_DATA);
 	status = switch_ivr_play_file_detailed(session, &fh, file, &args, &error);
 	switch_assert(!(fh.flags & SWITCH_FILE_OPEN));
 
@@ -3145,6 +3145,16 @@ SWITCH_STANDARD_APP(playback_function)
 	default:
 		switch_channel_set_variable_printf(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR: %d:%s", status, error);
 		break;
+	}
+
+	if (fh.event){
+		switch_event_header_t *hp;
+		for (hp = fh.event->headers; hp; hp = hp->next) {
+			char *var = hp->name;
+			char *val = hp->value;
+			switch_channel_set_variable(channel, var, val);
+		}
+		switch_event_destroy(&fh.event);
 	}
 
 }

--- a/src/mod/applications/mod_http_cache/mod_http_cache.c
+++ b/src/mod/applications/mod_http_cache/mod_http_cache.c
@@ -161,7 +161,7 @@ struct http_get_data {
 };
 typedef struct http_get_data http_get_data_t;
 
-static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cached_url_t *url, int use_mime_extension, switch_core_session_t *session);
+static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cached_url_t *url, int use_mime_extension, switch_event_t* event, switch_core_session_t *session);
 static size_t get_file_callback(void *ptr, size_t size, size_t nmemb, void *get);
 static size_t get_header_callback(void *ptr, size_t size, size_t nmemb, void *url);
 static void process_cache_control_header(cached_url_t *url, char *data);
@@ -245,7 +245,7 @@ struct url_cache {
 };
 static url_cache_t gcache;
 
-static char *url_cache_get(url_cache_t *cache, http_profile_t *profile, switch_core_session_t *session, const char *url, int download, int refresh, const char *extension, int validate_url_extension, int use_mime_ext, switch_memory_pool_t *pool);
+static char *url_cache_get(url_cache_t *cache, http_profile_t *profile, switch_core_session_t *session, const char *url, int download, int refresh, const char *extension, int validate_url_extension, int use_mime_ext, switch_event_t* event, switch_memory_pool_t *pool);
 static switch_status_t url_cache_add(url_cache_t *cache, switch_core_session_t *session, cached_url_t *url);
 static void url_cache_remove(url_cache_t *cache, switch_core_session_t *session, cached_url_t *url);
 static void url_cache_remove_soft(url_cache_t *cache, switch_core_session_t *session, cached_url_t *url);
@@ -719,7 +719,7 @@ static void url_cache_clear(url_cache_t *cache, switch_core_session_t *session)
  * @param pool The pool to use for allocating the filename
  * @return The filename or NULL if there is an error
  */
-static char *url_cache_get(url_cache_t *cache, http_profile_t *profile, switch_core_session_t *session, const char *url, int download, int refresh, const char *extension, int validate_url_extension, int use_mime_ext, switch_memory_pool_t *pool)
+static char *url_cache_get(url_cache_t *cache, http_profile_t *profile, switch_core_session_t *session, const char *url, int download, int refresh, const char *extension, int validate_url_extension, int use_mime_ext, switch_event_t *event, switch_memory_pool_t *pool)
 {
 	switch_time_t download_timeout_ns = cache->download_timeout * 1000 * 1000;
 	char *filename = NULL;
@@ -766,7 +766,7 @@ static char *url_cache_get(url_cache_t *cache, http_profile_t *profile, switch_c
 
 		/* download the file */
 		url_cache_unlock(cache, session);
-		if (http_get(cache, profile, u, use_mime_ext, session) == SWITCH_STATUS_SUCCESS) {
+		if (http_get(cache, profile, u, use_mime_ext, event, session) == SWITCH_STATUS_SUCCESS) {
 			/* Got the file, let the waiters know it is available */
 			url_cache_lock(cache, session);
 			u->status = CACHED_URL_AVAILABLE;
@@ -1141,7 +1141,7 @@ static void cached_url_destroy(cached_url_t *url, switch_memory_pool_t *pool)
  * @param session the (optional) session
  * @return SWITCH_STATUS_SUCCESS if successful
  */
-static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cached_url_t *url, int use_mime_extension, switch_core_session_t *session)
+static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cached_url_t *url, int use_mime_extension, switch_event_t* event, switch_core_session_t *session)
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	switch_curl_slist_t *headers = NULL;  /* optional linked-list of HTTP headers */
@@ -1208,6 +1208,7 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 				break;
 			} else {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Received curl error %d (attempt:%d) trying to fetch %s\n", curl_status, i+1, url->url);
+				switch_sleep(50 * 1000); // 50ms
 			}
 		}
 
@@ -1238,6 +1239,12 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 	}
 
 done:
+
+	if (event) {
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "http_cache_curl_status", "%d", curl_status);
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "http_cache_response_code", "%ld", httpRes);
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "http_cache_file_create_result", "%d", errno);
+	}
 
 	if (headers) {
 		switch_curl_slist_free_all(headers);
@@ -1359,7 +1366,7 @@ SWITCH_STANDARD_API(http_cache_get)
 		}
 	}
 
-	filename = url_cache_get(&gcache, profile, session, url, download, refresh, extension, validate_url_extension, use_mime_ext, pool);
+	filename = url_cache_get(&gcache, profile, session, url, download, refresh, extension, validate_url_extension, use_mime_ext, NULL, pool);
 	if (filename) {
 		stream->write_function(stream, "%s", filename);
 
@@ -1431,7 +1438,7 @@ SWITCH_STANDARD_API(http_cache_tryget)
 		}
 	}
 
-	filename = url_cache_get(&gcache, NULL, session, url, 0, refresh, extension, validate_url_extension, use_mime_ext, pool);
+	filename = url_cache_get(&gcache, NULL, session, url, 0, refresh, extension, validate_url_extension, use_mime_ext, NULL, pool);
 	if (filename) {
 		if (!strcmp(DOWNLOAD_NEEDED, filename)) {
 			stream->write_function(stream, "-ERR %s\n", DOWNLOAD_NEEDED);
@@ -1566,7 +1573,7 @@ SWITCH_STANDARD_API(http_cache_remove)
 		switch_event_create_brackets(url, '{', '}', ',', &params, &url, SWITCH_FALSE);
 	}
 
-	url_cache_get(&gcache, NULL, session, url, 0, 1, NULL, 0, 0, pool);
+	url_cache_get(&gcache, NULL, session, url, 0, 1, NULL, 0, 0, NULL, pool);
 	stream->write_function(stream, "+OK\n");
 
 	if (lpool) {
@@ -1851,7 +1858,7 @@ static switch_status_t http_cache_file_open(switch_file_handle_t *handle, const 
 	} else {
 		/* READ = HTTP GET */
 		file_flags |= SWITCH_FILE_FLAG_READ;
-		context->local_path = url_cache_get(&gcache, context->profile, NULL, path, 1, refresh, extension, validate_url_extension, use_mime_ext, handle->memory_pool);
+		context->local_path = url_cache_get(&gcache, context->profile, NULL, path, 1, refresh, extension, validate_url_extension, use_mime_ext, handle->event, handle->memory_pool);
 		if (!context->local_path) {
 			return SWITCH_STATUS_FALSE;
 		}

--- a/src/switch_ivr_play_say.c
+++ b/src/switch_ivr_play_say.c
@@ -1603,6 +1603,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_play_file_detailed(switch_core_sessio
 			if (fh->params) {
 				switch_event_merge(event, fh->params);
 			}
+			if (fh->event) {
+				switch_event_merge(event, fh->event);
+			}
 			switch_event_fire(&event);
 		}
 
@@ -1993,6 +1996,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_play_file_detailed(switch_core_sessio
 			}
 			if (fh->params) {
 				switch_event_merge(event, fh->params);
+			}
+			if (fh->event) {
+				switch_event_merge(event, fh->event);
 			}
 			switch_event_fire(&event);
 		}


### PR DESCRIPTION
TEL-4599: Add event variable for file interface
  - Allow custom file modules to add vars in playback events
  - Add custom file module events in channel variable

