### PR TITLE
ENGDESK-27769: don't use remote rtcp-mux if channel variable rtcp_mux is false

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4733,17 +4733,17 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 
 #ifdef RTCP_MUX
 			} else if (!strcasecmp(attr->a_name, "rtcp-mux")) {
-				const char *use_rtcp_mux = NULL;
-				use_rtcp_mux = switch_channel_get_variable(smh->session->channel, "rtcp_mux");
+				const char *use_rtcp_mux = switch_channel_get_variable(smh->session->channel, "rtcp_mux");
 
 				if (!use_rtcp_mux || switch_true(use_rtcp_mux)) {
 					engine->rtcp_mux = SWITCH_TRUE;
 					engine->remote_rtcp_port = engine->cur_payload_map->remote_sdp_port;
 					got_rtcp_mux++;
 
-					if (!smh->mparams->rtcp_audio_interval_msec) {
-						smh->mparams->rtcp_audio_interval_msec = SWITCH_RTCP_AUDIO_INTERVAL_MSEC;
-					}
+				}
+
+				if (!smh->mparams->rtcp_audio_interval_msec) {
+					smh->mparams->rtcp_audio_interval_msec = SWITCH_RTCP_AUDIO_INTERVAL_MSEC;
 				}
 #endif
 			} else if (!strcasecmp(attr->a_name, "candidate")) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4733,12 +4733,17 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 
 #ifdef RTCP_MUX
 			} else if (!strcasecmp(attr->a_name, "rtcp-mux")) {
-				engine->rtcp_mux = SWITCH_TRUE;
-				engine->remote_rtcp_port = engine->cur_payload_map->remote_sdp_port;
-				got_rtcp_mux++;
+				const char *use_rtcp_mux = NULL;
+				use_rtcp_mux = switch_channel_get_variable(smh->session->channel, "rtcp_mux");
 
-				if (!smh->mparams->rtcp_audio_interval_msec) {
-					smh->mparams->rtcp_audio_interval_msec = SWITCH_RTCP_AUDIO_INTERVAL_MSEC;
+				if (!use_rtcp_mux || switch_true(use_rtcp_mux)) {
+					engine->rtcp_mux = SWITCH_TRUE;
+					engine->remote_rtcp_port = engine->cur_payload_map->remote_sdp_port;
+					got_rtcp_mux++;
+
+					if (!smh->mparams->rtcp_audio_interval_msec) {
+						smh->mparams->rtcp_audio_interval_msec = SWITCH_RTCP_AUDIO_INTERVAL_MSEC;
+					}
 				}
 #endif
 			} else if (!strcasecmp(attr->a_name, "candidate")) {


### PR DESCRIPTION
Channel variable `rtcp_mux` is controlling whether FS will send in the answer `a=rtcp_mux` or not.
However it is not taken into account when activating the remote RTCP port. If `rtcp-mux` was offered by the remote side, FS will honor it despite not sending `a=rtcp-mux` in the response.
This breaks [RFC 5761 section 5.1.3 ](https://datatracker.ietf.org/doc/html/rfc5761#section-5.1.3).
If FS doesn't send `a=rtcp_mux` in the answer, it has to use the port defined in the offer in `a=rtcp:` as indicated in the RFC.