### PR TITLE
Engdesk 11524 fork

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -258,7 +258,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_sessio
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_activate(switch_core_session_t *session, switch_fork_direction_t direction);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_deactivate(switch_core_session_t *session, switch_fork_direction_t direction);
-SWITCH_DECLARE(void) switch_core_media_fork_update(switch_core_session_t *session, switch_fork_state_t *fork, uint32_t ssrc, switch_fork_direction_t direction);
+SWITCH_DECLARE(void) switch_core_media_fork_fire_start_event(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_fork_do_fire_start_event(switch_core_session_t *session, switch_fork_state_t *fork, const char *fmr);
 SWITCH_DECLARE(void) switch_core_media_check_dtmf_type(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_absorb_sdp(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_proxy_remote_addr(switch_core_session_t *session, const char *sdp_str);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -190,6 +190,24 @@ static inline const char *switch_media_type2str(switch_media_type_t type)
 	}
 }
 
+typedef struct switch_fork_s {
+	switch_sockaddr_t	*addr;
+	char				*host_str;
+	switch_port_t		port;
+	uint32_t			ssrc;
+	char cmd[500];
+	uint8_t				active;
+} switch_fork_t;
+
+typedef struct switch_fork_state_s {
+	switch_fork_t	fork_rx;
+	switch_fork_t	fork_tx;
+	char			id[40];
+	char			local_ip[100];
+	uint16_t		local_port;
+	uint8_t			start_event_fired;
+} switch_fork_state_t;
+
 
 SWITCH_DECLARE(switch_status_t) switch_media_handle_create(switch_media_handle_t **smhp, switch_core_session_t *session, switch_core_media_params_t *params);
 SWITCH_DECLARE(void) switch_media_handle_destroy(switch_core_session_t *session);
@@ -235,9 +253,12 @@ SWITCH_DECLARE(int) switch_core_media_check_nat(switch_media_handle_t *smh, cons
 
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_port(switch_core_session_t *session, switch_media_type_t type, int force);
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_session_t *session, switch_bool_t audio, switch_bool_t video);
-SWITCH_DECLARE(switch_status_t) switch_core_media_set_fork(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port);
-SWITCH_DECLARE(switch_status_t) switch_core_media_activate_fork(switch_core_session_t *session, switch_fork_direction_t direction);
-SWITCH_DECLARE(switch_status_t) switch_core_media_deactivate_fork(switch_core_session_t *session, switch_fork_direction_t direction);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_session_t *session, const char *id);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_activate(switch_core_session_t *session, switch_fork_direction_t direction);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_deactivate(switch_core_session_t *session, switch_fork_direction_t direction);
+SWITCH_DECLARE(void) switch_core_media_fork_update(switch_core_session_t *session, switch_fork_state_t *fork, uint32_t ssrc, switch_fork_direction_t direction);
 SWITCH_DECLARE(void) switch_core_media_check_dtmf_type(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_absorb_sdp(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_proxy_remote_addr(switch_core_session_t *session, const char *sdp_str);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -235,9 +235,9 @@ SWITCH_DECLARE(int) switch_core_media_check_nat(switch_media_handle_t *smh, cons
 
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_port(switch_core_session_t *session, switch_media_type_t type, int force);
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_session_t *session, switch_bool_t audio, switch_bool_t video);
-SWITCH_DECLARE(switch_status_t) switch_core_media_set_fork_write(switch_core_session_t *session, const char *ip, switch_port_t port);
-SWITCH_DECLARE(switch_status_t) switch_core_media_activate_fork_write(switch_core_session_t *session);
-SWITCH_DECLARE(switch_status_t) switch_core_media_deactivate_fork_write(switch_core_session_t *session);
+SWITCH_DECLARE(switch_status_t) switch_core_media_set_fork(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port);
+SWITCH_DECLARE(switch_status_t) switch_core_media_activate_fork(switch_core_session_t *session, switch_fork_direction_t direction);
+SWITCH_DECLARE(switch_status_t) switch_core_media_deactivate_fork(switch_core_session_t *session, switch_fork_direction_t direction);
 SWITCH_DECLARE(void) switch_core_media_check_dtmf_type(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_absorb_sdp(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_proxy_remote_addr(switch_core_session_t *session, const char *sdp_str);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -206,6 +206,8 @@ typedef struct switch_fork_state_s {
 	char			local_ip[100];
 	uint16_t		local_port;
 	uint8_t			wait_ssrc;
+	switch_time_t	wait_ssrc_time_start_us;
+	int				wait_ssrc_timeout_ms;
 	uint8_t			start_event_fired;
 } switch_fork_state_t;
 
@@ -256,7 +258,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_choose_port(switch_core_sessio
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_session_t *session, switch_bool_t audio, switch_bool_t video);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_session_t *session, const char *id);
-SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session, int timeout_ms);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_activate(switch_core_session_t *session, switch_fork_direction_t direction);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_deactivate(switch_core_session_t *session, switch_fork_direction_t direction);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -195,16 +195,17 @@ typedef struct switch_fork_s {
 	char				*host_str;
 	switch_port_t		port;
 	uint32_t			ssrc;
-	char cmd[500];
+	char				cmd[500];
 	uint8_t				active;
-} switch_fork_t;
+} switch_fork_session_t;
 
 typedef struct switch_fork_state_s {
-	switch_fork_t	fork_rx;
-	switch_fork_t	fork_tx;
+	switch_fork_session_t	fork_rx;
+	switch_fork_session_t	fork_tx;
 	char			id[40];
 	char			local_ip[100];
 	uint16_t		local_port;
+	uint8_t			wait_ssrc;
 	uint8_t			start_event_fired;
 } switch_fork_state_t;
 
@@ -255,6 +256,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_choose_port(switch_core_sessio
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_session_t *session, switch_bool_t audio, switch_bool_t video);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_session_t *session, const char *id);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_activate(switch_core_session_t *session, switch_fork_direction_t direction);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_deactivate(switch_core_session_t *session, switch_fork_direction_t direction);

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -299,9 +299,9 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, switch_port_t remote_rtcp_port,
 															  switch_bool_t change_adv_addr, const char **err);
 
