### PR TITLE
Engdesk 11745 timestamp fix normalised ts v50

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -437,6 +437,8 @@ SWITCH_DECLARE(void) switch_core_media_set_smode(switch_core_session_t *session,
 SWITCH_DECLARE(void) switch_core_media_set_resolveice(switch_bool_t resolve_ice);
 SWITCH_DECLARE(switch_bool_t) switch_core_media_has_resolveice(void);
 
+SWITCH_DECLARE(void) switch_core_media_do_2833(switch_core_session_t *session);
+																		
 SWITCH_END_EXTERN_C
 #endif
 /* For Emacs:

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -633,6 +633,7 @@ SWITCH_DECLARE(void) switch_rtp_video_refresh(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_video_loss(switch_rtp_t *rtp_session);
 
 SWITCH_DECLARE(switch_core_session_t*) switch_rtp_get_core_session(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session);
 /*!
   \}
 */

--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -976,10 +976,18 @@ typedef enum {
 	*/
 
 
-	RTP_BUG_ALWAYS_AUTO_ADJUST = (1 << 12)
+	RTP_BUG_ALWAYS_AUTO_ADJUST = (1 << 12),
 
 	/*
 	  Leave the auto-adjust behavior enableed permenantly rather than only at appropriate times.  (IMPLICITLY sets RTP_BUG_ACCEPT_ANY_PACKETS)
+
+	 */
+
+	RTP_BUG_SEND_NORMALISED_TIMESTAMPS = (1 << 13)
+
+	/*
+	  Send linear timestamps, including synchronised timestamps of 2833 DTMF packets. With this flag set, DTMF's timestamp will be synchronised
+	  with RTP timestamp to produce linear sequence. This sequence will increase by fixed (negotiated) sample count between two RTP packets independent of time.
 
 	 */
 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1407,6 +1407,10 @@ static switch_status_t sofia_send_dtmf(switch_core_session_t *session, const swi
 
 	dtmf_type = tech_pvt->mparams.dtmf_type;
 
+#if DEBUG_RTP
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Sofia: send_dtmf [digit: %c, duration: %u, flags: %d, source: %d] (%p)\n", dtmf->digit, dtmf->duration, dtmf->flags, dtmf->source, (void*)session);
+#endif
+
 	/* We only can send INFO when we have no media */
 	if (!switch_core_media_ready(tech_pvt->session, SWITCH_MEDIA_TYPE_AUDIO) ||
 		!switch_channel_media_ready(tech_pvt->channel) || switch_channel_test_flag(tech_pvt->channel, CF_PROXY_MODE) ||
@@ -1417,6 +1421,9 @@ static switch_status_t sofia_send_dtmf(switch_core_session_t *session, const swi
 	switch (dtmf_type) {
 	case DTMF_2833:
 		{
+#if DEBUG_RTP
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Sofia: send_dtmf [digit: %c, duration: %u, flags: %d, source: %d] queue 2833 (%p)\n", dtmf->digit, dtmf->duration, dtmf->flags, dtmf->source, (void*)session);
+#endif
 			return switch_core_media_queue_rfc2833(tech_pvt->session, SWITCH_MEDIA_TYPE_AUDIO, dtmf);
 		}
 	case DTMF_INFO:

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -49,6 +49,8 @@
 #include <stir_shaken.h>
 #endif
 
+#define DEBUG_RTP 0
+
 SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load);
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_sofia_shutdown);
 SWITCH_MODULE_DEFINITION(mod_sofia, mod_sofia_load, mod_sofia_shutdown, NULL);
@@ -1274,6 +1276,10 @@ static switch_status_t sofia_write_frame(switch_core_session_t *session, switch_
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	switch_time_t now = switch_micro_time_now();
 	switch_assert(tech_pvt != NULL);
+
+#if DEBUG_RTP
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Sofia: write frame %p\n", (void*)session);
+#endif
 
 	if (!switch_core_media_ready(tech_pvt->session, SWITCH_MEDIA_TYPE_AUDIO)) {
 		if (switch_channel_up_nosig(channel)) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -40,7 +40,7 @@
 #include <sofia-sip/sdp.h>
 #include <sofia-sip/su.h>
 
-#define DEBUG_RTP 0
+#define DEBUG_RTP 1
 
 static switch_t38_options_t * switch_core_media_process_udptl(switch_core_session_t *session, sdp_session_t *sdp, sdp_media_t *m);
 static void switch_core_media_find_zrtp_hash(switch_core_session_t *session, sdp_session_t *sdp);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -40,7 +40,7 @@
 #include <sofia-sip/sdp.h>
 #include <sofia-sip/su.h>
 
-#define DEBUG_RTP 1
+#define DEBUG_RTP 0
 
 static switch_t38_options_t * switch_core_media_process_udptl(switch_core_session_t *session, sdp_session_t *sdp, sdp_media_t *m);
 static void switch_core_media_find_zrtp_hash(switch_core_session_t *session, sdp_session_t *sdp);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -40,6 +40,8 @@
 #include <sofia-sip/sdp.h>
 #include <sofia-sip/su.h>
 
+#define DEBUG_RTP 0
+
 static switch_t38_options_t * switch_core_media_process_udptl(switch_core_session_t *session, sdp_session_t *sdp, sdp_media_t *m);
 static void switch_core_media_find_zrtp_hash(switch_core_session_t *session, sdp_session_t *sdp);
 static void switch_core_media_set_r_sdp_codec_string(switch_core_session_t *session, const char *codec_string, sdp_session_t *sdp, switch_sdp_type_t sdp_type);
@@ -3625,7 +3627,9 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_write_frame(switch_core_sessio
 	int fire_writable = 0;
 
 	switch_assert(session);
-
+#if DEBUG_RTP
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Core: write frame %p\n", (void*)session);
+#endif
 	if (!(smh = session->media_handle)) {
 		return SWITCH_STATUS_FALSE;
 	}
@@ -11413,13 +11417,18 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 
 	switch_core_media_check_dtmf_type(session);
 
-	if (switch_media_handle_test_media_flag(smh, SCMF_SUPPRESS_CNG) ||
-		((val = switch_channel_get_variable(session->channel, "supress_cng")) && switch_true(val)) ||
-		((val = switch_channel_get_variable(session->channel, "suppress_cng")) && switch_true(val))) {
-		use_cng = 0;
-		smh->mparams->cng_pt = 0;
+	val = switch_channel_get_variable(session->channel, "suppress_supress_cng");
+	if (!val) {
+	   val = switch_channel_get_variable(session->channel, "suppress_suppress_cng");
 	}
-
+	if (!val || !switch_true(val)) {
+		if (switch_media_handle_test_media_flag(smh, SCMF_SUPPRESS_CNG) ||
+				((val = switch_channel_get_variable(session->channel, "supress_cng")) && switch_true(val)) ||
+				((val = switch_channel_get_variable(session->channel, "suppress_cng")) && switch_true(val))) {
+			use_cng = 0;
+			smh->mparams->cng_pt = 0;
+		}
+	}
 
 
 
@@ -16955,6 +16964,10 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 
 	switch_assert(session != NULL);
 	switch_assert(frame != NULL);
+
+#if DEBUG_RTP
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Core session: write frame %p\n", (void*)session);
+#endif
 
 	if (!switch_channel_up_nosig(session->channel)) {
 		return SWITCH_STATUS_FALSE;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -17610,6 +17610,30 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 	return status;
 }
 
+SWITCH_DECLARE(void) switch_core_media_do_2833(switch_core_session_t *session)
+{
+	switch_rtp_engine_t *a_engine = NULL;
+	switch_media_handle_t *smh = NULL;
+
+	if (!session) {
+		return;
+	}
+
+	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Core media do 2833 (%p): no media\n", (void*) session);
+		return;
+	}
+
+	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
+	if (!a_engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Core media do 2833 (%p): no RTP session\n", (void*) session);
+		return;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Core media do 2833 (%p)\n", (void*) session);
+	do_2833(a_engine->rtp_session);
+}
+
 
 
 /* For Emacs:

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -1161,6 +1161,14 @@ SWITCH_DECLARE(void) switch_core_media_parse_rtp_bugs(switch_rtp_bug_flag_t *fla
 	if (switch_stristr("~ALWAYS_AUTO_ADJUST", str)) {
 		*flag_pole &= ~(RTP_BUG_ALWAYS_AUTO_ADJUST | RTP_BUG_ACCEPT_ANY_PACKETS);
 	}
+
+	if (switch_stristr("SEND_NORMALISED_TIMESTAMPS", str)) {
+		*flag_pole |= (RTP_BUG_SEND_NORMALISED_TIMESTAMPS);
+	}
+
+	if (switch_stristr("~SEND_NORMALISED_TIMESTAMPS", str)) {
+		*flag_pole &= ~(RTP_BUG_SEND_LINEAR_TIMESTAMPS);
+	}
 }
 
 /**

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -31,7 +31,7 @@
 
 #include <switch.h>
 #define DEFAULT_LEAD_FRAMES 10
-#define DEBUG_RTP 0
+#define DEBUG_RTP 1
 
 static const switch_state_handler_table_t audio_bridge_peer_state_handlers;
 static void cleanup_proxy_mode_a(switch_core_session_t *session);

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -520,6 +520,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 
 	for (;;) {
+		int sanity = 1000;
 		switch_channel_state_t b_state;
 		switch_status_t status;
 		switch_event_t *event;
@@ -533,70 +534,140 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		} else {
 			pass_val = 2;
 		}
+
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #1 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 		
 		if (pass_val != last_pass_val) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #2 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_core_session_passthru(session_a, SWITCH_MEDIA_TYPE_AUDIO, pass_val == 2 ? SWITCH_TRUE : SWITCH_FALSE);
 			last_pass_val = pass_val;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #3 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 		
 		if (switch_channel_test_flag(chan_a, CF_TRANSFER)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #4 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			data->clean_exit = 1;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #5 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (data->clean_exit || switch_channel_test_flag(chan_b, CF_TRANSFER)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #6 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_channel_clear_flag(chan_a, CF_HOLD);
 			switch_channel_clear_flag(chan_a, CF_SUSPEND);
 			goto end_of_bridge_loop;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #7 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (!switch_channel_test_flag(chan_b, CF_BRIDGED)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #8 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			goto end_of_bridge_loop;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #9 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (!switch_channel_ready(chan_a)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #10 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			if (switch_channel_up(chan_a)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #11 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 				data->clean_exit = 1;
 			}
 			goto end_of_bridge_loop;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #12 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if ((b_state = switch_channel_down_nosig(chan_b))) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #13 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			goto end_of_bridge_loop;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #14 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (switch_channel_test_flag(chan_a, CF_HOLD_ON_BRIDGE)) {
 			switch_core_session_message_t hmsg = { 0 };
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #15 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_channel_clear_flag(chan_a, CF_HOLD_ON_BRIDGE);
 			hmsg.message_id = SWITCH_MESSAGE_INDICATE_HOLD;
 			hmsg.from = __FILE__;
 			hmsg.numeric_arg = 1;
 			switch_core_session_receive_message(session_a, &hmsg);
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #16 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (read_frame_count > DEFAULT_LEAD_FRAMES && switch_channel_media_ack(chan_a) && switch_core_session_private_event_count(session_a)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #17 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_channel_set_flag(chan_b, CF_SUSPEND);
 			msg.numeric_arg = 42;
 			msg.string_arg = data->b_uuid;
 			msg.message_id = SWITCH_MESSAGE_INDICATE_UNBRIDGE;
 			msg.from = __FILE__;
 			switch_core_session_receive_message(session_a, &msg);
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #18 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_ivr_parse_next_event(session_a);
 			msg.message_id = SWITCH_MESSAGE_INDICATE_BRIDGE;
 			switch_core_session_receive_message(session_a, &msg);
 			switch_channel_clear_flag(chan_b, CF_SUSPEND);
 			switch_core_session_kill_channel(session_b, SWITCH_SIG_BREAK);
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #19 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		switch_ivr_parse_all_messages(session_a);
 
 		if (!inner_bridge && (switch_channel_test_flag(chan_a, CF_SUSPEND) || switch_channel_test_flag(chan_b, CF_SUSPEND))) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #21 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			status = switch_core_session_read_frame(session_a, &read_frame, SWITCH_IO_FLAG_NONE, stream_id);
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #22 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 			if (!SWITCH_READ_ACCEPTABLE(status)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #23 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 				goto end_of_bridge_loop;
 			}
 			continue;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #23 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (switch_channel_test_flag(chan_a, CF_HAS_TEXT) && switch_channel_test_flag(chan_b, CF_HAS_TEXT) && !txt_launch) {
 			txt_launch++;
@@ -625,8 +696,14 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 			}
 		}
 #endif
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #24 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (read_frame_count >= DEFAULT_LEAD_FRAMES && switch_channel_media_ack(chan_a)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #25 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			if (!played_banner && switch_channel_test_flag(chan_a, CF_VIDEO) && switch_channel_test_flag(chan_b, CF_VIDEO) &&
 				switch_channel_test_flag(chan_a, CF_ANSWERED) && switch_channel_test_flag(chan_b, CF_ANSWERED) &&
 				++banner_counter > 100 &&
@@ -637,6 +714,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				if (!b_banner_file) {
 					b_banner_file = switch_channel_get_variable(chan_a, "video_pre_call_banner_bleg");
 				}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #26 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 
 				switch_channel_clear_flag(chan_a, CF_VIDEO_PAUSE_READ);
@@ -688,6 +768,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				goto end_of_bridge_loop;
 			}
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #27 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		/* if 1 channel has DTMF pass it to the other */
 		while (switch_channel_has_dtmf(chan_a)) {
@@ -730,8 +813,25 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				}
 			}
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #28 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
+
+		while (switch_channel_has_dtmf(chan_b) && (sanity > 0)) {
+#if DEBUG_RTP
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: handling DTMF for B (sanity: %d) %p -> %p\n", sanity, (void*)session_a, (void*)session_b);
+#endif
+			switch_core_media_do_2833(session_b);
+			sanity--;
+		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #29 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (switch_core_session_dequeue_event(session_a, &event, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #30 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			if (input_callback) {
 				input_callback(session_a, event, SWITCH_INPUT_TYPE_EVENT, user_data, 0);
 			}
@@ -742,8 +842,14 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 			}
 
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #31 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (!switch_channel_test_flag(chan_a, CF_ANSWERED) && answer_limit && switch_epoch_time_now(NULL) > answer_limit) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #32 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Answer timeout hit on %s.\n", switch_channel_get_name(chan_a));
 			if (switch_true(switch_channel_get_variable_dup(chan_a, "continue_on_answer_timeout", SWITCH_FALSE, -1))) {
 				data->clean_exit = 1;
@@ -754,6 +860,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		}
 
 		if (!switch_channel_test_flag(chan_a, CF_ANSWERED)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #33 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			if (originator) {
 				if (!ans_b && switch_channel_test_flag(chan_b, CF_ANSWERED)) {
 					switch_channel_pass_callee_id(chan_b, chan_a);
@@ -799,6 +908,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				}
 			}
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #34 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (originator && !ans_b) ans_b = switch_channel_test_flag(chan_b, CF_ANSWERED);
 
@@ -818,12 +930,24 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 			switch_core_session_write_video_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, 0);
 		}
 #endif
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #35 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		if (!switch_channel_test_flag(chan_a, CF_AUDIO)) {
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #36 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			switch_ivr_sleep(session_a, 5000, SWITCH_FALSE, NULL);
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #37 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 			continue;
 		}
 
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #38 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 		/* read audio from 1 channel and write it to the other */
 		status = switch_core_session_read_frame(session_a, &read_frame, SWITCH_IO_FLAG_NONE, stream_id);
@@ -864,9 +988,15 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "%s ending bridge by request from read function\n", switch_channel_get_name(chan_a));
 			goto end_of_bridge_loop;
 		}
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #39 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 	}
 
   end_of_bridge_loop:
+#if DEBUG_RTP
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #40 %p -> %p\n", (void*)session_a, (void*)session_b);
+#endif
 
 	switch_core_session_passthru(session_a, SWITCH_MEDIA_TYPE_AUDIO, SWITCH_FALSE);
 

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -627,6 +627,8 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #17 %p -> %p\n", (void*)session_a, (void*)session_b);
 #endif
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_WARNING, "Audio bridge thread: kill channel B: %p -> %p\n", (void*)session_a, (void*)session_b);
+
 			switch_channel_set_flag(chan_b, CF_SUSPEND);
 			msg.numeric_arg = 42;
 			msg.string_arg = data->b_uuid;

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -31,7 +31,7 @@
 
 #include <switch.h>
 #define DEFAULT_LEAD_FRAMES 10
