### PR TITLE
TEL-5560: Upon recovery of an outbound session, if an inbound re-invite

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -1665,7 +1665,7 @@ static void our_sofia_event_callback(nua_event_t event,
 			sip->sip_payload->pl_data = su_strndup(nua_handle_get_home(nh), sip->sip_payload->pl_data, sip->sip_payload->pl_len);
 		}
 	}
-
+	
 	switch (event) {
 	case nua_r_get_params:
 	case nua_i_fork:
@@ -1711,6 +1711,7 @@ static void our_sofia_event_callback(nua_event_t event,
 		{
 			if (channel && sip) {
 				const char *r_sdp = NULL;
+				
 				sofia_glue_store_session_id(session, profile, sip, 0);
 
 				if (sip->sip_payload && sip->sip_payload->pl_data) {
@@ -2162,7 +2163,7 @@ static void our_sofia_event_callback(nua_event_t event,
 		}
 		break;
 	}
-
+	
   done:
 
 	if (tech_pvt && tech_pvt->want_event && event == tech_pvt->want_event) {

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1086,6 +1086,13 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 	if (switch_channel_test_flag(tech_pvt->channel, CF_RECOVERING)) {
 		switch_telnyx_on_channel_recover(tech_pvt->channel);
 	}
+	
+	/* TEL-5560: If this is set true, it means we previously received a reInvite
+	 * on an outbound leg.  Need to set this to false because we're now going to
+	 * send an outbound invite elsewhere.  (This function we're in gets called up
+	 * in initial invites and cases of 3XX in-dialog)
+	 */
+	switch_channel_set_variable(tech_pvt->channel, "dlg_req_swap_direction", "false");
 
 	if (sofia_test_flag(tech_pvt, TFLAG_SIP_HOLD_INACTIVE) ||
 		switch_true(switch_channel_get_variable_dup(tech_pvt->channel, "sofia_hold_inactive", SWITCH_FALSE, -1))) {


### PR DESCRIPTION
was received, the new reinvite outbound will swap the to & from headers unnecessarily.  Now we properly handle this situation, and also reset the dlg_req_swap_direction to false if we make any new outbound invite/reinvite.