### PR TITLE
TEL-6569: Add label support to record_ms variable for distinguishing recording types

### DIFF
--- a/RECORD_LABEL_FEATURE.md
+++ b/RECORD_LABEL_FEATURE.md
@@ -1,0 +1,80 @@
+# Record Label Feature Implementation
+
+## Overview
+This feature adds support for the `record_label` parameter to the `uuid_record` command, allowing different recording types to be distinguished for billing purposes.
+
+## Problem Solved
+- Voice AI and transcription services use `uuid_record` to start RTMP streams
+- The `record_ms` variable gets populated regardless of recording purpose
+- TDA (Telemetry, Data & Analytics) uses `record_ms` for billing calculations
+- This results in incorrect billing for Voice AI and transcription usage
+
+## Implementation Details
+
+### Changes Made
+1. Modified `send_record_stop_event()` function in `src/switch_ivr_async.c`
+2. Added `record_label` variable detection using existing `get_recording_var()` function
+3. When `record_label` is present, generates labeled variables instead of standard ones
+4. Maintains backward compatibility when no label is provided
+
+### Variable Generation Logic
+
+#### With record_label (e.g., "ai_agent"):
+- `record_ai_agent_samples_1`, `record_ai_agent_samples_2`, etc. (indexed)
+- `record_ai_agent_seconds_1`, `record_ai_agent_seconds_2`, etc. (indexed)
+- `record_ai_agent_ms_1`, `record_ai_agent_ms_2`, etc. (indexed)
+- `record_ai_agent_url_1`, `record_ai_agent_url_2`, etc. (indexed)
+- `record_ai_agent_samples` (cumulative)
+- `record_ai_agent_seconds` (cumulative)
+- `record_ai_agent_ms` (cumulative)
+
+#### Without record_label (backward compatibility):
+- `record_samples_1`, `record_samples_2`, etc. (indexed)
+- `record_seconds_1`, `record_seconds_2`, etc. (indexed)
+- `record_ms_1`, `record_ms_2`, etc. (indexed)
+- `record_url_1`, `record_url_2`, etc. (indexed)
+- `record_samples` (cumulative)
+- `record_seconds` (cumulative)
+- `record_ms` (cumulative)
+
+## Usage Examples
+
+### Standard Recording (backward compatible):
+```
+uuid_record {uuid} start rtmp://example.com/stream
+```
+Result: Generates `record_ms` variable for TDA billing
+
+### AI/Transcription Recording:
+```
+uuid_record {uuid} start rtmp://example.com/stream 0 {record_label=ai_agent}
+```
+Result: Generates `record_ai_agent_ms` variable, TDA ignores this for billing
+
+### Multiple Labeled Recordings:
+```
+uuid_record {uuid} start rtmp://transcription.com/stream 0 {record_label=transcription}
+uuid_record {uuid} start rtmp://ai.com/stream 0 {record_label=ai_agent}
+```
+Result: Generates separate `record_transcription_ms` and `record_ai_agent_ms` variables
+
+## Benefits
+1. **Clear Billing Separation**: TDA can continue using `record_ms` for billing while ignoring labeled variables
+2. **Data Preservation**: All recording data is preserved for future analysis
+3. **Flexible Labeling**: Support for any label name (ai_agent, transcription, etc.)
+4. **Backward Compatibility**: Existing recordings without labels continue to work as before
+5. **Multiple Recording Support**: Different recording types can run simultaneously
+
+## Technical Implementation
+- Uses existing `get_recording_var()` function to access the `record_label` parameter
+- Follows FreeSWITCH coding standards and memory management patterns
+- Maintains existing variable indexing system for multiple recordings
+- Increased buffer size to accommodate longer label names (64 bytes)
+- Preserves all existing functionality and error handling
+
+## Testing Recommendations
+1. Test standard recording without label (should generate `record_ms`)
+2. Test labeled recording (should generate `record_{label}_ms`)
+3. Test multiple concurrent recordings with different labels
+4. Verify CDR variables are set correctly
+5. Test with various label names and special characters

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1250,6 +1250,7 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 		switch_size_t updated_samples_out = current_samples_out;
 		const char *last_record_index_str = switch_channel_get_variable(channel, "last_record_index");
 		const char *prev_record_samples_str = switch_channel_get_variable(channel, "record_samples");
+		const char *record_label = get_recording_var(channel, rh->variables, "record_label");
 		int record_index = 1;
 
 		if (!zstr(last_record_index_str) && switch_is_number(last_record_index_str)) {
@@ -1269,7 +1270,7 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 			switch_size_t updated_record_ms = current_record_ms;
 			const char *prev_record_sec_str = switch_channel_get_variable(channel, "record_seconds");
 			const char *prev_record_ms_str = switch_channel_get_variable(channel, "record_ms");
-			char buffer_name[32];
+			char buffer_name[64];
 
 			snprintf(buffer_name, sizeof(buffer_name), "record_samples_%d", record_index);
 			switch_channel_set_variable_printf(channel, buffer_name, "%d", current_samples_out);
@@ -1286,8 +1287,49 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 				updated_record_ms += atoi(prev_record_ms_str);
 			}
 
