### PR TITLE
ENGDESK-11731 Add transcoding to telnyx_media_stream_start

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -196,6 +196,7 @@ static inline const char *switch_media_type2str(switch_media_type_t type)
 	}
 }
 
+#define FORK_CODEC_NAME_LEN 100
 typedef struct switch_fork_s {
 	switch_sockaddr_t	*addr;
 	char				*host_str;
@@ -203,6 +204,14 @@ typedef struct switch_fork_s {
 	uint32_t			ssrc;
 	char				cmd[500];
 	uint8_t				active;
+	char				codec_iananame[FORK_CODEC_NAME_LEN];
+	char				rtp_codec[FORK_CODEC_NAME_LEN];
+	char				fork_codec[FORK_CODEC_NAME_LEN];
+	uint8_t				transcoding_pt;
+	uint8_t				transcoding;
+	uint8_t				rtp_pt;
+	switch_codec_t codec_in;
+	switch_codec_t codec_out;
 } switch_fork_session_t;
 
 typedef struct switch_fork_state_s {
@@ -263,7 +272,7 @@ SWITCH_DECLARE(int) switch_core_media_check_nat(switch_media_handle_t *smh, cons
 
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_port(switch_core_session_t *session, switch_media_type_t type, int force);
 SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_session_t *session, switch_bool_t audio, switch_bool_t video);
-SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd);
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd, const char *codec_iananame);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_id(switch_core_session_t *session, const char *id);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_wait_ssrc(switch_core_session_t *session, int timeout_ms);
 SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set_local_address(switch_core_session_t *session);

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -299,7 +299,7 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, switch_port_t remote_rtcp_port,
 															  switch_bool_t change_adv_addr, const char **err);
 
-SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd);
+SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd, const char *codec_iananame);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_id(switch_rtp_t *rtp_session, const char *id);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_wait_ssrc(switch_rtp_t *rtp_session, int timeout_ms);
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set_local_address(switch_rtp_t *rtp_session, const char *ip, uint16_t port);
@@ -634,6 +634,7 @@ SWITCH_DECLARE(void) switch_rtp_video_loss(switch_rtp_t *rtp_session);
 
 SWITCH_DECLARE(switch_core_session_t*) switch_rtp_get_core_session(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(switch_status_t) switch_rtp_transcode(switch_codec_t *codec_in, switch_codec_t *codec_out, char *payload_in, uint32_t len_in, char *payload_out, uint32_t *len_out, uint32_t rate_in, uint32_t rate_out);
 /*!
   \}
 */

--- a/src/include/switch_utils.h
+++ b/src/include/switch_utils.h
@@ -1508,6 +1508,7 @@ SWITCH_DECLARE(switch_status_t) switch_digest_string(const char *digest_name, ch
 
 SWITCH_DECLARE(char *) switch_must_strdup(const char *_s);
 SWITCH_DECLARE(const char *) switch_memory_usage_stream(switch_stream_handle_t *stream);
+SWITCH_DECLARE(void) switch_string_tolower(char *s);
 
 SWITCH_END_EXTERN_C
 #endif

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9088,7 +9088,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_choose_ports(switch_core_sessi
 	return status;
 }
 
-SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd)
+SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t *session, switch_fork_direction_t direction, const char *ip, switch_port_t port, const char *cmd, const char *codec_iananame)
 {
 	switch_rtp_engine_t *a_engine = NULL;
 	switch_media_handle_t *smh = NULL;
@@ -9123,9 +9123,9 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_fork_set(switch_core_session_t
 
 	ssrc = (direction == FORK_DIRECTION_RX ? a_engine->remote_ssrc : a_engine->ssrc);
 
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "%s Fork (%s): setting up forking of media to %s:%d ssrc: %u\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port, ssrc);
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "%s Fork (%s): setting up forking of media to %s:%d ssrc: %u codec: %s\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port, ssrc, !zstr(codec_iananame) ? codec_iananame : "not set");
 
-	status = switch_rtp_fork_set(a_engine->rtp_session, direction, ip, port, ssrc, cmd);
+	status = switch_rtp_fork_set(a_engine->rtp_session, direction, ip, port, ssrc, cmd, codec_iananame);
 	if (status != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s Fork (%s): failed to setup forking media to %s:%d ssrc: %u\n", switch_channel_get_name(session->channel), direction == FORK_DIRECTION_RX ? "rx" : "tx", ip, port, ssrc);
 		return SWITCH_STATUS_FALSE;

--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -4859,6 +4859,17 @@ done:
 	return status;
 }
 
+SWITCH_DECLARE(void) switch_string_tolower(char *s)
+{
+	if (zstr(s)) {
+		return;
+	}
+
+	for (int i = 0; s[i]; i++) {
+		s[i] = tolower(s[i]);
+	}
+}
+
 /* For Emacs:
  * Local Variables:
  * mode:c


### PR DESCRIPTION
This will tell FreeSWITCH to transcode audio RTP to given codec.
This is applied to both (rx and tx) legs of fork.

Example (transcode to PCMU):

        telnyx_media_stream_start" data='{
                "rx":"udp:35.178.3.213:4900",
                "tx":"udp:35.178.3.213:4900",
                "wait_ssrc":"true",
                "wait_ssrc_timeout_ms":"10000",
                "transcode":"PCMU"
        }'