-#define DEBUG_RTP 1
+#define DEBUG_RTP 0
 
 static const switch_state_handler_table_t audio_bridge_peer_state_handlers;
 static void cleanup_proxy_mode_a(switch_core_session_t *session);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -563,7 +563,7 @@ typedef enum {
 	RESULT_GOTO_TIMERCHECK
 } handle_rfc2833_result_t;
 
-static void do_2833(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session);
 
 
 #define rtp_type(rtp_session) rtp_session->flags[SWITCH_RTP_FLAG_TEXT] ?  "text" : (rtp_session->flags[SWITCH_RTP_FLAG_VIDEO] ? "video" : "audio")
@@ -5847,7 +5847,7 @@ static void set_dtmf_delay(switch_rtp_t *rtp_session, uint32_t ms)
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG, "Queue digit delay of %dms\n", ms);
 }
 
-static void do_2833(switch_rtp_t *rtp_session)
+SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 {
 	switch_frame_flag_t flags = 0;
 	uint32_t samples = rtp_session->samples_per_interval;
@@ -7677,7 +7677,7 @@ static void check_timeout(switch_rtp_t *rtp_session)
 		elapsed = (now - rtp_session->last_media) / 1000;
 	}
 
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG10,
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
 					  "%s MEDIA TIMEOUT %s %d/%d", switch_core_session_get_name(rtp_session->session), rtp_type(rtp_session),
 					  elapsed, rtp_session->media_timeout);
 