-SWITCH_DECLARE(switch_status_t) switch_rtp_set_fork_write_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, const char **err);
-SWITCH_DECLARE(switch_status_t) switch_rtp_activate_fork_write(switch_rtp_t *rtp_session);
-SWITCH_DECLARE(void) switch_rtp_deactivate_fork_write(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(switch_status_t) switch_rtp_set_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, const char **err);
+SWITCH_DECLARE(switch_status_t) switch_rtp_activate_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
+SWITCH_DECLARE(void) switch_rtp_deactivate_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
 
 SWITCH_DECLARE(void) switch_rtp_reset_jb(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(char *) switch_rtp_get_remote_host(switch_rtp_t *rtp_session);

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -301,7 +301,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_id(switch_rtp_t *rtp_session, const char *id);
-SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_wait_ssrc(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_wait_ssrc(switch_rtp_t *rtp_session, int timeout_ms);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_local_address(switch_rtp_t *rtp_session, const char *ip, uint16_t port);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_activate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
 SWITCH_DECLARE(void) switch_rtp_fork_deactivate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -301,6 +301,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_id(switch_rtp_t *rtp_session, const char *id);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_wait_ssrc(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_local_address(switch_rtp_t *rtp_session, const char *ip, uint16_t port);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_activate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
 SWITCH_DECLARE(void) switch_rtp_fork_deactivate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -299,11 +299,12 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, switch_port_t remote_rtcp_port,
 															  switch_bool_t change_adv_addr, const char **err);
 
-SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, const char *cmd);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_id(switch_rtp_t *rtp_session, const char *id);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_local_address(switch_rtp_t *rtp_session, const char *ip, uint16_t port);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_activate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
 SWITCH_DECLARE(void) switch_rtp_fork_deactivate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
+SWITCH_DECLARE(void) switch_rtp_fork_fire_start_event(switch_rtp_t *rtp_session);
 
 SWITCH_DECLARE(void) switch_rtp_reset_jb(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(char *) switch_rtp_get_remote_host(switch_rtp_t *rtp_session);

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -299,9 +299,11 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, switch_port_t remote_rtcp_port,
 															  switch_bool_t change_adv_addr, const char **err);
 
-SWITCH_DECLARE(switch_status_t) switch_rtp_set_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, const char **err);
-SWITCH_DECLARE(switch_status_t) switch_rtp_activate_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
-SWITCH_DECLARE(void) switch_rtp_deactivate_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, const char *cmd);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_id(switch_rtp_t *rtp_session, const char *id);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_local_address(switch_rtp_t *rtp_session, const char *ip, uint16_t port);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_activate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
+SWITCH_DECLARE(void) switch_rtp_fork_deactivate(switch_rtp_t *rtp_session, switch_fork_direction_t direction);
 
 SWITCH_DECLARE(void) switch_rtp_reset_jb(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(char *) switch_rtp_get_remote_host(switch_rtp_t *rtp_session);

--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -308,6 +308,11 @@ typedef enum {
 } switch_call_direction_t;
 
 typedef enum {
+	FORK_DIRECTION_RX,
+	FORK_DIRECTION_TX
+} switch_fork_direction_t;
+
+typedef enum {
 	SBF_DIAL_ALEG = (1 << 0),
 	SBF_EXEC_ALEG = (1 << 1),
 	SBF_DIAL_BLEG = (1 << 2),

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9178,7 +9178,7 @@ SWITCH_DECLARE(void) switch_core_media_fork_do_fire_start_event(switch_core_sess
 		return;
 	}
 
-	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, "media_stream::start") == SWITCH_STATUS_SUCCESS) {
+	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, "telnyx_media_stream::start") == SWITCH_STATUS_SUCCESS) {
 		switch_channel_event_set_data(session->channel, event);
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "telnyx_media_streaming_start_time", "%ld", switch_micro_time_now() / 1000);
 		if (!zstr(fork->fork_rx.cmd)) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9187,11 +9187,11 @@ SWITCH_DECLARE(void) switch_core_media_fork_do_fire_start_event(switch_core_sess
 		if (!zstr(fork->fork_tx.cmd)) {
 			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "telnyx_media_streaming_tx", fork->fork_tx.cmd);
 		}
