### PR TITLE
TEL-6710: [b2bua] Resolve ERR log mod_dptools.c:3174 Could not play the media correctly. status: 1, error: Write frame failed

### DIFF
--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -3213,7 +3213,7 @@ SWITCH_STANDARD_APP(endless_playback_function)
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
 		break;
 	default:
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Could not play the media correctly. status: %d\n", status);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Could not play the media correctly. status: %d\n", status);
 		switch_channel_set_variable_printf(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR: %d", status);
 		break;
 	}
@@ -3263,7 +3263,7 @@ SWITCH_STANDARD_APP(loop_playback_function)
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
 		break;
 	default:
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Could not play the media correctly. status: %d\n", status);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Could not play the media correctly. status: %d\n", status);
 		switch_channel_set_variable_printf(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR: %d", status);
 		break;
 	}

--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -3171,7 +3171,7 @@ SWITCH_STANDARD_APP(playback_function)
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
 		break;
 	default:
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Could not play the media correctly. status: %d, error: %s\n", status, error);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Could not play the media correctly. status: %d, error: %s\n", status, error);
 		switch_channel_set_variable_printf(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR: %d:%s", status, error);
 		break;
 	}
@@ -3213,7 +3213,7 @@ SWITCH_STANDARD_APP(endless_playback_function)
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
 		break;
 	default:
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Could not play the media correctly. status: %d\n", status);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Could not play the media correctly. status: %d\n", status);
 		switch_channel_set_variable_printf(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR: %d", status);
 		break;
 	}
@@ -3263,7 +3263,7 @@ SWITCH_STANDARD_APP(loop_playback_function)
 		switch_channel_set_variable(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "FILE NOT FOUND");
 		break;
 	default:
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Could not play the media correctly. status: %d\n", status);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Could not play the media correctly. status: %d\n", status);
 		switch_channel_set_variable_printf(channel, SWITCH_CURRENT_APPLICATION_RESPONSE_VARIABLE, "PLAYBACK ERROR: %d", status);
 		break;
 	}


### PR DESCRIPTION
## Summary

This PR addresses the Jira ticket TEL-6710 by changing the log level from ERROR to DEBUG for 'Could not play the media correctly' messages in mod_dptools.c.

## Changes Made

- Changed SWITCH_LOG_ERROR to SWITCH_LOG_DEBUG for three instances of the 'Could not play the media correctly' message:
  - Line 3174: status with error message
  - Line 3216: status only
  - Line 3266: status only

## Rationale

These messages are currently logged as ERROR level, which creates unnecessary noise in the logs for what are often non-critical playback status conditions. By changing them to DEBUG level:

- Reduces log verbosity for normal operations
- Maintains the error response variables for application logic
- Allows debugging when needed by enabling DEBUG level logging

## Related

- Jira Ticket: TEL-6710
- Note: The comment mentioned mod_bcg729.c:206 'g729 zero length frame' but this file/message was not found in the current codebase

## Testing

The changes maintain the existing application logic while only affecting log output level. Error response variables are preserved for proper error handling by calling applications.