### PR TITLE
TEL-5189 Move check for telnyx_rtp_poll_timeout_s to switch_rtp_new

### DIFF
--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -286,8 +286,7 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 											  switch_payload_t payload,
 											  uint32_t samples_per_interval,
 											  uint32_t ms_per_packet,
-											  switch_rtp_flag_t flags[], char *timer_name, const char **err, switch_memory_pool_t *pool, uint32_t poll_timeout_s);
-
+											  switch_rtp_flag_t flags[], char *timer_name, const char **err, switch_memory_pool_t *pool);
 
 /*!
   \brief Assign a remote address to the RTP session

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9584,9 +9584,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 	switch_media_handle_t *smh;
 	int is_reinvite = 0;
 
-	// Use static global default from RTP poll timeout
-	uint32_t poll_timeout_s = TELNYX_RTP_DEFAULT_POLL_TIMEOUT_S;
-
 #ifdef HAVE_OPENSSL_DTLSv1_2_method
 			uint8_t want_DTLSv1_2 = 1;
 #else
@@ -9637,17 +9634,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 	
 	if (want_DTLSv1_2) {
 		switch_channel_set_flag(session->channel, CF_WANT_DTLSv1_2);
-	}
-
-	// If global XML setting is defined, use that
-	{
-		char *val = switch_core_get_variable("telnyx_rtp_poll_timeout_s");
-		if (!zstr(val) && switch_is_number(val)) {
-			poll_timeout_s = atoi(val);
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Using XML setting for RTP poll timeout (%u)\n", poll_timeout_s);
-		} else {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Using static global setting for RTP poll timeout (%u)\n", poll_timeout_s);
-		}
 	}
 
 	if (switch_channel_test_flag(session->channel, CF_PROXY_MODE)) {
@@ -9853,8 +9839,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 											   a_engine->cur_payload_map->pt,
 											   a_engine->read_impl.samples_per_packet,
 											   codec_ms,
-											   flags, timer_name, &err, switch_core_session_get_pool(session),
-											   poll_timeout_s);
+											   flags, timer_name, &err, switch_core_session_get_pool(session));
 		{
 			const char *val = NULL;
 			if (((val = switch_channel_get_variable(session->channel, "telnyx_voicemail")) && switch_true(val))) {
@@ -10267,9 +10252,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 												   t_engine->cur_payload_map->remote_sdp_ip,
 												   t_engine->cur_payload_map->remote_sdp_port,
 												   t_engine->cur_payload_map->pt,
-												   TEXT_TIMER_SAMPLES, TEXT_TIMER_MS * 1000, flags, NULL, &err, switch_core_session_get_pool(session),
-												   poll_timeout_s);
-
+												   TEXT_TIMER_SAMPLES, TEXT_TIMER_MS * 1000, flags, NULL, &err, switch_core_session_get_pool(session));
 
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%sTEXT RTP [%s] %s:%d->%s:%d codec: %u ms: %d [%s]\n",
 							  switch_channel_test_flag(session->channel, CF_PROXY_MEDIA) ? "PROXY " : "",
@@ -10592,9 +10575,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 														 v_engine->cur_payload_map->remote_sdp_ip,
 														 v_engine->cur_payload_map->remote_sdp_port,
 														 v_engine->cur_payload_map->pt,
-														 1, 90000, flags, NULL, &err, switch_core_session_get_pool(session),
-														 poll_timeout_s);
-
+														 1, 90000, flags, NULL, &err, switch_core_session_get_pool(session));
 
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%sVIDEO RTP [%s] %s:%d->%s:%d codec: %u ms: %d [%s]\n",
 							  switch_channel_test_flag(session->channel, CF_PROXY_MEDIA) ? "PROXY " : "",

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -5163,10 +5163,12 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 											  switch_payload_t payload,
 											  uint32_t samples_per_interval,
 											  uint32_t ms_per_packet,
-											  switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID], char *timer_name, const char **err, switch_memory_pool_t *pool,
-											  uint32_t poll_timeout_s)
+											  switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID], char *timer_name, const char **err, switch_memory_pool_t *pool)
 {
 	switch_rtp_t *rtp_session = NULL;
+
+	// Use static global default from RTP poll timeout
+	uint32_t poll_timeout_s = TELNYX_RTP_DEFAULT_POLL_TIMEOUT_S;
 
 	if (zstr(rx_host)) {
 		*err = "Missing local host";
@@ -5186,6 +5188,17 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 	if (!tx_port) {
 		*err = "Missing remote port";
 		goto end;
+	}
+
+	// If global XML setting is defined, use that
+	{
+		char *val = switch_core_get_variable("telnyx_rtp_poll_timeout_s");
+		if (!zstr(val) && switch_is_number(val)) {
+			poll_timeout_s = atoi(val);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "Using XML setting for RTP poll timeout (%us)\n", poll_timeout_s);
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "Using static global setting for RTP poll timeout (%us)\n", poll_timeout_s);
+		}
 	}
 
 	if (switch_rtp_create(&rtp_session, payload, samples_per_interval, ms_per_packet, flags, timer_name, err, pool, poll_timeout_s) != SWITCH_STATUS_SUCCESS) {


### PR DESCRIPTION
This avoids changing of switch_rtp_new signature, otherwise that would
require patching all the places where this method is called.
Worse, a check for channel var would have to be made at all those places,
that is redundant - moving a check into switch_rtp_new handles it all
in a single place.