### PR TITLE
TEL-5477:  Unblocking the rtmp connections upon failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent { label 'kubernetes-default' }
+    stages {
+        stage('Build') {
+            steps {
+                sh 'echo "Empty build to trigger telnyx_b2bua_builder"'
+            }
+        }
+    }
+}

--- a/meta-dev.yml
+++ b/meta-dev.yml
@@ -1,0 +1,11 @@
+names:
+    service: core-tel-freeswitch
+project:
+    squad: core.telephony.squad
+    primary_maintainer: ryanc
+    secondary_maintainer: null
+    public_api: false
+    private_api: false
+build:
+    promote_to_dev:
+        branch_pattern: "telnyx/telephony/master|telnyx/telephony/development"

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -3691,7 +3691,7 @@ static switch_status_t cmd_count(char **argv, int argc, switch_stream_handle_t *
 		for (hi = switch_core_hash_first(mod_sofia_globals.profile_hash); hi; hi = switch_core_hash_next(&hi)) {
 			switch_core_hash_this(hi, NULL, NULL, &val);
 			profile = (sofia_profile_t *) val;
-			if (sofia_test_pflag(profile, PFLAG_RUNNING)) {
+			if ((argc == 1 || !strcasecmp(argv[1], profile->name)) && sofia_test_pflag(profile, PFLAG_RUNNING)) {
 				sofia_gateway_t *gp;
 				switch_mutex_lock(profile->gw_mutex);
 				for (gp = profile->gateways; gp; gp = gp->next) {
@@ -7061,7 +7061,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	switch_console_set_complete("add sofia status gateway ::sofia::list_gateways");
 
 	switch_console_set_complete("add sofia count profiles");
-	switch_console_set_complete("add sofia count gateways");
+	switch_console_set_complete("add sofia count gateways ::sofia::list_profiles");
 
 	switch_console_set_complete("add sofia loglevel ::[all:default:tport:iptsec:nea:nta:nth_client:nth_server:nua:soa:sresolv:stun ::[0:1:2:3:4:5:6:7:8:9");
 	switch_console_set_complete("add sofia tracelevel ::[console:alert:crit:err:warning:notice:info:debug");

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -575,6 +575,9 @@ struct sofia_gateway {
 	switch_memory_pool_t *pool;
 	int deleted;
 	int destroy;
+	time_t last_inactive;
+	int32_t max_inactive_seconds;
+	int auto_delete_inactive;
 	switch_event_t *ib_vars;
 	switch_event_t *ob_vars;
 	uint32_t ib_calls;

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -728,6 +728,7 @@ struct sofia_profile {
 	switch_mutex_t *dbh_mutex;
 	switch_mutex_t *gateway_mutex;
 	sofia_gateway_t *gateways;
+	unsigned int gateway_unreg_max_yield_ms;
 	//su_home_t *home;
 	switch_hash_t *chat_hash;
 	switch_hash_t *reg_nh_hash;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -3741,6 +3741,7 @@ void *SWITCH_THREAD_FUNC sofia_profile_thread_run(switch_thread_t *thread, void 
 		config_sofia(SOFIA_CONFIG_RESPAWN, profile->name);
 	}
 
+	sofia_glue_del_every_gateway(profile);
 	sofia_profile_destroy(profile);
 
 	switch_mutex_lock(mod_sofia_globals.mutex);

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -6277,6 +6277,13 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 						profile->acl_proxy_x_token_header = switch_core_strdup(profile->pool, val);
 					} else if (!strcasecmp(var, "ignore-reason-header-by-sip-code")) {
 						profile->ignore_reason_header_by_sip_code = switch_core_strdup(profile->pool, val);
+					} else if (!strcasecmp(var, "gateway-unreg-max-yield-ms") && !zstr(val)) {
+						int32_t gateway_unreg_max_yield_ms = atoi(val);
+						if (gateway_unreg_max_yield_ms >= 0) {
+							profile->gateway_unreg_max_yield_ms = gateway_unreg_max_yield_ms;
+						} else {
+							profile->gateway_unreg_max_yield_ms = 0;
+						}
 					} else if (!strcasecmp(var, "proxy-hold")) {
 						if(switch_true(val)) {
 							sofia_set_pflag(profile, PFLAG_PROXY_HOLD);

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -2344,8 +2344,19 @@ void sofia_glue_del_profile(sofia_profile_t *profile)
 			switch_core_hash_delete(mod_sofia_globals.gateway_hash, gp->name);
 			switch_core_hash_delete(mod_sofia_globals.gateway_hash, pkey);
 			switch_safe_free(pkey);
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "deleted gateway %s from profile %s\n", gp->name, profile->name);
+			if (gp->ob_vars) {
+				switch_event_destroy(&gp->ob_vars);
+			}
+			if (gp->ib_vars) {
+				switch_event_destroy(&gp->ib_vars);
+			}
+			if (gp->nh) {
+				sofia_private_free(gp->sofia_private);
+				nua_handle_bind(gp->nh, NULL);
+				nua_handle_destroy(gp->nh);
+			}
 			switch_core_destroy_memory_pool(&(gp->pool));
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "deleted gateway %s from profile %s\n", gp->name, profile->name);
 		}
 		profile->gateways = NULL;
 	}


### PR DESCRIPTION
The only way for this to work properly without flooding the logs until the b2bua keels over was to make a couple very small changes to the core.  The problem is that by the time we receive the file name in mod_av, it's already been stripped such that any calls to switch_ivr_stop_record_session() will fail to find the media bug in the channel's private_hash .