### PR TITLE
ENGDESK-17768 Add silence-supp-off XML setting

### DIFF
--- a/conf/vanilla/autoload_configs/amrwb.conf.xml
+++ b/conf/vanilla/autoload_configs/amrwb.conf.xml
@@ -1,16 +1,17 @@
 <configuration name="amrwb.conf">
-  <settings>
-    <!--param name="default-bitrate" value="2"/-->
-    <param name="volte" value="1"/>
-    <param name="adjust-bitrate" value="0"/>
-	<param name="mode-set-overwrite" value="0"/>
-	<param name="mode-set-overwrite-with-default-bitrate" value="0"/>
-	<param name="mode-set" value="0,1,2"/>
-	<param name="invite-prefer-oa" value="1"/>
-	<!--param name="invite-prefer-be" value="1"/-->
-	<!--param name="force-oa" value="0"/-->
-	<!--param name="force-be" value="0"/-->
-	<!--param name="debug" value="0"/-->
-	<!--param name="fmtp-extra" value="silenceSupp:off - - - -"/-->
-  </settings>
+	<settings>
+		<!--param name="default-bitrate" value="2"/-->
+		<param name="volte" value="1"/>
+		<param name="adjust-bitrate" value="0"/>
+		<param name="mode-set-overwrite" value="0"/>
+		<param name="mode-set-overwrite-with-default-bitrate" value="0"/>
+		<param name="mode-set" value="0,1,2"/>
+		<param name="invite-prefer-oa" value="1"/>
+			<!--param name="invite-prefer-be" value="1"/-->
+			<!--param name="force-oa" value="0"/-->
+			<!--param name="force-be" value="0"/-->
+			<!--param name="debug" value="0"/-->
+			<!--param name="fmtp-extra" value="silenceSupp:off - - - -"/-->
+		<param name="silence-supp-off" value="0"/>
+	</settings>
 </configuration>

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9675,6 +9675,17 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 		}
 	}
 
+	val = switch_channel_get_variable(session->channel, "suppress_supress_cng");
+	if (!val) {
+		val = switch_channel_get_variable(session->channel, "suppress_suppress_cng");
+	}
+	if (!val || !switch_true(val)) {
+		if (((val = switch_channel_get_variable(session->channel, "supress_cng")) && switch_true(val)) ||
+				((val = switch_channel_get_variable(session->channel, "suppress_cng")) && switch_true(val))) {
+			switch_media_handle_set_media_flag(smh, SCMF_SUPPRESS_CNG);
+		}
+	}
+
 	switch_core_media_parse_media_flags(session);
 
 	if (switch_rtp_ready(a_engine->rtp_session)) {


### PR DESCRIPTION
Param `silence-supp-off `can be set in mod_amrwb XML config.
If it is on (true) then it turns off silence suppression (CNG)
by appending

	`silenceSupp:off - - - -`

to SDP.