### PR TITLE
TEL-5512: Fix segfault in switch_socket_sendto()

### DIFF
--- a/src/switch_apr.c
+++ b/src/switch_apr.c
@@ -787,7 +787,7 @@ SWITCH_DECLARE(switch_status_t) switch_socket_send_nonblock(switch_socket_t *soc
 SWITCH_DECLARE(switch_status_t) switch_socket_sendto(switch_socket_t *sock, switch_sockaddr_t *where, int32_t flags, const char *buf,
 													 switch_size_t *len)
 {
-	if (!where || !buf || !len || !*len) {
+	if (!sock || !where || !buf || !len || !*len) {
 		return SWITCH_STATUS_GENERR;
 	}
 	return apr_socket_sendto(sock, where, flags, buf, len);

--- a/src/switch_apr.c
+++ b/src/switch_apr.c
@@ -787,7 +787,7 @@ SWITCH_DECLARE(switch_status_t) switch_socket_send_nonblock(switch_socket_t *soc
 SWITCH_DECLARE(switch_status_t) switch_socket_sendto(switch_socket_t *sock, switch_sockaddr_t *where, int32_t flags, const char *buf,
 													 switch_size_t *len)
 {
-	if (!sock || !where || !buf || !len || !*len) {
+	if (!where || !buf || !len || !*len) {
 		return SWITCH_STATUS_GENERR;
 	}
 	return apr_socket_sendto(sock, where, flags, buf, len);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1403,7 +1403,7 @@ static int zrtp_send_rtp_callback(const zrtp_stream_t *stream, char *rtp_packet,
 	switch_size_t len = rtp_packet_length;
 	zrtp_status_t status = zrtp_status_ok;
 
-	if (!rtp_session || !rtp_session->sock_output) {
+	if (!rtp_session || !rtp_session->sock_output || rtp_session->flags[SWITCH_RTP_FLAG_SHUTDOWN]) {
 		return status;
 	}
 
@@ -3367,6 +3367,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_udptl_mode(switch_rtp_t *rtp_session)
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_session, const char *host, switch_port_t port, switch_port_t remote_rtcp_port,
 															  switch_bool_t change_adv_addr, const char **err)
 {
+	switch_socket_t *sock;
 	switch_sockaddr_t *remote_addr;
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	*err = "Success";
@@ -3393,7 +3394,9 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_
 		rtp_session->sock_output = rtp_session->sock_input;
 	} else {
 		if (rtp_session->sock_output && rtp_session->sock_output != rtp_session->sock_input) {
-			switch_socket_close(rtp_session->sock_output);
+			sock = rtp_session->sock_output;
+			rtp_session->sock_output = NULL;
+			switch_socket_close(sock);
 		}
 		if ((status = switch_socket_create(&rtp_session->sock_output,
 										   switch_sockaddr_get_family(rtp_session->remote_addr),


### PR DESCRIPTION
Fix Segmentation fault in `switch_socket_sendto()` call by `zrtp_send_rtp_callback()`

Previous fix on the same issue [https://github.com/team-telnyx/freeswitch/pull/132](https://github.com/team-telnyx/freeswitch/pull/132)