### PR TITLE
ENGDESK-6986: Fixed FS not sending ACK in reliable provisional response

### DIFF
--- a/libs/sofia-sip/libsofia-sip-ua/nua/nua_client.c
+++ b/libs/sofia-sip/libsofia-sip-ua/nua/nua_client.c
@@ -327,6 +327,10 @@ nua_client_request_remove(nua_client_request_t *cr)
 int
 nua_client_request_clean(nua_client_request_t *cr)
 {
+  if (cr->cr_oprq) {
+    nta_outgoing_destroy(cr->cr_oprq), cr->cr_oprq = NULL;
+  }
+
   if (cr->cr_orq) {
     nta_outgoing_destroy(cr->cr_orq), cr->cr_orq = NULL, cr->cr_acked = 0;
     return nua_client_request_unref(cr);
@@ -379,6 +383,9 @@ nua_client_request_destroy(nua_client_request_t *cr)
 
   if (cr->cr_orq)
     nta_outgoing_destroy(cr->cr_orq), cr->cr_orq = NULL;
+
+  if (cr->cr_oprq)
+    nta_outgoing_destroy(cr->cr_oprq), cr->cr_oprq = NULL;
 
   if (cr->cr_target)
     su_free(nh->nh_home, cr->cr_target);

--- a/libs/sofia-sip/libsofia-sip-ua/nua/nua_client.h
+++ b/libs/sofia-sip/libsofia-sip-ua/nua/nua_client.h
@@ -163,6 +163,7 @@ struct nua_client_request
   sip_t              *cr_sip;
 
   nta_outgoing_t     *cr_orq;
+  nta_outgoing_t     *cr_oprq;
 
   su_timer_t         *cr_timer;	        /**< Expires or retry timer */
 

--- a/libs/sofia-sip/libsofia-sip-ua/nua/nua_session.c
+++ b/libs/sofia-sip/libsofia-sip-ua/nua/nua_session.c
@@ -908,7 +908,7 @@ static int nua_invite_client_preliminary(nua_client_request_t *cr,
         if (nh->nh_prefs->nhp_tagged_on_prack) {
           nta_outgoing_destroy(cr->cr_orq), cr->cr_orq = tagged;
         } else {
-          nta_outgoing_destroy(tagged);
+          cr->cr_oprq = tagged;
         }
       }
       else {


### PR DESCRIPTION
 - Store outgoing prelim request in client session
 - Cleanup prelim transaction on client request destroy