### PR TITLE
ENGDESK-17208: Fix deadlock in conference relate api

### DIFF
--- a/src/mod/applications/mod_conference/conference_api.c
+++ b/src/mod/applications/mod_conference/conference_api.c
@@ -3415,6 +3415,7 @@ switch_status_t conference_api_sub_relate(conference_obj_t *conference, switch_s
 		uint32_t member_id, other_member_id;
 		for (i = 0; i < members && members_array[i]; i++) {
 			member_id = atoi(members_array[i]);
+			switch_mutex_lock(conference->relate_mutex);
 			for (i2 = 0; i2 < other_members && other_members_array[i2]; i2++) {
 				other_member_id = atoi(other_members_array[i2]);
 				if (clear) {
@@ -3424,6 +3425,7 @@ switch_status_t conference_api_sub_relate(conference_obj_t *conference, switch_s
 					_conference_api_sub_relate_set_member_relationship(conference, stream, member_id, other_member_id, nospeak, nohear, sendvideo, action);
 				}
 			}
+			switch_mutex_unlock(conference->relate_mutex);
 		}
 	}
 	switch_safe_free(lbuf_members);

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -3757,6 +3757,7 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 	switch_thread_rwlock_create(&conference->rwlock, conference->pool);
 	switch_mutex_init(&conference->member_mutex, SWITCH_MUTEX_NESTED, conference->pool);
 	switch_mutex_init(&conference->canvas_mutex, SWITCH_MUTEX_NESTED, conference->pool);
+	switch_mutex_init(&conference->relate_mutex, SWITCH_MUTEX_NESTED, conference->pool);
 
 	switch_mutex_lock(conference_globals.hash_mutex);
 	conference_utils_set_flag(conference, CFLAG_INHASH);

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -748,6 +748,7 @@ typedef struct conference_obj {
 	int super_canvas_show_all_layers;
 	int canvas_running_count;
 	switch_mutex_t *canvas_mutex;
+	switch_mutex_t *relate_mutex;
 	switch_hash_t *layout_hash;
 	switch_hash_t *layout_group_hash;
 	switch_fps_t video_fps;


### PR DESCRIPTION
## Issue
A conference with 100 members execute multiple relate api command and causes a deadlock.

## Findings
Two commands are executed almost at the same time
```
conference 1000 relate 1,...N 2,...N nospeak
conference 1000 relate 2,...N 1,...N nohear
```
The first command will first lock member 1 while it updates the relation from multiple members. This will also perform lock/unlock per each member. This is also applies to the second command in which it will lock member 2 while it updates the relation from multiple members. If this is run almost at the same time there is a chance that the first command is block due to member 2 being lock in the second command. While the second command is block due to member 1 being lock due to the first command. This call sequence will result a deadlock.

## Fix
Use a conference mutex when it perform a relate command. 