### PR TITLE
ENGDESK-46866: Disable SRTP Reset for unchanged Crypto parameters

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -4891,6 +4891,9 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 			if (!mki_changed && prev_key && prev_key->type == crypto_key->type &&
 			    memcmp(prev_key->keysalt, crypto_key->keysalt, keysalt_len) == 0) {
 				key_changed = 0;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+								  "CRYPTO: RECV key unchanged (tag=%u->%u, type=%d, suite same, key same, mki=%d->%d) - preserving SRTP session state\n",
+								  prev_key->index, index, crypto_key->type, prev_recv_mki, new_mki_used);
 			}
 
 			if (key_changed || mki_changed) {
@@ -4937,6 +4940,9 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 			if (!mki_changed && prev_key && prev_key->type == crypto_key->type &&
 			    memcmp(prev_key->keysalt, crypto_key->keysalt, keysalt_len) == 0) {
 				key_changed = 0;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+								  "CRYPTO: SEND key unchanged (tag=%u->%u, type=%d, suite same, key same, mki=%d->%d) - preserving SRTP session state\n",
+								  prev_key->index, index, crypto_key->type, prev_send_mki, new_mki_used);
 			}
 
 			if (key_changed || mki_changed) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -4689,6 +4689,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 
 	crypto_key->type = ssec->crypto_type;
 	crypto_key->index = index;
+	crypto_key->keylen = keysalt_len;
 	memcpy(crypto_key->keysalt, keysalt, keysalt_len);
 	crypto_key->next = rtp_session->crypto_keys[direction];
 	rtp_session->crypto_keys[direction] = crypto_key;
@@ -4889,6 +4890,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 			}
 
 			if (!mki_changed && prev_key && prev_key->type == crypto_key->type &&
+			    prev_key->keylen == keysalt_len &&
 			    memcmp(prev_key->keysalt, crypto_key->keysalt, keysalt_len) == 0) {
 				key_changed = 0;
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
@@ -4938,6 +4940,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 			}
 
 			if (!mki_changed && prev_key && prev_key->type == crypto_key->type &&
+			    prev_key->keylen == keysalt_len &&
 			    memcmp(prev_key->keysalt, crypto_key->keysalt, keysalt_len) == 0) {
 				key_changed = 0;
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -4611,6 +4611,8 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 	srtp_master_key_t		**mkis = NULL;
 	srtp_master_key_t		*mki = NULL;
 	int mki_idx = 0;
+	int prev_recv_mki = rtp_session->flags[SWITCH_RTP_FLAG_SECURE_RECV_MKI] ? 1 : 0;
+	int prev_send_mki = rtp_session->flags[SWITCH_RTP_FLAG_SECURE_SEND_MKI] ? 1 : 0;
 
 	keysalt_len = switch_core_media_crypto_keysalt_len(ssec->crypto_type);
 
@@ -4873,7 +4875,31 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 		policy->ssrc.type = ssrc_any_inbound;
 
 		if (rtp_session->flags[SWITCH_RTP_FLAG_SECURE_RECV] && idx == 0 && rtp_session->recv_ctx[idx]) {
-			rtp_session->flags[SWITCH_RTP_FLAG_SECURE_RECV_RESET] = 1;
+			/* Check if crypto suite and key material have actually changed - if not, preserve SRTP session state (ROC, replay window) */
+			switch_rtp_crypto_key_t *prev_key = crypto_key->next;
+			int key_changed = 1;
+			int mki_changed = 0;
+			int new_mki_used = rtp_session->flags[SWITCH_RTP_FLAG_SECURE_RECV_MKI] ? 1 : 0;
+
+			if (prev_recv_mki != new_mki_used) {
+				mki_changed = 1;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+								  "CRYPTO: RECV MKI usage changed (was=%d, now=%d) - resetting SRTP context\n",
+								  prev_recv_mki, new_mki_used);
+			}
+
+			if (!mki_changed && prev_key && prev_key->type == crypto_key->type &&
+			    memcmp(prev_key->keysalt, crypto_key->keysalt, keysalt_len) == 0) {
+				key_changed = 0;
+			}
+
+			if (key_changed || mki_changed) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+								  "CRYPTO: RECV key changed (tag=%u->%u, type=%d->%d, mki_changed=%d) - resetting SRTP context\n",
+								  prev_key ? prev_key->index : 0, index,
+								  prev_key ? prev_key->type : 0, crypto_key->type, mki_changed);
+				rtp_session->flags[SWITCH_RTP_FLAG_SECURE_RECV_RESET] = 1;
+			}
 		} else {
 			if ((stat = srtp_create(&rtp_session->recv_ctx[idx], policy)) || !rtp_session->recv_ctx[idx]) {
 				status = SWITCH_STATUS_FALSE;
@@ -4895,7 +4921,31 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_crypto_key(switch_rtp_t *rtp_sess
 		//policy->ssrc.value = rtp_session->ssrc;
 
 		if (rtp_session->flags[SWITCH_RTP_FLAG_SECURE_SEND] && idx == 0 && rtp_session->send_ctx[idx]) {
-			rtp_session->flags[SWITCH_RTP_FLAG_SECURE_SEND_RESET] = 1;
+			/* Check if crypto suite and key material have actually changed - if not, preserve SRTP session state */
+			switch_rtp_crypto_key_t *prev_key = crypto_key->next;
+			int key_changed = 1;
+			int mki_changed = 0;
+			int new_mki_used = rtp_session->flags[SWITCH_RTP_FLAG_SECURE_SEND_MKI] ? 1 : 0;
+
+			if (prev_send_mki != new_mki_used) {
+				mki_changed = 1;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+								  "CRYPTO: SEND MKI usage changed (was=%d, now=%d) - resetting SRTP context\n",
+								  prev_send_mki, new_mki_used);
+			}
+
+			if (!mki_changed && prev_key && prev_key->type == crypto_key->type &&
+			    memcmp(prev_key->keysalt, crypto_key->keysalt, keysalt_len) == 0) {
+				key_changed = 0;
+			}
+
+			if (key_changed || mki_changed) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+								  "CRYPTO: SEND key changed (tag=%u->%u, type=%d->%d, mki_changed=%d) - resetting SRTP context\n",
+								  prev_key ? prev_key->index : 0, index,
+								  prev_key ? prev_key->type : 0, crypto_key->type, mki_changed);
+				rtp_session->flags[SWITCH_RTP_FLAG_SECURE_SEND_RESET] = 1;
+			}
 		} else {
 			if ((stat = srtp_create(&rtp_session->send_ctx[idx], policy)) || !rtp_session->send_ctx[idx]) {
 				status = SWITCH_STATUS_FALSE;


### PR DESCRIPTION
SRTP context reset causes authentication mismatches when we have RTP sequence rollover and crypto changes aren't updated. New RTP context will have ROC=0 instead of ROC=1, causing authentication mismatches since SRTP auth includes ROC in the HMAC calculation.