### PR TITLE
ENGDESK-30126 Fix issue where a potential stereo L16 codec was used in ASR

### DIFF
--- a/src/switch_ivr_play_say.c
+++ b/src/switch_ivr_play_say.c
@@ -3085,7 +3085,6 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_speak_text(switch_core_session_t *ses
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	uint32_t rate = 0;
 	int interval = 0;
-	uint32_t channels;
 	switch_frame_t write_frame = { 0 };
 	switch_timer_t ltimer, *timer;
 	switch_codec_t lcodec, *codec;
@@ -3140,7 +3139,6 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_speak_text(switch_core_session_t *ses
 
 	rate = read_impl.actual_samples_per_second;
 	interval = read_impl.microseconds_per_packet / 1000;
-	channels = read_impl.number_of_channels;
 
 	if (need_create) {
 		memset(sh, 0, sizeof(*sh));
@@ -3170,7 +3168,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_speak_text(switch_core_session_t *ses
 		if (switch_core_codec_init(codec,
 								   codec_name,
 								   NULL,
-								   NULL, (int) rate, interval, channels, SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE, NULL,
+								   NULL, (int) rate, interval, 1, SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE, NULL,
 								   pool) == SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Raw Codec Activated\n");
 		} else {


### PR DESCRIPTION
I think the issue here was an attempt at creating a stereo L16 codec used for ASR which (IMO) doesn't make sense