### PR TITLE
TEL-4925: Allow ring ready instead of ignore early media during 3pcc call

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -2445,10 +2445,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 	}
 
 	if (caller_channel && switch_channel_test_flag(caller_channel, CF_3PCC_PROXY)) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Set ignore early media for 3PCC Proxy calls\n");
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Set ignore early media to ring ready for 3PCC Proxy calls\n");
 		if (!oglobals.ignore_early_media) {
 			oglobals.early_ok = 0;
-			oglobals.ignore_early_media = 1;
+			oglobals.ignore_early_media = 2;
 		}
 	}
 


### PR DESCRIPTION
**ISSUES**

During 3pcc call when the outbound send a 183 early media, FS will not forward the 183. The reason for this is that FS added a support to offer all codecs during 3pcc call. This changes is causing an audio issue when outbound sends an early media. For now, we disable the early media on this type of call. The problem right now is that when the outbound sends an early media FS don't send any ringing provision response to the inbound.

**SOLUTION**
Instead of disabling the early media, FS will translate 183 early media to a 180 ringing instead.