### PR TITLE
TEL-4781: load global vars before switch_event_init

### DIFF
--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -1987,7 +1987,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_init(switch_core_flag_t flags, switc
 	switch_core_set_variable("core_uuid", runtime.uuid_str);
 
 	switch_console_init(runtime.memory_pool);
-	switch_event_init(runtime.memory_pool);
 	switch_channel_global_init(runtime.memory_pool);
 
 	if (switch_xml_init(runtime.memory_pool, err) != SWITCH_STATUS_SUCCESS) {
@@ -1997,6 +1996,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_init(switch_core_flag_t flags, switc
 			return SWITCH_STATUS_MEMERR;
 		}
 	}
+
+	switch_event_init(runtime.memory_pool);
 
 	if (switch_test_flag((&runtime), SCF_USE_AUTO_NAT)) {
 		switch_nat_init(runtime.memory_pool, switch_test_flag((&runtime), SCF_USE_NAT_MAPPING));

--- a/src/switch_xml.c
+++ b/src/switch_xml.c
@@ -2341,7 +2341,7 @@ SWITCH_DECLARE(switch_xml_t) switch_xml_open_root(uint8_t reload, const char **e
 	switch_mutex_unlock(XML_LOCK);
 
 
-	if (root) {
+	if (root && reload) {
 		if (switch_event_create(&event, SWITCH_EVENT_RELOADXML) == SWITCH_STATUS_SUCCESS) {
 			if (switch_event_fire(&event) != SWITCH_STATUS_SUCCESS) {
 				switch_event_destroy(&event);


### PR DESCRIPTION
**Issue**:
switch_event_init is caching the output of default ipv4 result from switch_find_local_ip. We can enforce the ip by setting the `force_local_ip_v4` global variable. The problem is somehow the `force_local_ip_v4`  didn't take effect for the switch_event.

**Solution**:
We need to load the global variables before calling switch_event_init. The problem with this change will cause crashes since loading the xml configuration will fire event `RELOADXML` and the switch_event is not yet initialize. To solve this we only need to fire the event by checking the reload flag in switch_xml_open_root. This will not cause an issue because on core init, we are not yet reloading the xml.