### PR TITLE
ENGDESK-42254: Allow graceful codec transitions during OPUS decode failures

### DIFF
--- a/src/mod/codecs/mod_opus/mod_opus.c
+++ b/src/mod/codecs/mod_opus/mod_opus.c
@@ -930,7 +930,8 @@ static switch_status_t switch_opus_decode(switch_codec_t *codec,
 	if (samples < 0) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Decoder Error: %s fs:%u plc:%s!\n",
 							  opus_strerror(samples), frame_size, plc ? "true" : "false");
-		return SWITCH_STATUS_FALSE;
+		// Return SWITCH_STATUS_NOOP (pre-v1.10.12 behavior) to allow graceful codec transitions
+		return SWITCH_STATUS_NOOP;
 	}
 
 	*decoded_data_len = samples * 2 * (!context->codec_settings.sprop_stereo ? codec->implementation->number_of_channels : 2);


### PR DESCRIPTION
This fix restores pre-v1.10.12 behavior for OPUS decoder error handling which prevent call failures during codec transitions in OPUS decoder