### PR TITLE
TEL-5115 Fix segfault in zrtp

### DIFF
--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -1663,9 +1663,13 @@ SWITCH_DECLARE(uint32_t) switch_channel_test_flag(switch_channel_t *channel, swi
 
 	switch_assert(channel != NULL);
 
-	switch_mutex_lock(channel->flag_mutex);
+	if (channel->flag_mutex) {
+		switch_mutex_lock(channel->flag_mutex);
+	}
 	r = channel->flags[flag];
-	switch_mutex_unlock(channel->flag_mutex);
+	if (channel->flag_mutex) {
+		switch_mutex_unlock(channel->flag_mutex);
+	}
 
 	return r;
 }

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1408,6 +1408,16 @@ static void zrtp_event_callback(zrtp_stream_t *stream, unsigned event)
 	switch_event_t *fsevent = NULL;
 	const char *type;
 
+	if (!rtp_session || !rtp_session->session) {
+		return;
+	}
+
+	channel = switch_core_session_get_channel(rtp_session->session);
+	if (switch_test_flag(rtp_session->session, SSF_DESTROYED) || !channel || switch_channel_down_nosig(channel)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Discarding a dangling call to zrtp_event_callback\n");
+		return;
+	}
+
 	if (switch_core_session_read_lock(rtp_session->session) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Unable to acquire session lock!\n");
 		return;


### PR DESCRIPTION
Check for flag_mutex in switch_channel_test_flag
and ignore dangling calls to zrtp_event_callback