### PR TITLE
ENGDESK-28183: Process crypto key with no MKI index

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -2100,6 +2100,8 @@ SWITCH_DECLARE(int) switch_core_session_check_incoming_crypto(switch_core_sessio
 
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "CRYPTO: build crypto for tag %d\n", crypto_tag);
 					switch_core_media_build_crypto(session->media_handle, type, crypto_tag, ctype, SWITCH_RTP_CRYPTO_SEND, 1, use_alias);
+					if (switch_channel_var_true(session->channel, "rtp_secure_media_mki"))
+						switch_core_media_add_crypto(session, &engine->ssec[engine->crypto_type], SWITCH_RTP_CRYPTO_SEND);
 					switch_rtp_add_crypto_key(engine->rtp_session, SWITCH_RTP_CRYPTO_SEND, atoi(crypto), &engine->ssec[engine->crypto_type]);
 			}
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4745,9 +4745,9 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 				const char *use_rtcp_mux = switch_channel_get_variable(smh->session->channel, "rtcp_mux");
 
 				if (!use_rtcp_mux || switch_true(use_rtcp_mux)) {
-				engine->rtcp_mux = SWITCH_TRUE;
-				engine->remote_rtcp_port = engine->cur_payload_map->remote_sdp_port;
-				got_rtcp_mux++;
+					engine->rtcp_mux = SWITCH_TRUE;
+					engine->remote_rtcp_port = engine->cur_payload_map->remote_sdp_port;
+					got_rtcp_mux++;
 
 				}
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -4890,6 +4890,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 
 	} else {
 		policy->key = (uint8_t *) crypto_key->keysalt;
+		rtp_session->flags[SWITCH_RTP_FLAG_SECURE_RECV_MKI] = 0;
 	}
 
 	policy->next = NULL;


### PR DESCRIPTION
Patch fixes
- Crypto key received with no MKI index but LIFETIME value
- FS encryption for newly generated crypto key with MKI due to reINVITE