### PR TITLE
TEL-6150 Fix opus offering stereo sound when mono is configured.

### DIFF
--- a/src/mod/codecs/mod_opus/mod_opus.c
+++ b/src/mod/codecs/mod_opus/mod_opus.c
@@ -359,7 +359,7 @@ static char *gen_fmtp(opus_codec_settings_t *settings, switch_memory_pool_t *poo
 	}
 
 	if (settings->stereo) {
-		snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "stereo=%d; ", settings->stereo);
+		snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "stereo=%d; ", opus_prefs.mono ? 0 : settings->stereo);
 	}
 
 	if (settings->sprop_stereo) {


### PR DESCRIPTION
this will also fix the upstream [bug](https://github.com/signalwire/freeswitch/issues/2503) 