### PR TITLE
ENGDESK-14612: Added the setting of the channel variable p_aid_full

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -11310,6 +11310,9 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 				} else if (profile->paid_type == PAID_VERBATIM) {
 					switch_channel_set_variable(channel, "sip_P-Asserted-Identity",  full_paid_header);
 				}
+				
+				// We want the full PAID to be recorded without risk of transfering the data to other call legs
+				switch_channel_set_variable(channel, "full_paid_header",  full_paid_header);
 			}
 		}
 		if (!zstr(passerted->paid_display)) {


### PR DESCRIPTION
It is to capture the whole P-AID header value, which in the case of some clients will include the jurisdictional information (JIP), which is being appended in the params to the PAID.