### PR TITLE
TEL-6649: Add test_string_stream_mem_leak for mod_sofia

### DIFF
--- a/src/mod/endpoints/mod_sofia/Makefile.am
+++ b/src/mod/endpoints/mod_sofia/Makefile.am
@@ -46,7 +46,7 @@ endif
 test_test_string_stream_mem_leak_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS) $(STIRSHAKEN_LIBS)
 test_test_string_stream_mem_leak_LDADD = libsofiamod.la $(SOFIA_SIP_LIBS) $(STIRSHAKEN_LIBS)
 
-TESTS = test/test_sofia_funcs.sh test/test_nuafail
+TESTS = test/test_sofia_funcs.sh test/test_nuafail test/test_string_stream_mem_leak
 #TESTS += test/test_run_sipp.sh
 
 if ISMAC


### PR DESCRIPTION
With this change, I see this test is running now
```
root@vagrant-telnyx:/vagrant/git-repo/team-telnyx/telnyx_b2bua_builder-02# make test-tuan-02
docker run -t \
	-e USER=root \
	-e GROUP=root \
	-e VERSION=1.10.12 \
	-e REVISION=telv86.0 \
	-e GITHUB_PASSWORD= \
	-e GITHUB_USERNAME= \
	-e ARTIFACTORY_CREDS= \
	-e ARTIFACTORY_PATH=https://artifactory.telnyx.com/generic/freeswitch \
	-e LIBRARY_PATH=/usr/local/lib \
	-e LD_LIBRARY_PATH=/usr/local/lib \
	--rm \
	--name telnyx_b2bua-bookworm-test-run \
	-v `pwd`:/SRC -v `pwd`/out-docker-vm/freeswitch:/usr/local/freeswitch \
	registry.internal.telnyx.com/jenkins/freeswitch-docker-base:1.5.0 \
	/bin/sh -c "cd /SRC && \
		cp -r /SRC/freeswitch/DEBBUILD/telnyx_b2bua-1.10.12-telv86.0/usr/local/freeswitch/* /usr/local/freeswitch/ && \
		cd freeswitch/tests/unit && \
		./test.sh src/mod/endpoints/mod_sofia/test/test_string_stream_mem_leak"
real-time non-blocking time  (microseconds, -R) unlimited
core file size              (blocks, -c) unlimited
data seg size               (kbytes, -d) unlimited
scheduling priority                 (-e) 0
file size                   (blocks, -f) unlimited
pending signals                     (-i) 31565
max locked memory           (kbytes, -l) 8192
max memory size             (kbytes, -m) unlimited
open files                          (-n) 1048576
pipe size                (512 bytes, -p) 8
POSIX message queues         (bytes, -q) 819200
real-time priority                  (-r) 0
stack size                  (kbytes, -s) 8192
cpu time                   (seconds, -t) unlimited
max user processes                  (-u) unlimited
virtual memory              (kbytes, -v) unlimited
file locks                          (-x) unlimited

Starting test: src/mod/endpoints/mod_sofia/test/test_string_stream_mem_leak

Relative dir is src/mod/endpoints/mod_sofia/test
Start executing /SRC/freeswitch/src/mod/endpoints/mod_sofia/test/test_string_stream_mem_leak
test_switch_string_stream_write_basic ............................. PASS
test_switch_string_stream_write_empty_string ...................... PASS
test_switch_string_stream_write_large_string ...................... PASS
test_switch_string_stream_write_multiple_calls .................... PASS
test_switch_string_stream_write_memory_stress ..................... PASS
test_switch_string_stream_write_format_specifiers ................. PASS
test_switch_string_stream_write_memory_leak_detection ............. PASS

----------------------------------------------------------------------------

PASSED (7/7 tests in 0.045342s)
End executing /SRC/freeswitch/src/mod/endpoints/mod_sofia/test/test_string_stream_mem_leak
Exit status is 0
```

```
Test Distribution Information:
Total tests found: 43
Chunk size: 43
Running chunk 1/1

Tests to be executed:
  1) tests/unit/switch_event
  2) tests/unit/switch_hash
  3) tests/unit/switch_ivr_originate
  4) tests/unit/switch_utils
  5) tests/unit/switch_core
  6) tests/unit/switch_console
  7) tests/unit/switch_vpx
  8) tests/unit/switch_core_file
  9) tests/unit/switch_ivr_play_say
 10) tests/unit/switch_core_codec
 11) tests/unit/switch_rtp
 12) tests/unit/switch_xml
 13) tests/unit/switch_core_video
 14) tests/unit/switch_core_db
 15) tests/unit/switch_vad
 16) tests/unit/switch_packetizer
 17) tests/unit/switch_core_session
 18) tests/unit/test_sofia
 19) tests/unit/switch_ivr_async
 20) tests/unit/switch_core_asr
 21) tests/unit/switch_log
 22) tests/unit/switch_hold
 23) tests/unit/switch_sip
 24) tests/unit/switch_mod_telnyx
 25) tests/unit/switch_mod_gstt
 26) tests/unit/switch_3pcc
 27) tests/unit/switch_rtp_pcap
 28) src/mod/codecs/mod_amr/test/test_amr
 29) src/mod/codecs/mod_amrwb/test/test_amrwb
 30) src/mod/applications/mod_av/test/test_mod_av
 31) src/mod/applications/mod_av/test/test_avformat
 32) src/mod/applications/mod_commands/test/test_mod_commands
 33) src/mod/applications/mod_conference/test/test_image
 34) src/mod/applications/mod_conference/test/test_member
 35) src/mod/applications/mod_http_cache/test/test_aws
 36) src/mod/languages/mod_lua/test/test_mod_lua
 37) src/mod/formats/mod_sndfile/test/test_sndfile
 38) src/mod/formats/mod_sndfile/test/test_sndfile_conf
 39) src/mod/endpoints/mod_sofia/test/test_sofia_funcs.sh
 40) src/mod/endpoints/mod_sofia/test/test_nuafail
 41) src/mod/endpoints/mod_sofia/test/test_string_stream_mem_leak
 42) src/mod/applications/mod_test/test/test_asr
 43) src/mod/applications/mod_test/test/test_tts
```