### PR TITLE
TEL-4972: create switch_core_session_get_channel_unsafe in order to avoid crash when no channel

### DIFF
--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -865,6 +865,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_thread_pool_launch(switch_co
   \return a pointer to the channel object
 */
 	 _Ret_ SWITCH_DECLARE(switch_channel_t *) switch_core_session_get_channel(_In_ switch_core_session_t *session);
+/*!
+  \brief Retrieve a pointer to the channel object associated with a given session
+  \param session the session to retrieve from
+  \return a pointer to the channel object
+*/
+	 _Ret_ SWITCH_DECLARE(switch_channel_t *) switch_core_session_get_channel_unsafe(_In_ switch_core_session_t *session);
 
 /*!
   \brief Signal a session's state machine thread that a state change has occured

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -1448,6 +1448,11 @@ SWITCH_DECLARE(switch_channel_t *) switch_core_session_get_channel(switch_core_s
 	return session->channel;
 }
 
+SWITCH_DECLARE(switch_channel_t *) switch_core_session_get_channel_unsafe(switch_core_session_t *session)
+{
+	return session->channel;
+}
+
 SWITCH_DECLARE(switch_mutex_t *) switch_core_session_get_mutex(switch_core_session_t *session)
 {
 	return session->mutex;


### PR DESCRIPTION
the switch_core_session_get_channel has an `assert` that leads to a crash when the channel is not ready or already hang up which happens a lot with Push Notification calls.

see mod_telnyx_rtc PR #49
