### PR TITLE
ENGDESK-29582: Add PRACK_WAIT flag for multiple switch_channel_answer…

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -375,6 +375,7 @@ typedef enum {
 	TFLAG_SKIP_EARLY,
 	TFLAG_100_UEPOCH_SET,
 	TFLAG_PRACK_LOCK,
+	TFLAG_PRACK_WAIT,
 	/* No new flags below this line */
 	TFLAG_MAX
 } TFLAGS;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2641,6 +2641,9 @@ void sofia_event_callback(nua_event_t event,
 					switch_mutex_lock(tech_pvt->prack_mutex);
 					if (sofia_test_flag(tech_pvt, TFLAG_PRACK_LOCK)) {
 						sofia_clear_flag(tech_pvt, TFLAG_PRACK_LOCK);
+						if (sofia_test_flag(tech_pvt, TFLAG_PRACK_WAIT)) {
+							sofia_clear_flag(tech_pvt, TFLAG_PRACK_WAIT);
+						}
 						switch_thread_cond_signal(tech_pvt->prack_cond);
 					}
 					switch_mutex_unlock(tech_pvt->prack_mutex);


### PR DESCRIPTION
There are few times when the `switch_channel_state` is called twice at the same time in`switch_ivr_bridge` when channel state change to `EXCHANGE_MEDIA`.

Sample
```
2024-03-28 00:22:52.263398 94.73% [NOTICE] sofia.c:9151 Channel [sofia/outbound/5wW3AfbYpXP5oyVNoz6n9MDfr@192.168.100.154:5090] has been answered
2024-03-28 00:22:52.263398 94.73% [INFO] call_tracker.cpp:87 Telnyx recovery tracking (local) session: 192.168.100.154@192.168.100.154@709edc29-5d67-4dd0-ae93-95004416a60f
2024-03-28 00:22:52.263398 94.73% [DEBUG] switch_channel.c:4091 (sofia/outbound/5wW3AfbYpXP5oyVNoz6n9MDfr@192.168.100.154:5090) Callstate Change EARLY -> ACTIVE
2024-03-28 00:22:52.263398 94.73% [DEBUG] switch_core_state_machine.c:612 (sofia/outbound/5wW3AfbYpXP5oyVNoz6n9MDfr@192.168.100.154:5090) Running State Change CS_EXCHANGE_MEDIA (Cur 6 Tot 8)
2024-03-28 00:22:52.263398 94.73% [DEBUG] switch_core_state_machine.c:681 (sofia/outbound/5wW3AfbYpXP5oyVNoz6n9MDfr@192.168.100.154:5090) State EXCHANGE_MEDIA
2024-03-28 00:22:52.263398 94.73% [DEBUG] mod_sofia.c:744 SOFIA EXCHANGE_MEDIA
2024-03-28 00:22:52.263398 94.73% [ERR] switch_ivr_bridge.c:927 switch_channel_answer called.
2024-03-28 00:22:52.263398 94.73% [INFO] mod_sofia.c:1562 sofia/inbound-prack/sipp@192.168.100.154:5040 Waiting for incoming PRACK! (Blocking ANSWER message)
2024-03-28 00:22:52.263398 94.73% [ERR] switch_ivr_bridge.c:896 switch_channel_answer called.
2024-03-28 00:22:52.263398 94.73% [INFO] mod_sofia.c:1562 sofia/inbound-prack/sipp@192.168.100.154:5040 Waiting for incoming PRACK! (Blocking ANSWER message)
```

In this case, the PRACK `switch_thread_cond_timedwait` function is called twice, which causes an issue. I added a flag to ensure this is called once