-		if (!zstr(fmr)) {
-			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "variable_media_fork_request", fmr);
-		}
+		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "variable_media_fork_request", fmr);
 		switch_event_fire(&event);
 	}
+
+	switch_channel_set_variable(session->channel, "variable_media_fork_request", fmr);
 }
 
 SWITCH_DECLARE(void) switch_core_media_fork_fire_start_event(switch_core_session_t *session)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9044,7 +9044,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_sessio
 	return switch_rtp_fork_set_id(a_engine->rtp_session, id);
 }
 
-SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session)
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session, int timeout_ms)
 {
 	switch_rtp_engine_t *a_engine = NULL;
 	switch_media_handle_t *smh = NULL;
@@ -9064,8 +9064,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core
 		return SWITCH_STATUS_FALSE;
 	}
 
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork: setting up wait_ssrc\n", switch_channel_get_name(session->channel));
-	return switch_rtp_fork_set_wait_ssrc(a_engine->rtp_session);
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork: setting up wait_ssrc with timeout of %d ms\n", switch_channel_get_name(session->channel), timeout_ms);
+	return switch_rtp_fork_set_wait_ssrc(a_engine->rtp_session, timeout_ms);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9041,9 +9041,31 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_sessio
 	}
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork: setting up fork id to %s\n", switch_channel_get_name(session->channel), id);
-	switch_rtp_fork_set_id(a_engine->rtp_session, id);
+	return switch_rtp_fork_set_id(a_engine->rtp_session, id);
+}
 