@@ -7687,6 +7687,7 @@ static void check_timeout(switch_rtp_t *rtp_session)
 			switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
 
 			if (switch_telnyx_sip_on_media_timeout(channel, rtp_session)) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s Execute on media timeout\n", rtp_session_name(rtp_session));
 				switch_channel_execute_on(channel, "execute_on_media_timeout");
 				switch_channel_hangup(channel, SWITCH_CAUSE_MEDIA_TIMEOUT);
 			} else {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -51,16 +51,16 @@
 #include <switch_jitterbuffer.h>
 #include <switch_estimators.h>
 
-#define DEBUG_RTP 0
-//#define DEBUG_TS_ROLLOVER
+#define DEBUG_RTP 1
+#define DEBUG_TS_ROLLOVER
 #ifdef DEBUG_TS_ROLLOVER
 #define TS_ROLLOVER_START 4294951295
 #endif
 
-//#define DEBUG_2833
-//#define RTP_DEBUG_WRITE_DELTA
-//#define DEBUG_MISSED_SEQ
-//#define DEBUG_EXTRA
+#define DEBUG_2833
+#define RTP_DEBUG_WRITE_DELTA
+#define DEBUG_MISSED_SEQ
+#define DEBUG_EXTRA
 //#define DEBUG_RTCP
 #define DEBUG_ESTIMATORS_
 #define DEBUG_HOMER 0

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -51,7 +51,7 @@
 #include <switch_jitterbuffer.h>
 #include <switch_estimators.h>
 
-#define DEBUG_RTP 1
+#define DEBUG_RTP 0
 #define DEBUG_TS_ROLLOVER
 #ifdef DEBUG_TS_ROLLOVER
 #define TS_ROLLOVER_START 4294951295

--- a/src/switch_version.c
+++ b/src/switch_version.c
@@ -35,11 +35,6 @@
  */
 #include <switch.h>
 #include <switch_version.h>
-#undef SWITCH_VERSION_REVISION
-#define SWITCH_VERSION_REVISION "telv50.1+git~1638354761~20211201T183241~77b677bb75"
-
-#undef SWITCH_VERSION_REVISION_HUMAN
-#define SWITCH_VERSION_REVISION_HUMAN "[Telnyx B2BUA Version 50 Build 1, git 1638354761 2021-12-01 18:32:41 +0800 77b677bb75, Built at Thu Dec  2 16:11:35 UTC 2021] "
 
 const char *switch_version_major_str = SWITCH_VERSION_MAJOR;
 const char *switch_version_minor_str = SWITCH_VERSION_MINOR;

--- a/src/switch_version.c
+++ b/src/switch_version.c
@@ -35,6 +35,11 @@
  */
 #include <switch.h>
 #include <switch_version.h>
+#undef SWITCH_VERSION_REVISION
+#define SWITCH_VERSION_REVISION "telv50.1+git~1638354761~20211201T183241~77b677bb75"
+
+#undef SWITCH_VERSION_REVISION_HUMAN
+#define SWITCH_VERSION_REVISION_HUMAN "[Telnyx B2BUA Version 50 Build 1, git 1638354761 2021-12-01 18:32:41 +0800 77b677bb75, Built at Thu Dec  2 16:11:35 UTC 2021] "
 
 const char *switch_version_major_str = SWITCH_VERSION_MAJOR;
 const char *switch_version_minor_str = SWITCH_VERSION_MINOR;


### PR DESCRIPTION
This fix can be enabled via RTP bugs, e.g:

`<action application="export" data="rtp_manual_rtp_bugs=SEND_NORMALISED_TIMESTAMPS"/>`