-			switch_channel_set_variable_printf(channel, "record_seconds", "%d", updated_record_seconds);
-			switch_channel_set_variable_printf(channel, "record_ms", "%d", updated_record_ms);
+			/* Handle labeled recording variables */
+			if (!zstr(record_label)) {
+				/* Generate labeled variables for this specific recording */
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_samples_%d", record_label, record_index);
+				switch_channel_set_variable_printf(channel, buffer_name, "%d", current_samples_out);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_seconds_%d", record_label, record_index);
+				switch_channel_set_variable_printf(channel, buffer_name, "%d", current_record_seconds);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_ms_%d", record_label, record_index);
+				switch_channel_set_variable_printf(channel, buffer_name, "%d", current_record_ms);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_url_%d", record_label, record_index);
+				switch_channel_set_variable_printf(channel, buffer_name, "%s", !zstr(rh->file) ? rh->file : "");
+
+				/* Generate cumulative labeled variables */
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_samples", record_label);
+				const char *prev_labeled_samples_str = switch_channel_get_variable(channel, buffer_name);
+				switch_size_t updated_labeled_samples = current_samples_out;
+				if (!zstr(prev_labeled_samples_str) && switch_is_number(prev_labeled_samples_str)) {
+					updated_labeled_samples += atoi(prev_labeled_samples_str);
+				}
+				switch_channel_set_variable_printf(channel, buffer_name, "%d", updated_labeled_samples);
+
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_seconds", record_label);
+				const char *prev_labeled_sec_str = switch_channel_get_variable(channel, buffer_name);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_ms", record_label);
+				const char *prev_labeled_ms_str = switch_channel_get_variable(channel, buffer_name);
+				switch_size_t updated_labeled_seconds = current_record_seconds;
+				switch_size_t updated_labeled_ms = current_record_ms;
+
+				if ((!zstr(prev_labeled_sec_str) && switch_is_number(prev_labeled_sec_str))
+					&& !zstr(prev_labeled_ms_str) && switch_is_number(prev_labeled_ms_str)) {
+					updated_labeled_seconds += atoi(prev_labeled_sec_str);
+					updated_labeled_ms += atoi(prev_labeled_ms_str);
+				}
+
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_seconds", record_label);
+				switch_channel_set_variable_printf(channel, buffer_name, "%d", updated_labeled_seconds);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_ms", record_label);
+				switch_channel_set_variable_printf(channel, buffer_name, "%d", updated_labeled_ms);
+			} else {
+				/* No label provided - use standard record_ms variables for backward compatibility */
+				switch_channel_set_variable_printf(channel, "record_seconds", "%d", updated_record_seconds);
+				switch_channel_set_variable_printf(channel, "record_ms", "%d", updated_record_ms);
+			}
 		}
 	}
 

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1271,12 +1271,22 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 			const char *prev_record_sec_str = switch_channel_get_variable(channel, "record_seconds");
 			const char *prev_record_ms_str = switch_channel_get_variable(channel, "record_ms");
 			char buffer_name[64];
-			const char *prev_labeled_samples_str = switch_channel_get_variable(channel, buffer_name);
-			const char *prev_labeled_sec_str = switch_channel_get_variable(channel, buffer_name);
-			const char *prev_labeled_ms_str = switch_channel_get_variable(channel, buffer_name);
+			const char *prev_labeled_samples_str = NULL;
+			const char *prev_labeled_sec_str = NULL;
+			const char *prev_labeled_ms_str = NULL;
 			switch_size_t updated_labeled_samples = current_samples_out;
 			switch_size_t updated_labeled_seconds = current_record_seconds;
 			switch_size_t updated_labeled_ms = current_record_ms;
+			
+			/* Get previous labeled variables if record_label exists */
+			if (!zstr(record_label)) {
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_samples", record_label);
+				prev_labeled_samples_str = switch_channel_get_variable(channel, buffer_name);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_seconds", record_label);
+				prev_labeled_sec_str = switch_channel_get_variable(channel, buffer_name);
+				snprintf(buffer_name, sizeof(buffer_name), "record_%s_ms", record_label);
+				prev_labeled_ms_str = switch_channel_get_variable(channel, buffer_name);
+			}
 			
 			snprintf(buffer_name, sizeof(buffer_name), "record_samples_%d", record_index);
 			switch_channel_set_variable_printf(channel, buffer_name, "%d", current_samples_out);
@@ -1311,9 +1321,6 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 					updated_labeled_samples += atoi(prev_labeled_samples_str);
 				}
 				switch_channel_set_variable_printf(channel, buffer_name, "%d", updated_labeled_samples);
