### PR TITLE
TEL-6574: Fix deadlock in sofia_receive_message during RESAMPLE_EVENT

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1750,6 +1750,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 		}
 		break;
 	case SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY:
+	case SWITCH_MESSAGE_RESAMPLE_EVENT:
 		// Do nothing and exit to prevent unnecessary locking of sofia_mutex
 		goto end;
 	default:


### PR DESCRIPTION
Here is the breakdown of the Deadlock

Thread 1760 (SIP state processing):
sofia_media_activate_rtp()
├─ Line 59: switch_mutex_lock(tech_pvt->sofia_mutex)    ✓ ACQUIRED
├─ Line 60: switch_core_media_activate_rtp()
│  └─ switch_core_media_set_codec()
│     ├─ Line 4282: switch_core_session_lock_codec_write()
│     │  └─ Line 65: switch_mutex_lock(session->codec_write_mutex) <-- **BLOCKS HERE**

Thread 1759 (Audio bridging):
switch_core_session_write_frame()
├─ Line 17769: sofia_receive_message()
├─ Line 1760: switch_mutex_lock(tech_pvt->sofia_mutex) <-- **BLOCKS HERE**

In `switch_core_session_write_frame` may fire `SWITCH_RESAMPLE_EVENT` which again locks the `sofia_mutex` causing this deadlock. I don't see `SWITCH_RESAMPLE_EVENT` being consume in mod_sofia so a easy fix here is to ignore it.