### PR TITLE
TEL-6554: Add unit test which triggers a crash in switch_event_destroy.

### DIFF
--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -3,6 +3,119 @@
 
 // #define BENCHMARK 1
 
+typedef struct {
+    switch_event_t *event;
+    switch_mutex_t *mutex;
+    int fire_count;
+    int destroy_count;
+    volatile int should_stop;
+    volatile int race_detected;
+} race_test_data_t;
+
+static void *SWITCH_THREAD_FUNC fire_thread_func(switch_thread_t *thread, void *obj)
+{
+    race_test_data_t *data = (race_test_data_t *)obj;
+    int iterations = 0;
+
+    while (!data->should_stop && iterations < 1000) {
+        switch_mutex_lock(data->mutex);
+
+        if (data->event) {
+            switch_event_t *event_copy = NULL;
+
+            // Try to duplicate the event before firing
+            if (switch_event_dup(&event_copy, data->event) == SWITCH_STATUS_SUCCESS) {
+                data->fire_count++;
+                switch_mutex_unlock(data->mutex);
+
+                // Fire the event copy - this should be safe
+                switch_event_fire(&event_copy);
+            } else {
+                switch_mutex_unlock(data->mutex);
+            }
+        } else {
+            switch_mutex_unlock(data->mutex);
+        }
+
+        iterations++;
+        switch_yield(1000); // 1ms
+    }
+
+    return NULL;
+}
+
+static void *SWITCH_THREAD_FUNC destroy_thread_func(switch_thread_t *thread, void *obj)
+{
+    race_test_data_t *data = (race_test_data_t *)obj;
+    int iterations = 0;
+
+    while (!data->should_stop && iterations < 500) {
+        switch_mutex_lock(data->mutex);
+
+        if (data->event) {
+            // Try to destroy and recreate event
+            switch_event_destroy(&data->event);
+            data->destroy_count++;
+
+            // Recreate event for next iteration
+            if (switch_event_create(&data->event, SWITCH_EVENT_CUSTOM) == SWITCH_STATUS_SUCCESS) {
+                switch_event_add_header_string(data->event, SWITCH_STACK_BOTTOM, "Test-Header", "race-test");
+                switch_event_add_header_string(data->event, SWITCH_STACK_BOTTOM, "Event-Subclass", "race::test");
+            }
+        }
+
+        switch_mutex_unlock(data->mutex);
+        iterations++;
+        switch_yield(2000); // 2ms
+    }
+
+    return NULL;
+}
+
+static void *SWITCH_THREAD_FUNC unsafe_fire_thread_func(switch_thread_t *thread, void *obj)
+{
+    race_test_data_t *data = (race_test_data_t *)obj;
+    int iterations = 0;
+
+    while (!data->should_stop && iterations < 100) {
+        if (data->event) {
+            switch_event_t *event_to_fire = data->event;
+            data->fire_count++;
+
+            // This is UNSAFE - we're firing an event that might be destroyed
+            // by another thread at the same time
+            switch_event_fire(&event_to_fire);
+        }
+        iterations++;
+        switch_yield(1000); // 1ms
+    }
+    return NULL;
+}
+
+static void *SWITCH_THREAD_FUNC unsafe_destroy_thread_func(switch_thread_t *thread, void *obj)
+{
+    race_test_data_t *data = (race_test_data_t *)obj;
+    int iterations = 0;
+
+    while (!data->should_stop && iterations < 50) {
+        if (data->event) {
+            // This is UNSAFE - we're destroying an event that might be
+            // in use by the fire thread
+            switch_event_destroy(&data->event);
+            data->destroy_count++;
+
+            // Recreate event
+            if (switch_event_create(&data->event, SWITCH_EVENT_CUSTOM) == SWITCH_STATUS_SUCCESS) {
+                switch_event_add_header_string(data->event, SWITCH_STACK_BOTTOM, "Test-Header", "race-test-unsafe");
+                switch_event_add_header_string(data->event, SWITCH_STACK_BOTTOM, "Event-Subclass", "race::test::unsafe");
+            }
+        }
+        iterations++;
+        switch_yield(2000); // 2ms
+    }
+    return NULL;
+}
+
 FST_MINCORE_BEGIN("./conf")
 
 FST_SUITE_BEGIN(switch_event)
@@ -101,6 +214,124 @@ FST_TEST_BEGIN(benchmark)
   printf("switch_event Total %" SWITCH_UINT64_T_FMT "us / %d loops, %.2f us per loop, %.0f loops per second\n", 
        micro_total, loops, micro_per, rate_per_sec);
 
