### PR TITLE
TEL-6404: Fix potential deadlock in mod_sofia

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1749,6 +1749,9 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 			}
 		}
 		break;
+	case SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY:
+		// Do nothing and exit to prevent unnecessary locking of sofia_mutex
+		goto end;
 	default:
 		break;
 	}


### PR DESCRIPTION
 - Fix deadlock when sofia receive SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY