### PR TITLE
ENGDESK-44294: Mark conference as recovered if it is created by a recovered channel.

### DIFF
--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -3925,6 +3925,9 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 		switch_channel_event_set_data(channel, event);
 	}
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Action", "conference-create");
+	if (channel && switch_channel_test_flag(channel, CF_RECOVERED)) {
+		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Conference-Recovered", "true");
+	}
 	switch_event_fire(&event);
 
  end:


### PR DESCRIPTION
…overed channel.