-	return SWITCH_STATUS_SUCCESS;
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session)
+{
+	switch_rtp_engine_t *a_engine = NULL;
+	switch_media_handle_t *smh = NULL;
+
+	if (!session) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork: no media\n", switch_channel_get_name(session->channel));
+		return SWITCH_STATUS_FALSE;
+	}
+
+	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
+	if (!a_engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork: failed to set wait_ssrc (no RTP session)\n", switch_channel_get_name(session->channel));
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork: setting up wait_ssrc\n", switch_channel_get_name(session->channel));
+	return switch_rtp_fork_set_wait_ssrc(a_engine->rtp_session);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session)
@@ -9087,9 +9109,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_
 	}
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "%s Fork: setting up fork ip to %s\n", switch_channel_get_name(session->channel), ip);
-	switch_rtp_fork_set_local_address(a_engine->rtp_session, ip, port);
-
-	return SWITCH_STATUS_SUCCESS;
+	return switch_rtp_fork_set_local_address(a_engine->rtp_session, ip, port);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_activate(switch_core_session_t *session, switch_fork_direction_t direction)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8972,7 +8972,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_sessi
 	return status;
 }
 
-SWITCH_DECLARE(switch_status_t) switch_core_media_set_fork_write(switch_core_session_t *session, const char *ip, switch_port_t port)
+SWITCH_DECLARE(switch_status_t) switch_core_media_set_fork(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port)
 {
 	switch_rtp_engine_t *a_engine = NULL;
 	switch_media_handle_t *smh = NULL;
@@ -8981,115 +8981,88 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_set_fork_write(switch_core_ses
 	switch_assert(session);
 
 	if (!ip) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s No Fork IP!\n", 
-			switch_channel_get_name(session->channel));
-		return status;
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): no ip!\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
 	}
 
 	if (!port) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s No Fork Port!\n", 
-			switch_channel_get_name(session->channel));
-		return status;
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): no port!\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
 	}
 
 	if (!(smh = session->media_handle)) {
-		return status;
-	}
-
-	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
-	if (a_engine->rtp_session && (status = switch_rtp_set_fork_write_address(a_engine->rtp_session, ip, port, &err)) == SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork write media to %s:%d\n",
-						  switch_channel_get_name(session->channel), ip, port);
-		switch_rtp_activate_fork_write(a_engine->rtp_session);
-	} else {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Failed to fork media to %s:%d (%s)\n",
-						  switch_channel_get_name(session->channel), ip, port, err);
-	}
-
-	return status;
-}
-
-SWITCH_DECLARE(switch_status_t) switch_core_media_fork_write(switch_core_session_t *session, const char *ip, switch_port_t port)
-{
-	switch_rtp_engine_t *a_engine = NULL;
-	switch_media_handle_t *smh = NULL;
-	const char *err = NULL;
-	switch_status_t status = SWITCH_STATUS_FALSE;
-	switch_assert(session);
-
-	if (!ip) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s No Fork IP!\n", 
-			switch_channel_get_name(session->channel));
-		return status;
-	}
-
-	if (!port) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s No Fork Port!\n", 
-			switch_channel_get_name(session->channel));
-		return status;
-	}
-
-	if (!(smh = session->media_handle)) {
-		return status;
-	}
-
-	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
-	if (a_engine->rtp_session && (status = switch_rtp_set_fork_write_address(a_engine->rtp_session, ip, port, &err)) == SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Set fork write media to %s:%d\n",
-						  switch_channel_get_name(session->channel), ip, port);
-	} else {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Failed to set fork media to %s:%d (%s)\n",
-						  switch_channel_get_name(session->channel), ip, port, err);
-	}
-
-	return status;
-}
-
-SWITCH_DECLARE(switch_status_t) switch_core_media_activate_fork_write(switch_core_session_t *session)
-{
-	switch_rtp_engine_t *a_engine = NULL;
-	switch_media_handle_t *smh = NULL;
-	switch_status_t status = SWITCH_STATUS_FALSE;
-	switch_assert(session);
-
-	if (!(smh = session->media_handle)) {
-		return status;
-	}
-
-	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
-	if (a_engine->rtp_session && (status = switch_rtp_activate_fork_write(a_engine->rtp_session)) == SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Start fork write media\n",
-						  switch_channel_get_name(session->channel));
-	} else {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Failed to start fork media\n",
-						  switch_channel_get_name(session->channel));
-	}
-
-	return status;
-}
-
-SWITCH_DECLARE(switch_status_t) switch_core_media_deactivate_fork_write(switch_core_session_t *session)
-{
-	switch_rtp_engine_t *a_engine = NULL;
-	switch_media_handle_t *smh = NULL;
-	switch_assert(session);
-
-	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): no media\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
 		return SWITCH_STATUS_FALSE;
 	}
 
 	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