+}
+FST_TEST_END()
+
+FST_TEST_BEGIN(race_fire_destroy)
+{
+    race_test_data_t test_data = {0};
+    switch_thread_t *fire_thread = NULL;
+    switch_thread_t *destroy_thread = NULL;
+    switch_threadattr_t *thd_attr = NULL;
+    switch_memory_pool_t *pool = NULL;
+    switch_status_t status;
+	switch_status_t fire_retval, destroy_retval;
+
+    // Create pool and mutex
+    switch_core_new_memory_pool(&pool);
+    switch_mutex_init(&test_data.mutex, SWITCH_MUTEX_NESTED, pool);
+    
+    // Create initial event
+    status = switch_event_create(&test_data.event, SWITCH_EVENT_CUSTOM);
+    fst_requires(status == SWITCH_STATUS_SUCCESS);
+    
+    switch_event_add_header_string(test_data.event, SWITCH_STACK_BOTTOM, "Test-Header", "race-test");
+    switch_event_add_header_string(test_data.event, SWITCH_STACK_BOTTOM, "Event-Subclass", "race::test");
+    
+    // Create thread attributes
+    switch_threadattr_create(&thd_attr, pool);
+    switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+    
+    // Start fire thread
+    status = switch_thread_create(&fire_thread, thd_attr, fire_thread_func, &test_data, pool);
+    fst_requires(status == SWITCH_STATUS_SUCCESS);
+    
+    // Start destroy thread  
+    status = switch_thread_create(&destroy_thread, thd_attr, destroy_thread_func, &test_data, pool);
+    fst_requires(status == SWITCH_STATUS_SUCCESS);
+    
+    // Let threads run for 2 seconds
+    switch_sleep(2000000); // 2 seconds
+    
+    // Signal threads to stop
+    test_data.should_stop = 1;
+    
+    // Wait for threads to finish
+    switch_thread_join(&fire_retval, fire_thread);
+    switch_thread_join(&destroy_retval, destroy_thread);
+    
+    // Clean up remaining event
+    switch_mutex_lock(test_data.mutex);
+    if (test_data.event) {
+        switch_event_destroy(&test_data.event);
+    }
+    switch_mutex_unlock(test_data.mutex);
+    
+    printf("Race test results: fired %d times, destroyed %d times\n", 
+           test_data.fire_count, test_data.destroy_count);
+    
+    // Test should complete without crashing
+    fst_check(test_data.fire_count > 0);
+    fst_check(test_data.destroy_count > 0);
+    
+    switch_core_destroy_memory_pool(&pool);
+}
+FST_TEST_END()
+
+FST_TEST_BEGIN(race_fire_destroy_unsafe)
+{
+    race_test_data_t test_data = {0};
+    switch_thread_t *fire_thread = NULL;
+    switch_thread_t *destroy_thread = NULL;
+    switch_threadattr_t *thd_attr = NULL;
+    switch_memory_pool_t *pool = NULL;
+    switch_status_t status;
+	switch_status_t fire_retval, destroy_retval;
+
+    // Create pool - NO MUTEX for this test to force race condition
+    switch_core_new_memory_pool(&pool);
+    
+    // Create initial event
+    status = switch_event_create(&test_data.event, SWITCH_EVENT_CUSTOM);
+    fst_requires(status == SWITCH_STATUS_SUCCESS);
+    
+    switch_event_add_header_string(test_data.event, SWITCH_STACK_BOTTOM, "Test-Header", "race-test-unsafe");
+    switch_event_add_header_string(test_data.event, SWITCH_STACK_BOTTOM, "Event-Subclass", "race::test::unsafe");
+    
+    // Create thread attributes
+    switch_threadattr_create(&thd_attr, pool);
+    switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+    
+    // Start unsafe threads
+    status = switch_thread_create(&fire_thread, thd_attr, unsafe_fire_thread_func, &test_data, pool);
+    fst_requires(status == SWITCH_STATUS_SUCCESS);
+    
+    status = switch_thread_create(&destroy_thread, thd_attr, unsafe_destroy_thread_func, &test_data, pool);
+    fst_requires(status == SWITCH_STATUS_SUCCESS);
+    
+    // Let threads run for 1 second (shorter due to unsafe nature)
+    switch_sleep(1000000); // 1 second
+    
+    // Signal threads to stop
+    test_data.should_stop = 1;
+    
+    // Wait for threads to finish
+    switch_thread_join(&fire_retval, fire_thread);
+    switch_thread_join(&destroy_retval, destroy_thread);
+    
+    // Clean up remaining event if it exists
+    if (test_data.event) {
+        switch_event_destroy(&test_data.event);
+    }
+    
+    printf("Unsafe race test results: fired %d times, destroyed %d times\n", 
+           test_data.fire_count, test_data.destroy_count);
+    
+    // Test should complete - this might crash due to race conditions
+    fst_check(test_data.fire_count > 0);
+    fst_check(test_data.destroy_count > 0);
+    
+    switch_core_destroy_memory_pool(&pool);
 }
 FST_TEST_END()
 


### PR DESCRIPTION
WIP - this contains just a unit test; please take a look at `race_fire_destroy_unsafe`. This will immediately trigger a crash with the following stack trace:

#0  0x00007f72b5ab7efa in __GI___libc_free (mem=0x55de359ba) at ./malloc/malloc.c:3362
#1  0x00007f72b5deaf98 in free_header (header=0x7f72b34878f8) at src/switch_event.c:952
#2  0x00007f72b5debfca in switch_event_destroy (event=0x7f72b3487978) at src/switch_event.c:1301
#3  0x00007f72b5dedf1d in switch_event_fire_detailed (file=0x55de34b57a5f "switch_event.c", func=0x55de34b584b0 <__func__.3> "unsafe_fire_thread_func", line=87,
    event=0x7f72b3487978, user_data=0x0) at src/switch_event.c:2019
#4  0x000055de34b53999 in unsafe_fire_thread_func (thread=0x55de359fc620, obj=0x7ffd9b3e78d0) at switch_event.c:87
#5  0x00007f72b614a48d in dummy_worker () from /usr/local/freeswitch/lib/libfreeswitch.so.1
#6  0x00007f72b5aa81f5 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#7  0x00007f72b5b27b00 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:100
