### PR TITLE
TEL-4919: Support Multiple Identity Header 

### DIFF
--- a/libs/sofia-sip/libsofia-sip-ua/sip/sip_basic.c
+++ b/libs/sofia-sip/libsofia-sip-ua/sip/sip_basic.c
@@ -1255,7 +1255,7 @@ char *sip_cseq_dup_one(sip_header_t *dst, sip_header_t const *src,
 
 /**@ingroup sip_cseq
  *
- *�Create a @CSeq header object.
+ * Create a @CSeq header object.
  *
  * Create a @CSeq header object with the
  * sequence number @a seq, method enum @a method and method name @a
@@ -1554,7 +1554,7 @@ issize_t sip_content_length_e(char b[], isize_t bsiz, sip_header_t const *h, int
 
 /**@ingroup sip_content_length
  *
- *�Create a @ContentLength header object.
+ * Create a @ContentLength header object.
  *
  * Create a @ContentLength
  * header object with the value @a n.  The memory for the header is

--- a/libs/sofia-sip/libsofia-sip-ua/sip/sip_basic.c
+++ b/libs/sofia-sip/libsofia-sip-ua/sip/sip_basic.c
@@ -1255,7 +1255,7 @@ char *sip_cseq_dup_one(sip_header_t *dst, sip_header_t const *src,
 
 /**@ingroup sip_cseq
  *
- * Create a @CSeq header object.
+ *ï¿½Create a @CSeq header object.
  *
  * Create a @CSeq header object with the
  * sequence number @a seq, method enum @a method and method name @a
@@ -1554,7 +1554,7 @@ issize_t sip_content_length_e(char b[], isize_t bsiz, sip_header_t const *h, int
 
 /**@ingroup sip_content_length
  *
- * Create a @ContentLength header object.
+ *ï¿½Create a @ContentLength header object.
  *
  * Create a @ContentLength
  * header object with the value @a n.  The memory for the header is
@@ -2844,7 +2844,7 @@ static msg_dup_f sip_identity_dup_one;
 static msg_update_f sip_identity_update;
 
 msg_hclass_t sip_identity_class[] =
-SIP_HEADER_CLASS(identity, "Identity", "", id_common, single, identity);
+SIP_HEADER_CLASS(identity, "Identity", "", id_common, prepend, identity);
 
 issize_t sip_identity_d(su_home_t *home, sip_header_t *h, char *s, isize_t slen)
 {

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -924,11 +924,7 @@ char *sofia_glue_get_extra_headers(switch_channel_t *channel, const char *prefix
 			if (!strncasecmp(name, prefix, strlen(prefix))) {
 				if ( !exclude_regex || !(proceed = switch_regex_perform(name, exclude_regex, &re, ovector, sizeof(ovector) / sizeof(ovector[0])))) {
 					const char *hname = name + strlen(prefix);
-					if (!strcasecmp(hname, "identity_div")) {
-						stream.write_function(&stream, "%.8s: %s\r\n", hname, value);
-					} else {
-						stream.write_function(&stream, "%s: %s\r\n", hname, value);
-					}
+					stream.write_function(&stream, "%s: %s\r\n", hname, value);
 					switch_regex_safe_free(re);
 				} else {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Ignoring Extra Header [%s] , matches exclude_outgoing_extra_header [%s]\n", name, exclude_regex);
@@ -1071,6 +1067,8 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 	uint8_t is_t38 = 0;
 	const char *hold_char = "*";
 	const char *session_id_header = sofia_glue_session_id_header(session, tech_pvt->profile);
+	const char *identity = NULL;
+	const char *identity_div = NULL;
 
 	switch_size_t mp_data_len = 0;
 	sip_payload_t *mp_payload = 0;
@@ -1627,6 +1625,13 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		cseq = sip_cseq_create(tech_pvt->nh->nh_home, callsequence, SIP_METHOD_INVITE);
 	}
 
+	if ((val = switch_channel_get_variable(channel, "sip_identity"))) {
+		identity = switch_core_session_strdup(session, val);
+	}
+
+	if ((val = switch_channel_get_variable(channel, "sip_identity_div"))) {
+		identity_div = switch_core_session_strdup(session, val);
+	}
 
 	switch_channel_clear_flag(channel, CF_MEDIA_ACK);
 
@@ -1716,6 +1721,8 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 				   TAG_IF(!zstr(tech_pvt->privacy), SIPTAG_PRIVACY_STR(tech_pvt->privacy)),
 				   TAG_IF(!zstr(alert_info), SIPTAG_HEADER_STR(alert_info)),
 				   TAG_IF(!zstr(extra_headers), SIPTAG_HEADER_STR(extra_headers)),
+				   TAG_IF(!zstr(identity), SIPTAG_IDENTITY_STR(identity)),
+				   TAG_IF(!zstr(identity_div), SIPTAG_IDENTITY_STR(identity_div)),
 				   TAG_IF(sofia_test_pflag(tech_pvt->profile, PFLAG_PASS_CALLEE_ID), SIPTAG_HEADER_STR("X-FS-Support: " FREESWITCH_SUPPORT)),
 				   TAG_IF(!zstr(max_forwards), SIPTAG_MAX_FORWARDS_STR(max_forwards)),
 				   TAG_IF(!zstr(route_uri), NUTAG_PROXY(route_uri)),

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -924,7 +924,11 @@ char *sofia_glue_get_extra_headers(switch_channel_t *channel, const char *prefix
 			if (!strncasecmp(name, prefix, strlen(prefix))) {
 				if ( !exclude_regex || !(proceed = switch_regex_perform(name, exclude_regex, &re, ovector, sizeof(ovector) / sizeof(ovector[0])))) {
 					const char *hname = name + strlen(prefix);
-					stream.write_function(&stream, "%s: %s\r\n", hname, value);
+					if (!strcasecmp(hname, "identity_div")) {
+						stream.write_function(&stream, "%.8s: %s\r\n", hname, value);
+					} else {
+						stream.write_function(&stream, "%s: %s\r\n", hname, value);
+					}
 					switch_regex_safe_free(re);
 				} else {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Ignoring Extra Header [%s] , matches exclude_outgoing_extra_header [%s]\n", name, exclude_regex);


### PR DESCRIPTION
**Issue**
STIR/SHAKEN may need to add multiple Identity header. User added this in their dialplan:
```
<action application="export" data="sip_h_identity=..."/>
<action application="export" data="sip_h_identity=... (diversion)"/>
```
The problem is that:
1. Channel Variable is unique
2. Libsofia don't allow multiple Identity headers

**Solution**
I have introduce a special channel variable to add `Identity` Header and support identity diversion.
```
<action application="export" data="sip_identity=..."/>
<action application="export" data="sip_identity_div=... (diversion)"/>
```
libsofia has a support for Identity Header but parsing or creating this header was set to a single entry. I have allowed this header to be added multiple times. Once I applied this changes, I got this outgoing invite result:
```
INVITE sip:201@192.168.100.19:35060 SIP/2.0
Via: SIP/2.0/UDP 192.168.100.19;rport;branch=z9hG4bKpyeNy5D850c4D
Max-Forwards: 69
From: "1000" <sip:1000@192.168.100.19>;tag=UK72g8DmUQN1e
To: <sip:201@192.168.100.19:35060>
Call-ID: 5e80fddf-cfed-4660-a449-92fbdc0afb32
CSeq: 38499679 INVITE
Identity: foo
Identity: bar
...
```