### PR TITLE
TEL-5209 TEL-5195 TEL-5190 Changes to AMR-WB

### DIFF
--- a/conf/vanilla/autoload_configs/amrwb.conf.xml
+++ b/conf/vanilla/autoload_configs/amrwb.conf.xml
@@ -1,24 +1,16 @@
 <configuration name="amrwb.conf">
-	<settings>
-	<!--  AMRWB modes (supported bitrates):
-		mode 8 AMR-WB_23.85 23.85 Kbit/s
-		mode 7 AMR-WB_23.05 23.05 Kbit/s
-		mode 7 AMR-WB_19.85 19.85 Kbit/s
-		mode 6 AMR-WB_18.25 18.25 Kbit/s
-		mode 5 AMR-WB_15.85 15.85 Kbit/s
-		mode 4 AMR-WB_14.25 14.25 Kbit/s
-		mode 3 AMR-WB_12.65 12.65 Kbit/s
-		mode 2 AMR-WB_8.85 8.85 Kbit/s
-		mode 1 AMR-WB_6.60 6.60 Kbit/s
-	-->
-	<param name="default-bitrate" value="8"/>
-	 <!-- Enable VoLTE specific FMTP -->
-	<param name="volte" value="1"/>
-	<!-- Enable automatic bitrate variation during the call based on RTCP feedback -->
-	<param name="adjust-bitrate" value="0"/>
-	<!-- force OA when originating -->
-	<param name="force-oa" value="0"/>
-	<!-- don't mirror mode-set in SDP answer, but use our own (default-bitrate). -->
+  <settings>
+    <!--param name="default-bitrate" value="2"/-->
+    <param name="volte" value="1"/>
+    <param name="adjust-bitrate" value="0"/>
 	<param name="mode-set-overwrite" value="0"/>
+	<param name="mode-set-overwrite-with-default-bitrate" value="0"/>
+	<param name="mode-set" value="0,1,2"/>
+	<param name="invite-prefer-oa" value="1"/>
+	<!--param name="invite-prefer-be" value="1"/-->
+	<!--param name="force-oa" value="0"/-->
+	<!--param name="force-be" value="0"/-->
+	<!--param name="debug" value="0"/-->
+	<!--param name="fmtp-extra" value="silenceSupp:off - - - -"/-->
   </settings>
 </configuration>

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -31,7 +31,35 @@
  *
  * The amrwb codec itself is not distributed with this module.
  *
- * mod_amrwb.c -- GSM-AMRWB Codec Module
+ * mod_amrwb.c -- GSM-AMRWB Codec Modul
+ *
+ *
+ * XML Parameters
+ *
+ * default-bitrate
+ *		Bitrate mode that will be used if mode-set-overwrite and mode-set-overwrite-with-default-bitrate are set).
+ * volte
+ *		If set, configures codec for use on cellular networks.
+ * adjust-bitrate
+ *		Vary bitrate according to feedback from RTCP.
+ * force-oa
+ *		Configure codec in octet aligned mode.
+ * force-be
+ *		Configure codec in bandwidth efficient mode.
+ * mode-set-overwrite
+ *		When answering a call, use codec bitrate modes from mode-set param, instead of mirroring the OFFER.
+ * mode-set-overwrite-with-default-bitrate
+ *		If mode-set-overwrite is on, then use default-bitrate mode instead of mode-set.
+ * invite-prefer-oa
+ *		When answering a call, if AMR-WB is offered in 2 modes (octet aligned and bandwidth efficient), select octet aligned.
+ * invite-prefer-be
+ *		When answering a call, if AMR-WB is offered in 2 modes (octet aligned and bandwidth efficient), select bandwidth efficient.
+ * mode-set
+ *		Provides bitrate modes to be used with mode-set-overwrite (if mode-set-overwrite-with-default-bitrate is off).
+ * debug
+ *		If on, print extra codec info (CMR, ToC, last frame flag) at the FS's DEBUG level.
+ * fmtp-extra
+ *		Append any extra info to fmtp entry for AMR-WB.
  *
  */
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -6369,10 +6369,12 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					 * If this is last codec, accept it (in case of multiple, they could have been rejected but last should get matched
 					 * to any AMR-WB implementation loaded).
 					 */
-					if (amrwb_offerings_n > 1) {
-						if (amrwb_offerings_rejected_n + 1 < amrwb_offerings_n) {
-							if (SWITCH_STATUS_IGNORE == switch_core_codec_parse_fmtp(map->rm_encoding, map->rm_fmtp, map->rm_rate, &codec_fmtp)) {
-								match = 0;
+					if (!strcasecmp(map->rm_encoding, "AMR-WB")) {
+						if (amrwb_offerings_n > 1) {
+							if (amrwb_offerings_rejected_n + 1 < amrwb_offerings_n) {
+								if (SWITCH_STATUS_IGNORE == switch_core_codec_parse_fmtp(map->rm_encoding, map->rm_fmtp, map->rm_rate, &codec_fmtp)) {
+									match = 0;
+								}
 							}
 						}
 					}
@@ -6436,7 +6438,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 				// Count rejected AMR-WB offerings
 				if (!amrwb_matched && !strcasecmp(map->rm_encoding, "AMR-WB")) {
 					++amrwb_offerings_rejected_n;
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "AMR-WB codec [%s:%d:%u%d] rejected\n",
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "AMR-WB codec [%s:%d:%u:%d] rejected\n",
 							rm_encoding, map->rm_pt, (int) remote_codec_rate, codec_ms);
 				}
 


### PR DESCRIPTION
- Add app to print the module config (always print it on module's load)
- Improve codec negotiation according to invite-prefer-oa/invite-prefer-be
- Support new XML config params:
 
```
  default-bitrate
 		Bitrate mode that will be used if mode-set-overwrite 
                and mode-set-overwrite-with-default-bitrate are set).
  volte
 		If set, configures codec for use on cellular networks.
  adjust-bitrate
 		Vary bitrate according to feedback from RTCP.
  force-oa
 		Configure codec in octet aligned mode.
  force-be
 		Configure codec in bandwidth efficient mode.
  mode-set-overwrite
 		When answering a call, use codec bitrate modes from mode-set param, 
                instead of mirroring the OFFER.
  mode-set-overwrite-with-default-bitrate
 		If mode-set-overwrite is on, then use default-bitrate mode 
                instead of mode-set.
  invite-prefer-oa
 		When answering a call, if AMR-WB is offered in 2 modes (octet aligned 
                and bandwidth efficient), select octet aligned.
  invite-prefer-be
 		When answering a call, if AMR-WB is offered in 2 modes (octet aligned 
                and bandwidth efficient), select bandwidth efficient.
  mode-set
 		Provides bitrate modes to be used with mode-set-overwrite 
                (if mode-set-overwrite-with-default-bitrate is off).
  debug
 		If on, print extra codec info (CMR, ToC, last frame flag) 
                at the FS's DEBUG level.
  fmtp-extra
 		Append any extra info to fmtp entry for AMR-WB.
```
- Push new XML config to conf/vanilla