### PR TITLE
TEL-5473: Decided to go with the builtin min-idle-cpu option for simplicity sake.

### DIFF
--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -337,7 +337,8 @@ typedef enum {
 	SOF_NO_EFFECTIVE_ANIII = (1 << 3),
 	SOF_NO_EFFECTIVE_CID_NUM = (1 << 4),
 	SOF_NO_EFFECTIVE_CID_NAME = (1 << 5),
-	SOF_NO_LIMITS = (1 << 6)
+	SOF_NO_LIMITS = (1 << 6),
+	SOF_NO_CPU_IDLE_LIMITS = (1 << 7)
 } switch_originate_flag_enum_t;
 typedef uint32_t switch_originate_flag_t;
 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -4904,6 +4904,11 @@ static switch_call_cause_t sofia_outgoing_channel(switch_core_session_t *session
 	int mod = 0;
 
 	*new_session = NULL;
+	
+	// Need to allow for override for outbound calls even when min-idle-cpu fails
+	if(mod_sofia_globals.min_idle_cpu_override_outbound) {
+		flags |= SOF_NO_CPU_IDLE_LIMITS;
+	}
 
 	if (!outbound_profile || zstr(outbound_profile->destination_number)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Invalid Empty Destination\n");

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -405,6 +405,9 @@ struct mod_sofia_globals {
 	char guess_mask_str[16];
 	int debug_presence;
 	int debug_sla;
+	int min_idle_cpu_failure_code; // SIP RC For when insufficient cpu-idle
+	char min_idle_cpu_failure_text[128]; // The text portion of the SIP response
+	int min_idle_cpu_override_outbound;
 	int auto_restart;
 	int reg_deny_binding_fetch_and_no_lookup; /* backwards compatibility */
 	int auto_nat;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2719,7 +2719,7 @@ void sofia_event_callback(nua_event_t event,
 
 			set_call_id(tech_pvt, sip);
 		} else {
-			nua_respond(nh, 503, "Maximum Calls In Progress", SIPTAG_RETRY_AFTER_STR("300"), TAG_END());
+			nua_respond(nh, mod_sofia_globals.min_idle_cpu_failure_code, mod_sofia_globals.min_idle_cpu_failure_text, SIPTAG_RETRY_AFTER_STR("300"), TAG_END());
 			nua_destroy_event(de->event);
 			su_free(nua_handle_get_home(nh), de);
 
@@ -4660,6 +4660,9 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 	mod_sofia_globals.auto_restart = SWITCH_TRUE;
 	mod_sofia_globals.reg_deny_binding_fetch_and_no_lookup = SWITCH_FALSE; /* handle backwards compatilibity - by default use new behavior */
 	mod_sofia_globals.rewrite_multicasted_fs_path = SWITCH_FALSE;
+	
+	mod_sofia_globals.min_idle_cpu_failure_code = 503;
+	strcpy(mod_sofia_globals.min_idle_cpu_failure_text, "Maximum Calls In Progress");
 
 	if ((settings = switch_xml_child(cfg, "global_settings"))) {
 		for (param = switch_xml_child(settings, "param"); param; param = param->next) {
@@ -4716,6 +4719,17 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 				mod_sofia_globals.stir_shaken_vs_cert_path_check = switch_true(val);
 			} else if (!strcasecmp(var, "stir-shaken-vs-require-date")) {
 				mod_sofia_globals.stir_shaken_vs_require_date = switch_true(val);
+			} else if (!strcasecmp(var, "min-idle-cpu-failure-code")) {
+				int temp_rc = atoi(val);
+				if(temp_rc > 399 && temp_rc < 700) {
+					mod_sofia_globals.min_idle_cpu_failure_code = temp_rc;
+				} else {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "min-idle-cpu-failure-code must be between 400 and 699.  Value was %d, leaving value set to 503.\n", temp_rc);
+				}
+			} else if (!strcasecmp(var, "min-idle-cpu-failure-text")) {
+				strncpy(mod_sofia_globals.min_idle_cpu_failure_text, val, 128);
+			} else if (!strcasecmp(var, "min-idle-cpu-override-outbound")) {
+				mod_sofia_globals.min_idle_cpu_override_outbound = atoi(val);
 			}
 		}
 	}

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -2586,7 +2586,8 @@ SWITCH_DECLARE(switch_core_session_t *) switch_core_session_request_uuid(switch_
 		return NULL;
 	}
 
-	if (runtime.min_idle_time > 0 && runtime.profile_time < runtime.min_idle_time) {
+	if (runtime.min_idle_time > 0 && runtime.profile_time < runtime.min_idle_time && !(originate_flags & SOF_NO_CPU_IDLE_LIMITS)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Minimum CPU idle time is insufficient to process any new calls.  Session cannot be created.  Min set to %lf , current value %lf .\n", runtime.min_idle_time, runtime.profile_time);
 		return NULL;
 	}
 

--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -2078,7 +2078,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 	char *fail_on_single_reject_var = NULL;
 	char *loop_data = NULL;
 	uint32_t progress_timelimit_sec = 0, request_timelimit_sec = 0;
-	const char *cid_tmp, *lc;
+	const char *cid_tmp, *lc, *min_idle_cpu_override_tmp;
 	originate_global_t oglobals = { 0 };
 	int cdr_total = 0;
 	int local_clobber = 0;
@@ -2663,7 +2663,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 	} else {
 		cid_num_override = switch_event_get_header(var_event, "origination_caller_id_number");
 	}
-
+	
+	// To override any min_idle_cpu limits set on a per-call/per-caller basis
+	if ((min_idle_cpu_override_tmp = switch_event_get_header(var_event, "min_idle_cpu_override")) && switch_true(min_idle_cpu_override_tmp)) {
+		dftflags |= SOF_NO_CPU_IDLE_LIMITS;
+	}
+	
 	if (flags & SOF_NO_LIMITS) {
 		dftflags |= SOF_NO_LIMITS;
 	}


### PR DESCRIPTION
Added in some configuration to allow changing the SIP response upon such a failure for an inbound SIP initial invite.  Also allowed for overriding this limit for outbound SIP call creation.  I did have to add 1 item to an enum in switch_types.h , but I don't foresee any long term issue with that.