-	if (a_engine->rtp_session) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Stop fork write media\n",
-						  switch_channel_get_name(session->channel));
-		switch_rtp_deactivate_fork_write(a_engine->rtp_session);
-		return SWITCH_STATUS_SUCCESS;
-	} else {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "%s Failed to stop fork media: No RTP session\n",
-						  switch_channel_get_name(session->channel));
+	if (!a_engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): failed to setup forking media to %s:%d (no RTP session)\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port);
+		return SWITCH_STATUS_FALSE;
 	}
 
-	return SWITCH_STATUS_FALSE;
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork (%s): setting up forking of media to %s:%d\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port);
+
+	status = switch_rtp_set_fork(a_engine->rtp_session, direction, ip, port, &err);
+	if (status != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): failed to setup forking media to %s:%d (%s)\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port, err);
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork (%s): ready (to %s:%d)\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port);
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_activate_fork(switch_core_session_t *session, switch_fork_direction_t direction)
+{
+	switch_rtp_engine_t *a_engine = NULL;
+	switch_media_handle_t *smh = NULL;
+	switch_status_t status = SWITCH_STATUS_FALSE;
+	switch_assert(session);
+
+	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): no media\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
+	if (!a_engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): failed to activate (no RTP session)\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	status = switch_rtp_activate_fork(a_engine->rtp_session, direction);
+	if (status != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): failed to activate fork\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork (%s): active\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_deactivate_fork(switch_core_session_t *session, switch_fork_direction_t direction)
+{
+	switch_rtp_engine_t *a_engine = NULL;
+	switch_media_handle_t *smh = NULL;
+	switch_assert(session);
+
+	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): no media\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
+	if (!a_engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): failed to deactivate (no RTP session)\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_rtp_deactivate_fork(a_engine->rtp_session, direction);
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Fork (%s): deactivated\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx");
+	return SWITCH_STATUS_SUCCESS;
 }
 
 //?

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -327,6 +327,13 @@ typedef struct ts_normalize_s {
 	int last_external;
 } ts_normalize_t;
 
