### PR TITLE
TEL-5763: Fix crashes on mod_unimrcp

### DIFF
--- a/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
+++ b/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
@@ -2534,7 +2534,9 @@ static switch_status_t recog_channel_load_grammar(speech_channel_t *schannel, co
 	/* Create the grammar and save it */
 	if ((status = grammar_create(&g, name, type, data, schannel->memory_pool)) == SWITCH_STATUS_SUCCESS) {
 		recognizer_data_t *r = (recognizer_data_t *) schannel->data;
-		switch_core_hash_insert(r->grammars, g->name, g);
+		if (r) {
+			switch_core_hash_insert(r->grammars, g->name, g);
+		}
 	}
 
   done:
@@ -3879,6 +3881,7 @@ static apt_bool_t recog_stream_read(mpf_audio_stream_t *stream, mpf_frame_t *fra
 	speech_channel_t *schannel = (speech_channel_t *) stream->obj;
 	switch_size_t to_read = frame->codec_frame.size;
 	recognizer_data_t *r = NULL;
+	switch_status_t status;
 	
 	// Check schannel data is not NULL or destroyed
 	if (schannel) {
@@ -3890,11 +3893,13 @@ static apt_bool_t recog_stream_read(mpf_audio_stream_t *stream, mpf_frame_t *fra
 	}
 
 	/* grab the data.  pad it if there isn't enough */
-	if (speech_channel_read(schannel, frame->codec_frame.buffer, &to_read, 0) == SWITCH_STATUS_SUCCESS) {
+	if ((status = speech_channel_read(schannel, frame->codec_frame.buffer, &to_read, 0)) == SWITCH_STATUS_SUCCESS) {
 		if (to_read < frame->codec_frame.size) {
 			memset((uint8_t *) frame->codec_frame.buffer + to_read, schannel->silence, frame->codec_frame.size - to_read);
 		}
 		frame->type |= MEDIA_FRAME_TYPE_AUDIO;
+	} else if (status == SWITCH_STATUS_FALSE) {
+		return FALSE;
 	}
 
 	switch_mutex_lock(schannel->mutex);

--- a/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
+++ b/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c
@@ -3893,7 +3893,8 @@ static apt_bool_t recog_stream_read(mpf_audio_stream_t *stream, mpf_frame_t *fra
 	}
 
 	/* grab the data.  pad it if there isn't enough */
-	if ((status = speech_channel_read(schannel, frame->codec_frame.buffer, &to_read, 0)) == SWITCH_STATUS_SUCCESS) {
+	status = speech_channel_read(schannel, frame->codec_frame.buffer, &to_read, 0);
+	if (status == SWITCH_STATUS_SUCCESS) {
 		if (to_read < frame->codec_frame.size) {
 			memset((uint8_t *) frame->codec_frame.buffer + to_read, schannel->silence, frame->codec_frame.size - to_read);
 		}


### PR DESCRIPTION
There's a chance this [PR](https://github.com/team-telnyx/freeswitch/pull/216) fixes the issue. However, I've added additional checks in case it doesn't.

```
Stack trace:
0 [recog_channel_load_grammar()] /SRC/freeswitch/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c:2537
1 [recog_asr_load_grammar()] /SRC/freeswitch/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c:3407
2 [switch_core_asr_load_grammar()] /SRC/freeswitch/src/switch_core_asr.c:156
3 [switch_ivr_detect_speech()] /SRC/freeswitch/src/switch_ivr_async.c:5589
...
```
```
Stack trace:
0 [__GI___pthread_mutex_lock()] nptl/pthread_mutex_lock.c:67
1 [apr_thread_mutex_lock()] /usr/local/freeswitch/lib/libfreeswitch.so.1:0x542869
2 [switch_mutex_lock()] /SRC/freeswitch/src/switch_apr.c:302
3 [recog_stream_read()] /SRC/freeswitch/src/mod/asr_tts/mod_unimrcp/mod_unimrcp.c:3901
4 [mpf_bridge_process()] mpf_bridge.c:?
5 [mpf_context_process()] /usr/local/freeswitch/lib/freeswitch/mod/mod_unimrcp.so:0x4a872
6 [mpf_context_factory_process()] /usr/local/freeswitch/lib/freeswitch/mod/mod_unimrcp.so:0x49bd6
```