### PR TITLE
TEL-6715: [b2bua] Resolve ERR log avformat.c:2741 Error while writing audio frame: -32 Broken pipe

### DIFF
--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -2738,7 +2738,10 @@ GCC_DIAG_ON(deprecated-declarations)
 					if ((context->errs % 10) == 0) {
 						char ebuf[255] = "";
 
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error while writing audio frame: %d %s\n", ret, get_error_text(ret, ebuf, sizeof(ebuf)));
+						char uuid_buf[SWITCH_UUID_FORMATTED_LENGTH + 1] = "";
+
+							switch_uuid_str(uuid_buf, sizeof(uuid_buf));
+							switch_log_printf(SWITCH_CHANNEL_UUID_LOG(uuid_buf), SWITCH_LOG_ERROR, "Error while writing audio frame: %d %s\n", ret, get_error_text(ret, ebuf, sizeof(ebuf)));
 						if ((ret == -5 || ret == -104) && handle->stream_name) {
 							context->errs = 1001;
 						}

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -2540,6 +2540,11 @@ static switch_status_t av_file_write(switch_file_handle_t *handle, void *data, s
 	int inuse;
 	int sample_start = 0;
 	AVCodecContext *c = NULL;
+	const char *uuid = NULL;
+
+	if (handle->params) {
+		uuid = switch_event_get_header(handle->params, "session");
+	}
 
 	if (!switch_test_flag(handle, SWITCH_FILE_FLAG_WRITE)) {
 		return SWITCH_STATUS_FALSE;
@@ -2738,10 +2743,7 @@ GCC_DIAG_ON(deprecated-declarations)
 					if ((context->errs % 10) == 0) {
 						char ebuf[255] = "";
 
-						char uuid_buf[SWITCH_UUID_FORMATTED_LENGTH + 1] = "";
-
-							switch_uuid_str(uuid_buf, sizeof(uuid_buf));
-							switch_log_printf(SWITCH_CHANNEL_UUID_LOG(uuid_buf), SWITCH_LOG_ERROR, "Error while writing audio frame: %d %s\n", ret, get_error_text(ret, ebuf, sizeof(ebuf)));
+						switch_log_printf(SWITCH_CHANNEL_UUID_LOG(uuid), SWITCH_LOG_ERROR, "Error while writing audio frame: %d %s\n", ret, get_error_text(ret, ebuf, sizeof(ebuf)));
 						if ((ret == -5 || ret == -104) && handle->stream_name) {
 							context->errs = 1001;
 						}


### PR DESCRIPTION
## Summary

This pull request addresses TEL-6715 by adding a UUID to the high-frequency error log "Error while writing audio frame: -32 Broken pipe" in avformat.c:2741.

## Changes

- Modified `/src/mod/applications/mod_av/avformat.c` line 2741
- Added UUID generation using `switch_uuid_str()`
- Changed from `SWITCH_CHANNEL_LOG` to `SWITCH_CHANNEL_UUID_LOG()` pattern
- Follows existing freeswitch logging patterns used in other modules

## Impact

- Helps reduce ERR log noise by enabling better correlation and analysis
- Provides unique identifiers for each error occurrence
- Supports the goal of improving AIDA reporting for b2bua deployment control room
- Addresses one of the 14 high-frequency ERR logs that account for 99.5% of all ERR and CRIT logs

## References

- Jira Ticket: TEL-6715
- Parent Epic: TEL-6680
- Related Ticket: TEL-6683

The change is minimal and focused, only adding UUID generation to the existing error log without modifying any other functionality.