### PR TITLE
TEL-6190: Sync sample rate mismatch for bridge_early_media

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -1943,7 +1943,7 @@ static void *SWITCH_THREAD_FUNC early_thread_run(switch_thread_t *thread, void *
 								|| (state->write_frame->codec->implementation->actual_samples_per_second > write_impl.actual_samples_per_second)) {
 							
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(state->oglobals->session), SWITCH_LOG_DEBUG,
-												"Changing sampling rate from %uhz to %uhz\n", write_impl.actual_samples_per_second, peer_read_impl.actual_samples_per_second);
+												"Changing sampling rate from %uHz to %uHz\n", write_impl.actual_samples_per_second, peer_read_impl.actual_samples_per_second);
 							
 							if (switch_core_codec_ready(state->write_codec)) {
 								switch_core_codec_destroy(state->write_codec);
@@ -1959,7 +1959,7 @@ static void *SWITCH_THREAD_FUNC early_thread_run(switch_thread_t *thread, void *
 													switch_core_session_get_pool(state->oglobals->session)) == SWITCH_STATUS_SUCCESS) {
 
 								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(state->oglobals->session), SWITCH_LOG_DEBUG,
-												"Raw Codec Activation Success L16@%uhz %d channel %dms\n",
+												"Raw Codec Activation Success L16@%uHz %d channel %dms\n",
 												peer_read_impl.actual_samples_per_second, peer_read_impl.number_of_channels, peer_read_impl.microseconds_per_packet / 1000);
 								state->write_frame->codec = state->write_codec;
 								state->write_frame->datalen = peer_read_impl.decoded_bytes_per_packet;

--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -1861,6 +1861,8 @@ struct early_state {
 	int ready;
 	ringback_t *ringback;
 	int ttl;
+	switch_frame_t *write_frame;
+	switch_codec_t *write_codec;
 };
 typedef struct early_state early_state_t;
 
@@ -3591,6 +3593,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 								early_state.ready = 1;
 								early_state.ringback = &ringback;
 								early_state.ttl = and_argc;
+								early_state.write_frame = &write_frame;
+								early_state.write_codec = &write_codec;
 								switch_mutex_init(&early_state.mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 								switch_buffer_create_dynamic(&early_state.buffer, 1024, 1024, 0);
 								switch_thread_create(&oglobals.ethread, thd_attr, early_thread_run, &early_state, switch_core_session_get_pool(session));


### PR DESCRIPTION
This resolves the bad audio experienced (esp. for G722 codec) when `bridge_early_media` is set and the codec is updated during early media.

Tested this when `inherit_codec` is set and unset. Works fine for both cases.