+typedef struct switch_fork_s {
+	switch_sockaddr_t	*addr;
+	char				*host_str;
+	switch_port_t		port;
+	uint8_t				active;
+} switch_fork_t;
+
 struct switch_rtp {
 	/*
 	 * Two sockets are needed because we might be transcoding protocol families
@@ -352,7 +359,7 @@ struct switch_rtp {
 	uint32_t tmmbn;
 
 	ts_normalize_t ts_norm;
-	switch_sockaddr_t *remote_addr, *rtcp_remote_addr, *fork_write_addr;
+	switch_sockaddr_t *remote_addr, *rtcp_remote_addr;
 	rtp_msg_t recv_msg;
 	rtcp_msg_t rtcp_recv_msg;
 	rtcp_msg_t *rtcp_recv_msg_p;
@@ -377,6 +384,9 @@ struct switch_rtp {
 	int fork_write;
 	int srtp_idx_rtp;
 	int srtp_idx_rtcp;
+
+	switch_fork_t fork_rx;
+	switch_fork_t fork_tx;
 
 	switch_dtls_t *dtls;
 	switch_dtls_t *rtcp_dtls;
@@ -414,7 +424,6 @@ struct switch_rtp {
 	char *local_host_str;
 	char *remote_host_str;
 	char *eff_remote_host_str;
-	char *fork_write_host_str;
 	switch_time_t first_stun;
 	switch_time_t last_stun;
 	uint32_t wrong_addrs;
@@ -432,7 +441,6 @@ struct switch_rtp {
 	switch_port_t local_port;
 	switch_port_t remote_port;
 	switch_port_t eff_remote_port;
-	switch_port_t fork_write_port;
 	switch_port_t remote_rtcp_port;
 
 	struct switch_rtp_vad_data vad_data;
@@ -3228,47 +3236,69 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_
 	return status;
 }
 
-SWITCH_DECLARE(switch_status_t) switch_rtp_set_fork_write_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, const char **err)
+SWITCH_DECLARE(switch_status_t) switch_rtp_set_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, const char **err)
 {
-	switch_sockaddr_t *fork_write_addr;
+	switch_sockaddr_t *addr = NULL;
+	switch_fork_t *fork = NULL;
 	*err = "Success";
 
-	if (switch_sockaddr_info_get(&fork_write_addr, host, SWITCH_UNSPEC, port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !fork_write_addr) {
+	if (!rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Fork: No RTP session\n");
+		*err = "No RTP session";
+		return SWITCH_STATUS_FALSE;
+	}
+
+	fork = (direction == FORK_DIRECTION_RX ? &rtp_session->fork_rx : &rtp_session->fork_tx);
+
+	if (switch_sockaddr_info_get(&addr, host, SWITCH_UNSPEC, port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !addr) {
 		*err = "Remote Address Error!";
 		return SWITCH_STATUS_FALSE;
 	}
 
-	switch_mutex_lock(rtp_session->write_mutex);
+	switch_mutex_lock(direction == FORK_DIRECTION_RX ? rtp_session->read_mutex : rtp_session->write_mutex);
 
-	rtp_session->fork_write_addr = fork_write_addr;
-	rtp_session->fork_write_host_str = switch_core_strdup(rtp_session->pool, host);
-	rtp_session->fork_write_port = port;
+	fork->addr = addr;
+	fork->host_str = switch_core_strdup(rtp_session->pool, host);
+	fork->port = port;
 
-	switch_mutex_unlock(rtp_session->write_mutex);
+	switch_mutex_unlock(direction == FORK_DIRECTION_RX ? rtp_session->read_mutex : rtp_session->write_mutex);
 
 	return SWITCH_STATUS_SUCCESS;
 }
 
-SWITCH_DECLARE(switch_status_t) switch_rtp_activate_fork_write(switch_rtp_t *rtp_session)
+SWITCH_DECLARE(switch_status_t) switch_rtp_activate_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction)
 {
+	switch_fork_t *fork = NULL;
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
-	switch_mutex_lock(rtp_session->write_mutex);
-	if (rtp_session->fork_write_addr) {
-		rtp_session->fork_write = 1;
-	} else {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Fail to activate fork write. Fork Address is missing\n");
-		status = SWITCH_STATUS_FALSE;
+
+	if (!rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Fork: No RTP session\n");
+		return SWITCH_STATUS_FALSE;
 	}
-	switch_mutex_unlock(rtp_session->write_mutex);
+
+	fork = (direction == FORK_DIRECTION_RX ? &rtp_session->fork_rx : &rtp_session->fork_tx);
+
+	switch_mutex_lock(direction == FORK_DIRECTION_RX ? rtp_session->read_mutex : rtp_session->write_mutex);
+	fork->active = 1;
+	switch_mutex_unlock(direction == FORK_DIRECTION_RX ? rtp_session->read_mutex : rtp_session->write_mutex);
 
 	return status;
 }
 
-SWITCH_DECLARE(void) switch_rtp_deactivate_fork_write(switch_rtp_t *rtp_session)
+SWITCH_DECLARE(void) switch_rtp_deactivate_fork(switch_rtp_t *rtp_session, switch_fork_direction_t direction)
 {
-	switch_mutex_lock(rtp_session->write_mutex);
-	rtp_session->fork_write = 0;
-	switch_mutex_unlock(rtp_session->write_mutex);
+	switch_fork_t *fork = NULL;
+
+	if (!rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Fork: No RTP session\n");
+		return;
+	}
+
+	fork = (direction == FORK_DIRECTION_RX ? &rtp_session->fork_rx : &rtp_session->fork_tx);
+
+	switch_mutex_lock(direction == FORK_DIRECTION_RX ? rtp_session->read_mutex : rtp_session->write_mutex);
+	fork->active = 0;
+	switch_mutex_unlock(direction == FORK_DIRECTION_RX ? rtp_session->read_mutex : rtp_session->write_mutex);
 }
 
 static const char *dtls_state_names_t[] = {"OFF", "HANDSHAKE", "SETUP", "READY", "FAIL", "INVALID"};
@@ -6500,6 +6530,15 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 #endif
 		}
 
+		if (rtp_session->fork_rx.active) {
+			if (rtp_session->sock_output && (*bytes > 0)) {
+				size_t lbytes = *bytes;
+				if (switch_socket_sendto(rtp_session->sock_output, rtp_session->fork_rx.addr, 0, (void *) &rtp_session->recv_msg.header, &lbytes) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Fork (rx): failed to transmit %zu bytes\n", lbytes);
+				}
+			}
+		}
+
 
 		if (rtp_session->has_rtp) {
 			if (rtp_session->recv_msg.header.cc > 0) { /* Contributing Source Identifiers (4 bytes = sizeof CSRC header)*/
@@ -8836,11 +8875,12 @@ static int rtp_common_write(switch_rtp_t *rtp_session,
 			switch_swap_linear((int16_t *)send_msg->body, (int) datalen);
 		}
 
-		if (rtp_session->fork_write && rtp_session->fork_write_addr) {
-			if (switch_socket_sendto(rtp_session->sock_output, rtp_session->fork_write_addr, 0, (void *) send_msg, &bytes) != SWITCH_STATUS_SUCCESS) {
-#ifdef DEBUG_RTP_FORK_MEDIA
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "WRITE Fork Failed! %d\n", (int) bytes);
-#endif
+		if (rtp_session->fork_tx.active) {
+			if (rtp_session->sock_output && (bytes > 0)) {
+				size_t lbytes = bytes;
+				if (switch_socket_sendto(rtp_session->sock_output, rtp_session->fork_tx.addr, 0, (void *) send_msg, &lbytes) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Fork (tx): failed to transmit %zu bytes\n", lbytes);
+				}
 			}
 		}
 


### PR DESCRIPTION
This should go on top of merge-ndebug https://github.com/team-telnyx/freeswitch/pull/104
with changes to mod call control: https://github.com/team-telnyx/mod_call_control/pull/14

    ENGDESK-11524 Fork (add blocking mode waiting for rx ssrc)
    
            Use wait_ssrc (or ssrc_wait) to tell FS to wait for rx ssrc before firing media_stream::start event.
            Example:
                    uuid_broadcast b34c6ba3-a119-4919-b177-d579f2e58c6e
                    telnyx_media_stream_start::'{"rx":"udp:35.178.3.213:4901","tx":"udp:35.178.3.213:4900","wait_ssrc":"true"}'
    
            Default behaviour is not to wait for rx ssrc. You will get rx ssrc 0 then in the event.
            Note though that interestingly even this mode is still fine for only two streams case:
                    - if only rx was requested you don't need to know it's ssrc in advance to demultiplex (single stream)
                    - if only tx was requested tx ssrc is in the event (it is always)
                    - if rx and tx was requested you can demultiplex by tx ssrc (other one is rx)