-
-				snprintf(buffer_name, sizeof(buffer_name), "record_%s_seconds", record_label);
-				snprintf(buffer_name, sizeof(buffer_name), "record_%s_ms", record_label);
 
 				if ((!zstr(prev_labeled_sec_str) && switch_is_number(prev_labeled_sec_str))
 					&& !zstr(prev_labeled_ms_str) && switch_is_number(prev_labeled_ms_str)) {

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1271,7 +1271,13 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 			const char *prev_record_sec_str = switch_channel_get_variable(channel, "record_seconds");
 			const char *prev_record_ms_str = switch_channel_get_variable(channel, "record_ms");
 			char buffer_name[64];
-
+			const char *prev_labeled_samples_str = switch_channel_get_variable(channel, buffer_name);
+			const char *prev_labeled_sec_str = switch_channel_get_variable(channel, buffer_name);
+			const char *prev_labeled_ms_str = switch_channel_get_variable(channel, buffer_name);
+			switch_size_t updated_labeled_samples = current_samples_out;
+			switch_size_t updated_labeled_seconds = current_record_seconds;
+			switch_size_t updated_labeled_ms = current_record_ms;
+			
 			snprintf(buffer_name, sizeof(buffer_name), "record_samples_%d", record_index);
 			switch_channel_set_variable_printf(channel, buffer_name, "%d", current_samples_out);
 			snprintf(buffer_name, sizeof(buffer_name), "record_seconds_%d", record_index);
@@ -1301,19 +1307,13 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 
 				/* Generate cumulative labeled variables */
 				snprintf(buffer_name, sizeof(buffer_name), "record_%s_samples", record_label);
-				const char *prev_labeled_samples_str = switch_channel_get_variable(channel, buffer_name);
-				switch_size_t updated_labeled_samples = current_samples_out;
 				if (!zstr(prev_labeled_samples_str) && switch_is_number(prev_labeled_samples_str)) {
 					updated_labeled_samples += atoi(prev_labeled_samples_str);
 				}
 				switch_channel_set_variable_printf(channel, buffer_name, "%d", updated_labeled_samples);
 
 				snprintf(buffer_name, sizeof(buffer_name), "record_%s_seconds", record_label);
-				const char *prev_labeled_sec_str = switch_channel_get_variable(channel, buffer_name);
 				snprintf(buffer_name, sizeof(buffer_name), "record_%s_ms", record_label);
-				const char *prev_labeled_ms_str = switch_channel_get_variable(channel, buffer_name);
-				switch_size_t updated_labeled_seconds = current_record_seconds;
-				switch_size_t updated_labeled_ms = current_record_ms;
 
 				if ((!zstr(prev_labeled_sec_str) && switch_is_number(prev_labeled_sec_str))
 					&& !zstr(prev_labeled_ms_str) && switch_is_number(prev_labeled_ms_str)) {


### PR DESCRIPTION
## Overview

This PR implements the  feature for the  command to distinguish between different recording types for billing purposes.

## Problem Solved

- Voice AI and transcription services use  to start RTMP streams to transcription/Voice AI services
- The  variable gets populated whenever  is used, regardless of purpose
- TDA uses  as an indicator for call recording billing
- This results in incorrect billing for Voice AI and transcription usage

## Solution

Added support for a  parameter that generates labeled recording variables:

### Usage Examples:
- **Standard recording**: `uuid_record {uuid} start rtmp://...` → generates `record_ms` (consumed by TDA for billing)
- **AI/transcription**: `uuid_record {uuid} start rtmp://... 0 {record_label=ai_agent}` → generates `record_ai_agent_ms` (not consumed by TDA for billing)

## Implementation Details

### Changes Made:
1. Modified `send_record_stop_event()` function in `src/switch_ivr_async.c`
2. Added `record_label` variable detection using existing `get_recording_var()` function
3. When `record_label` is present, generates labeled variables instead of standard ones
4. Maintains backward compatibility when no label is provided

### Variable Generation:
- **With label**: `record_{label}_ms`, `record_{label}_seconds`, `record_{label}_samples`, etc.
- **Without label**: `record_ms`, `record_seconds`, `record_samples`, etc. (backward compatible)
- **Indexed support**: `record_{label}_ms_1`, `record_{label}_ms_2`, etc. for multiple recordings

## Benefits

1. **Clear Billing Separation**: TDA can continue using `record_ms` for billing while ignoring labeled variables
2. **Data Preservation**: All recording data is preserved for future analysis
3. **Flexible Labeling**: Support for any label name (ai_agent, transcription, etc.)
4. **Backward Compatibility**: Existing recordings without labels continue to work as before
5. **Multiple Recording Support**: Different recording types can run simultaneously

## Testing

The implementation follows FreeSWITCH coding standards and should be tested with:
- Standard recording without label (should generate `record_ms`)
- Labeled recording (should generate `record_{label}_ms`)
- Multiple concurrent recordings with different labels
- CDR variable verification

## Related

- **Jira Ticket**: TEL-6569
- **Original Discussion**: Slack thread https://telnyx.slack.com/archives/CEX7M4TPX/p1755703328848069