### PR TITLE
ENGDESK-8951: Prevent duplicate ASR event when fire_asr_events is set

### DIFF
--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -1798,7 +1798,8 @@ typedef enum {
 	SWITCH_ASR_FLAG_FREE_POOL = (1 << 1),
 	SWITCH_ASR_FLAG_CLOSED = (1 << 2),
 	SWITCH_ASR_FLAG_FIRE_EVENTS = (1 << 3),
-	SWITCH_ASR_FLAG_AUTO_RESUME = (1 << 4)
+	SWITCH_ASR_FLAG_AUTO_RESUME = (1 << 4),
+	SWITCH_ASR_FLAG_QUEUE_EVENTS = (1 << 5)
 
 } switch_asr_flag_enum_t;
 typedef uint32_t switch_asr_flag_t;

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -4759,7 +4759,9 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 						switch_event_fire(&dup);
 					}
 
-				} else if (switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
+				} 
+				
+				if (switch_test_flag(sth->ah, SWITCH_ASR_FLAG_QUEUE_EVENTS) && switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_ERROR, "Event queue failed!\n");
 					switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "delivery-failure", "true");
 					switch_event_fire(&event);
@@ -4784,7 +4786,10 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 				switch_channel_event_set_data(channel, dup);
 				switch_event_fire(&dup);
 			}
-		} else if (switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
+
+		}
+
+		if (switch_test_flag(sth->ah, SWITCH_ASR_FLAG_QUEUE_EVENTS) && switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_ERROR, "Event queue failed!\n");
 			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "delivery-failure", "true");
 			switch_event_fire(&event);
@@ -5066,6 +5071,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_detect_speech_init(switch_core_sessio
 		switch_set_flag(ah, SWITCH_ASR_FLAG_FIRE_EVENTS);
 	}
 
+	if ((p = switch_channel_get_variable(channel, "queue_asr_events")) && switch_false(p)) {
+		switch_clear_flag(ah, SWITCH_ASR_FLAG_QUEUE_EVENTS);
+	} else {
+		switch_set_flag(ah, SWITCH_ASR_FLAG_QUEUE_EVENTS);
+	}
+
 	switch_snprintf(key, sizeof(key), "%s/%s/%s/%s", mod_name, NULL, NULL, dest);
 
 	if ((status = switch_core_media_bug_add(session, "detect_speech", key,
@@ -5150,6 +5161,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_detect_speech(switch_core_session_t *
 
 	if ((p = switch_channel_get_variable(channel, "fire_asr_events")) && switch_true(p)) {
 		switch_set_flag(sth->ah, SWITCH_ASR_FLAG_FIRE_EVENTS);
+	}
+
+	if ((p = switch_channel_get_variable(channel, "queue_asr_events")) && switch_false(p)) {
+		switch_clear_flag(ah, SWITCH_ASR_FLAG_QUEUE_EVENTS);
+	} else {
+		switch_set_flag(ah, SWITCH_ASR_FLAG_QUEUE_EVENTS);
 	}
 
 	return SWITCH_STATUS_SUCCESS;

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -4759,9 +4759,7 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 						switch_event_fire(&dup);
 					}
 
-				}
-
-				if (switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
+				} else if (switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_ERROR, "Event queue failed!\n");
 					switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "delivery-failure", "true");
 					switch_event_fire(&event);
@@ -4786,10 +4784,7 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 				switch_channel_event_set_data(channel, dup);
 				switch_event_fire(&dup);
 			}
-
-		}
-
-		if (switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
+		} else if (switch_core_session_queue_event(sth->session, &event) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_ERROR, "Event queue failed!\n");
 			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "delivery-failure", "true");
 			switch_event_fire(&event);


### PR DESCRIPTION
**ISSUE**
ASR events is not published during Transfer. This is due the event is queued in the session and it require to call the switch_core_session_dequeue_event to get the event and publish it. This is done in some of the APP/API command such as bridge, record, sleep etc. This method is not being called when FS transfer the call. To fix this we need to call `fire_asr_events` to publish ASR events immediately but the problem is this will cause to fire 2 events during bridge.

**SOLUTION**
If `fire_asr_events` is set then FS will fire the event immediately and FS will queue the event and later publish it. You need to set `queue_asr_events` to false to prevent FS to queue ASR events. This will prevent 2 events being published in ASR when this two variable is set.