### PR TITLE
TEL-5828: Properly log SRTP decryption errors

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -82,6 +82,7 @@ typedef enum {
 	SCMF_MULTI_ANSWER_VIDEO,
 	SCMF_RECV_SDP,
 	SCMF_REJECT_IPV6,
+	SCMF_SRTP_HANGUP_ON_ERROR,
 	SCMF_MAX
 } switch_core_media_flag_t;
 

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -5315,6 +5315,12 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 						} else {
 							sofia_clear_media_flag(profile, SCMF_DISABLE_RTP_AUTOADJ);
 						}
+					} else if (!strcasecmp(var, "srtp-hangup-on-error")) {
+						if (switch_true(val)) {
+							sofia_set_media_flag(profile, SCMF_SRTP_HANGUP_ON_ERROR);
+						} else {
+							sofia_clear_media_flag(profile, SCMF_SRTP_HANGUP_ON_ERROR);
+						}
 					} else if (!strcasecmp(var, "NDLB-support-asterisk-missing-srtp-auth")) {
 						if (switch_true(val)) {
 							profile->mndlb |= SM_NDLB_DISABLE_SRTP_AUTH;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -10012,6 +10012,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 		flags[SWITCH_RTP_FLAG_USE_MILLISECONDS_PER_PACKET]++;
 	}
 
+	if (((val = switch_channel_get_variable(session->channel, "srtp_hangup_on_error")))) {
+		flags[SWITCH_RTP_FLAG_SRTP_HANGUP_ON_ERROR] = switch_true(val);
+	} else if (switch_media_handle_test_media_flag(smh, SCMF_SRTP_HANGUP_ON_ERROR)) {
+		flags[SWITCH_RTP_FLAG_SRTP_HANGUP_ON_ERROR]++;
+	}
+
 	if (switch_media_handle_test_media_flag(smh, SCMF_SUPPRESS_CNG)) {
 		smh->mparams->cng_pt = 0;
 	} else if (smh->mparams->cng_pt) {


### PR DESCRIPTION
 - Expose ability to terminate call with SRTP issue