### PR TITLE
ENGDESK-16451 Indicate transcoding on telnyx_media_stream_start event

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -10264,6 +10264,16 @@ SWITCH_DECLARE(void) switch_rtp_fork_fire_start_event(switch_rtp_t *rtp_session)
 			goto end;
 		}
 
+		if (fork_rx->transcoding) {
+			cJSON_AddBoolToObject(rx, "transcoding", 1);
+			cJSON_AddStringToObject(rx, "transcoding_codec_in", fork_rx->rtp_codec);
+			cJSON_AddStringToObject(rx, "transcoding_codec_out", fork_rx->fork_codec);
+			cJSON_AddNumberToObject(rx, "transcoding_pt_in", fork_rx->rtp_pt);
+			cJSON_AddNumberToObject(rx, "transcoding_pt_out", fork_rx->transcoding_pt);
+		} else {
+			cJSON_AddBoolToObject(rx, "transcoding", 0);
+		}
+
 		cJSON_AddItemToObject(f, "rx", rx);
 	}
 
@@ -10283,6 +10293,16 @@ SWITCH_DECLARE(void) switch_rtp_fork_fire_start_event(switch_rtp_t *rtp_session)
 
 		if (cJSON_AddNumberToObject(tx, "port", fork_tx->port) == NULL) {
 			goto end;
+		}
+
+		if (fork_tx->transcoding) {
+			cJSON_AddBoolToObject(tx, "transcoding", 1);
+			cJSON_AddStringToObject(tx, "transcoding_codec_in", fork_tx->rtp_codec);
+			cJSON_AddStringToObject(tx, "transcoding_codec_out", fork_tx->fork_codec);
+			cJSON_AddNumberToObject(tx, "transcoding_pt_in", fork_tx->rtp_pt);
+			cJSON_AddNumberToObject(tx, "transcoding_pt_out", fork_tx->transcoding_pt);
+		} else {
+			cJSON_AddBoolToObject(tx, "transcoding", 0);
 		}
 
 		cJSON_AddItemToObject(f, "tx", tx);


### PR DESCRIPTION
Added 5 new variables to variable_media_fork_request of telnyx_media_stream::start event:

		- 'transcoding': JSON boolean, tells if forked
			stream is being transcoded. This variable will always appear,
			the other 4 variables appear only if value of'transcoding' is true
		- 'transcoding_codec_in': JSON string, IANA name of codec
			used as input RTP to transcoding process (RTP used on call
			legs), in lower case
		- 'transcoding_codec_out': JSON string, IANA name of codec
			used as output RTP from the transcoding process (RTP sent
			to addresses requested in fork command ('rx'/'tx'), in lower case
		- 'transcoding_pt_in': JSON number, payload number of transcoding input RTP
		- 'transcoding_pt_out': JSON number, payload number of transcoding output RTP

	Example, when transcoding forked stream:

		{
			"fork":	{
				"ip_address":	"35.178.3.213",
				"tx_port":	18946,
				"rx_port":	18946
			},
			"rx":	{
				"ssrc":	0,
				"ip":	"127.0.0.1",
				"port":	4000,
				"transcoding":	true,
				"transcoding_codec_in":	"pcmu",
				"transcoding_codec_out":	"pcma",
				"transcoding_pt_in":	0,
				"transcoding_pt_out":	8
			},
			"tx":	{
				"ssrc":	445760437,
				"ip":	"127.0.0.1",
				"port":	5000,
				"transcoding":	true,
				"transcoding_codec_in":	"pcmu",
				"transcoding_codec_out":	"pcma",
				"transcoding_pt_in":	0,
				"transcoding_pt_out":	8
			}
		}

	Example, when transcoding wasn't requested or it was requested, but isn't needed:

	{
		"fork":	{
			"ip_address":	"35.178.3.213",
			"tx_port":	18608,
			"rx_port":	18608
		},
		"rx":	{
			"ssrc":	0,
			"ip":	"127.0.0.1",
			"port":	4000,
			"transcoding":	false
		},
		"tx":	{
			"ssrc":	445752248,
			"ip":	"127.0.0.1",
			"port":	5000,
			"transcoding":	false
		}
	}