### PR TITLE
ENGDESK-12873 Fix bug checking rtp_rewrite_timestamps variable

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9682,8 +9682,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 		flags[SWITCH_RTP_FLAG_AUTOFLUSH]++;
 	}
 
-	if (!(switch_media_handle_test_media_flag(smh, SCMF_REWRITE_TIMESTAMPS) ||
-		  ((val = switch_channel_get_variable(session->channel, "rtp_rewrite_timestamps")) && switch_false(val)))) {
+	val = switch_channel_get_variable(session->channel, "rtp_rewrite_timestamps");
+	if ((!val && !switch_media_handle_test_media_flag(smh, SCMF_REWRITE_TIMESTAMPS)) || (val && switch_false(val))) {
 		flags[SWITCH_RTP_FLAG_RAW_WRITE]++;
 	}
 


### PR DESCRIPTION
    This prevents core media setting SWITCH_RTP_FLAG_RAW_WRITE to true.
    When SWITCH_RTP_FLAG_RAW_WRITE is true, then B2BUA copies timestamps.
    When it is false, then B2BUA generates them.

    Previously it would cause SWITCH_RTP_FLAG_RAW_WRITE set to true if:
	- core media SCMF_REWRITE_TIMESTAMPS flag is not defined (do not want to rewrite timestamps)
	- or variable rtp_rewrite_timestamps is defined and true

    Now it would do that if
	- variable rtp_rewrite_timestamps is not defined and SCMF_REWRITE_TIMESTAMPS is not set
	- variable rtp_rewrite_timestamps is defined and false.