### PR TITLE
TEL-5708: Fix SegFault crash in mod_unimrcp

### DIFF
--- a/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
+++ b/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
@@ -1596,6 +1596,11 @@ static const char *speech_channel_state_to_string(speech_channel_state_t state)
 static switch_status_t speech_channel_set_state(speech_channel_t *schannel, speech_channel_state_t state)
 {
 	switch_status_t status;
+
+	if (!schannel || !schannel->mutex) {
+		return SWITCH_STATUS_FALSE;
+	}
+	
 	switch_mutex_lock(schannel->mutex);
 	status = speech_channel_set_state_unlocked(schannel, state);
 	switch_mutex_unlock(schannel->mutex);

--- a/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
+++ b/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
@@ -358,7 +358,7 @@ struct speech_channel {
 	/** True, if channel was opened successfully */
 	int channel_opened;
 	/** channel destroy flag*/
-	apt_bool_t channel_destroyed;
+	int channel_destroyed;
 	/** rate */
 	uint16_t rate;
 	/** silence sample */
@@ -899,7 +899,7 @@ static switch_status_t speech_channel_create(speech_channel_t ** schannel, const
 	schan->rate = rate;
 	schan->silence = 0;			/* L16 silence sample */
 	schan->channel_opened = 0;
-	schan->channel_destroyed = FALSE;
+	schan->channel_destroyed = 0;
 
 	if (switch_mutex_init(&schan->mutex, SWITCH_MUTEX_UNNESTED, pool) != SWITCH_STATUS_SUCCESS ||
 		switch_thread_cond_create(&schan->cond, pool) != SWITCH_STATUS_SUCCESS ||
@@ -943,7 +943,7 @@ static switch_status_t speech_channel_destroy(speech_channel_t *schannel)
 					}
 				}
 			}
-			schannel->channel_destroyed = TRUE;
+			schannel->channel_destroyed = 1;
 			switch_mutex_unlock(schannel->mutex);
 		}
 
@@ -1601,7 +1601,7 @@ static switch_status_t speech_channel_set_state(speech_channel_t *schannel, spee
 {
 	switch_status_t status;
 
-	if (!schannel || schannel->channel_destroyed) {
+	if (!schannel || !schannel->mutex || schannel->channel_destroyed) {
 		return SWITCH_STATUS_FALSE;
 	}
 

--- a/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
+++ b/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
@@ -357,6 +357,8 @@ struct speech_channel {
 	audio_queue_t *audio_queue;
 	/** True, if channel was opened successfully */
 	int channel_opened;
+	/** channel destroy flag*/
+	apt_bool_t channel_destroyed;
 	/** rate */
 	uint16_t rate;
 	/** silence sample */
@@ -897,6 +899,7 @@ static switch_status_t speech_channel_create(speech_channel_t ** schannel, const
 	schan->rate = rate;
 	schan->silence = 0;			/* L16 silence sample */
 	schan->channel_opened = 0;
+	schan->channel_destroyed = FALSE;
 
 	if (switch_mutex_init(&schan->mutex, SWITCH_MUTEX_UNNESTED, pool) != SWITCH_STATUS_SUCCESS ||
 		switch_thread_cond_create(&schan->cond, pool) != SWITCH_STATUS_SUCCESS ||
@@ -940,6 +943,7 @@ static switch_status_t speech_channel_destroy(speech_channel_t *schannel)
 					}
 				}
 			}
+			schannel->channel_destroyed = TRUE;
 			switch_mutex_unlock(schannel->mutex);
 		}
 
@@ -1513,7 +1517,7 @@ static switch_status_t speech_channel_set_param(speech_channel_t *schannel, cons
  */
 static switch_status_t speech_channel_write(speech_channel_t *schannel, void *data, switch_size_t *len)
 {
-	if (!schannel || !schannel->mutex || !schannel->audio_queue) {
+	if (!schannel || !schannel->mutex || !schannel->audio_queue || schannel->channel_destroyed) {
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -1537,7 +1541,7 @@ static switch_status_t speech_channel_read(speech_channel_t *schannel, void *dat
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-	if (!schannel || !schannel->mutex || !schannel->audio_queue) {
+	if (!schannel || !schannel->mutex || !schannel->audio_queue || schannel->channel_destroyed) {
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -1597,10 +1601,10 @@ static switch_status_t speech_channel_set_state(speech_channel_t *schannel, spee
 {
 	switch_status_t status;
 
-	if (!schannel || !schannel->mutex) {
+	if (!schannel || schannel->channel_destroyed) {
 		return SWITCH_STATUS_FALSE;
 	}
-	
+
 	switch_mutex_lock(schannel->mutex);
 	status = speech_channel_set_state_unlocked(schannel, state);
 	switch_mutex_unlock(schannel->mutex);
@@ -1912,7 +1916,7 @@ static apt_bool_t speech_on_channel_add(mrcp_application_t *application, mrcp_se
 	const mpf_codec_descriptor_t *descriptor;
 
 	/* check status */
-	if (!session || !schannel || status != MRCP_SIG_STATUS_CODE_SUCCESS) {
+	if (!session || !schannel || status != MRCP_SIG_STATUS_CODE_SUCCESS || schannel->channel_destroyed) {
 		goto error;
 	}
 


### PR DESCRIPTION
Crash occurred as a result of a null pointer `schannel->mutex` passed to the `switch_mutex_lock` method

```
Segmentation fault (thread 140528481740544, pid 2883416)
Stack trace:
0 [__GI___pthread_mutex_lock()] nptl/pthread_mutex_lock.c:67
1 [apr_thread_mutex_lock()] /usr/local/freeswitch/lib/libfreeswitch.so.1:0x541fe9
2 [switch_mutex_lock()] /SRC/freeswitch/src/switch_apr.c:302
3 [speech_channel_set_state()] /SRC/freeswitch/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c:1600
4 [speech_on_channel_add()] /SRC/freeswitch/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c:1958
5 [mrcp_application_message_dispatch()] /usr/local/freeswitch/lib/freeswitch/mod/mod_unimrcp.so:0x2f1d3
6 [recog_message_handler()] /SRC/freeswitch/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c:3650
7 [mrcp_app_sig_response_raise()] mrcp_client_session.c:?
8 [mrcp_client_on_channel_modify()] /usr/local/freeswitch/lib/freeswitch/mod/mod_unimrcp.so:0x32184
9 [mrcp_client_msg_process()] mrcp_client.c:?
10 [apt_task_msg_process()] /usr/local/freeswitch/lib/freeswitch/mod/mod_unimrcp.so:0x40ee7
11 [apt_consumer_task_run()] apt_consumer_task.c:?
12 [apt_task_run()] apt_task.c:?
13 [dummy_worker()] thread.c:?
14 [start_thread()] ./nptl/pthread_create.c:478 (discriminator 6)
15 [__GI___clone()] sysdeps/unix/sysv/linux/x86_64/clone.S:97
```