### PR TITLE
TEL-6717: [b2bua] Resolve ERR log mod_avmd.c:1622 Stop failed - no avmd session running on this channel

### DIFF
--- a/src/mod/applications/mod_avmd/mod_avmd.c
+++ b/src/mod/applications/mod_avmd/mod_avmd.c
@@ -1619,7 +1619,7 @@ SWITCH_STANDARD_APP(avmd_stop_app) {
 
     bug = (switch_media_bug_t *) switch_channel_get_private(channel, "_avmd_");
     if (bug == NULL) {
-        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Stop failed - no avmd session running on this channel [%s]!\n", switch_channel_get_name(channel));
+        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Stop failed - no avmd session running on this channel [%s]!\n", switch_channel_get_name(channel));
         return;
     }
 


### PR DESCRIPTION
## Summary

This pull request addresses TEL-6717 by changing the log level of the "Stop failed - no avmd session running on this channel" message from ERROR to WARNING in mod_avmd.c:1622.

## Changes

- **File Modified**: `src/mod/applications/mod_avmd/mod_avmd.c`
- **Line 1622**: Changed `SWITCH_LOG_ERROR` to `SWITCH_LOG_WARNING`
- **Impact**: Reduces noise in error logs as this is expected behavior when avmd session is not running

## Context

This error log appears in 92.30% of cases and was identified as needing to be moved from ERR to WARNING level based on team discussion. The log message includes a channel UUID, making it useful for correlation while not representing a critical error condition.

## References

- Jira Ticket: TEL-6717
- Parent Epic: TEL-6680
- Related Issue: TEL-6683

## Testing

The change follows existing patterns in the codebase where SWITCH_LOG_WARNING is used for similar scenarios (lines 558, 562, 572, 576 in the same file). No functional changes to the avmd module behavior - only log level adjustment.