### PR TITLE
TEL-6792: Add bridge codec variables for transcoding detection

### DIFF
--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -2522,6 +2522,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_uuid_bridge(const char *originator_uu
 			switch_channel_set_variable(originatee_channel, SWITCH_BRIDGE_CHANNEL_VARIABLE, switch_channel_get_name(originator_channel));
 			switch_channel_set_variable(originatee_channel, SWITCH_BRIDGE_UUID_VARIABLE, switch_core_session_get_uuid(originator_session));
 			switch_channel_set_variable(originatee_channel, SWITCH_SIGNAL_BOND_VARIABLE, switch_core_session_get_uuid(originator_session));
+			set_bridge_codec_vars(originator_channel, originatee_channel);
 
 
 			originator_cp = switch_channel_get_caller_profile(originator_channel);

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -2066,6 +2066,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_multi_threaded_bridge(switch_core_ses
 
 		switch_channel_set_bridge_time(caller_channel);
 		switch_channel_set_bridge_time(peer_channel);
+		set_bridge_codec_vars(caller_channel, peer_channel);
 
 		if (switch_event_create(&event, SWITCH_EVENT_CHANNEL_BRIDGE) == SWITCH_STATUS_SUCCESS) {
 			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Bridge-A-Unique-ID", switch_core_session_get_uuid(session));

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -1921,6 +1921,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_signal_bridge(switch_core_session_t *
 	}
 
 	check_bridge_export(caller_channel, peer_channel);
+	set_bridge_codec_vars(caller_channel, peer_channel);
 
 	switch_channel_set_flag_recursive(caller_channel, CF_SIGNAL_BRIDGE_TTL);
 	switch_channel_set_flag_recursive(peer_channel, CF_SIGNAL_BRIDGE_TTL);

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -1875,6 +1875,35 @@ static void check_bridge_export(switch_channel_t *channel, switch_channel_t *pee
 	switch_channel_process_export(channel, peer_channel, NULL, SWITCH_BRIDGE_EXPORT_VARS_VARIABLE);
 }
 
+/**
+ * Copy codec names from each channel to the peer channel with "bridge_" prefix
+ * This allows detection of transcoding by comparing codec variables in a single CDR
+ */
+static void set_bridge_codec_vars(switch_channel_t *channel_a, switch_channel_t *channel_b)
+{
+	const char *codec_var;
+
+	/* Copy audio codec name from channel_a to channel_b */
+	if ((codec_var = switch_channel_get_variable(channel_a, "rtp_use_codec_name"))) {
+		switch_channel_set_variable(channel_b, "bridge_rtp_use_codec_name", codec_var);
+	}
+
+	/* Copy audio codec name from channel_b to channel_a */
+	if ((codec_var = switch_channel_get_variable(channel_b, "rtp_use_codec_name"))) {
+		switch_channel_set_variable(channel_a, "bridge_rtp_use_codec_name", codec_var);
+	}
+
+	/* Copy video codec name from channel_a to channel_b (if present) */
+	if ((codec_var = switch_channel_get_variable(channel_a, "rtp_use_video_codec_name"))) {
+		switch_channel_set_variable(channel_b, "bridge_rtp_use_video_codec_name", codec_var);
+	}
+
+	/* Copy video codec name from channel_b to channel_a (if present) */
+	if ((codec_var = switch_channel_get_variable(channel_b, "rtp_use_video_codec_name"))) {
+		switch_channel_set_variable(channel_a, "bridge_rtp_use_video_codec_name", codec_var);
+	}
+}
+
 SWITCH_DECLARE(switch_status_t) switch_ivr_signal_bridge(switch_core_session_t *session, switch_core_session_t *peer_session)
 {
 	switch_channel_t *caller_channel = switch_core_session_get_channel(session);


### PR DESCRIPTION
## Overview
  Add `bridge_rtp_use_codec_name` and `bridge_rtp_use_video_codec_name` variables to enable transcoding detection from a single CDR without correlating multiple CDRs.

  ## Problem
  Currently, detecting transcoding requires correlating the user CDR with the opposite leg CDR (vendor CDR). This requires complex cross-referencing:
  - User CDR has `rtp_use_codec_name` for the user leg
  - Vendor CDR has `rtp_use_codec_name` for the vendor leg
  - Must match by call UUID/timestamp to determine if transcoding occurred

  ## Solution
  This PR adds bidirectional bridge codec variables that copy each leg's codec name to the bridged partner:
  - Each leg gets its own codec in `rtp_use_codec_name` (existing)
  - Each leg now also gets the partner's codec in `bridge_rtp_use_codec_name` (new)

  **Example:**
  - A-leg (PCMU) bridges to B-leg (opus)
  - A-leg CDR: `rtp_use_codec_name=PCMU`, `bridge_rtp_use_codec_name=opus` → **transcoding detected**
  - B-leg CDR: `rtp_use_codec_name=opus`, `bridge_rtp_use_codec_name=PCMU` → **transcoding detected**

  If values match (e.g., both PCMU), no transcoding occurred.

  ## Implementation Details

  **Files Modified:**
  - `freeswitch/src/switch_ivr_bridge.c` (+32 lines)

  **Changes:**
  1. Added `set_bridge_codec_vars()` helper function to copy codec names bidirectionally
  2. Integrated into all three bridge types:
     - Signal bridge (`switch_ivr_signal_bridge`)
     - Media bridge (`switch_ivr_multi_threaded_bridge`)
     - UUID bridge (`switch_ivr_uuid_bridge`)

  **Variables Created:**
  - `bridge_rtp_use_codec_name` - Audio codec from bridged leg
  - `bridge_rtp_use_video_codec_name` - Video codec from bridged leg (only set if video negotiated)

  ## Commit Structure
  Each commit represents a logical unit of work:
  1. `ffb5cc77d8` - Add helper function
  2. `94c3bdd918` - Signal bridge integration
  3. `4081ebdc23` - Media bridge integration
  4. `016d2eaac7` - UUID bridge integration

  ## Testing Instructions

  ### Build
  ```bash
  make publish-package
  # or
  make build-deb-package-on-docker

  Test Case 1: No Transcoding

  1. Originate call with PCMU codec
  2. Bridge to endpoint using PCMU codec
  3. Check CDR: rtp_use_codec_name should equal bridge_rtp_use_codec_name

  Test Case 2: With Transcoding

  1. Originate call with PCMU codec
  2. Bridge to endpoint using opus codec
  3. Check A-leg CDR: rtp_use_codec_name=PCMU, bridge_rtp_use_codec_name=opus
  4. Check B-leg CDR: rtp_use_codec_name=opus, bridge_rtp_use_codec_name=PCMU

  Verification Command

  fs_cli -x "uuid_dump <call-uuid>" | grep -E "(rtp_use_codec_name|bridge_rtp_use_codec_name)"

  Edge Cases Handled

  - ✅ Codec variables not set yet (NULL checks prevent crashes)
  - ✅ One-legged calls (helper function never called, no overhead)
  - ✅ Proxy/bypass media mode (NULL checks handle missing variables)
  - ✅ Video-only calls (only video codec variables populated)

  Known Limitations

  - Variables represent codec at bridge time only
  - Not updated if codec changes mid-call via RE-INVITE (rare scenario)
  - This can be addressed in a future ticket if needed

  Performance Impact

  - Minimal: ~4 NULL checks + ~4 variable assignments per bridge
  - No new locks, threads, or memory allocations
  - Estimated < 1μs overhead per bridge

  Backward Compatibility

  - ✅ Fully backward compatible
  - ✅ No API changes
  - ✅ No configuration changes required
  - ✅ Safe to rollback (no dependencies)

  Checklist

  - Code follows FreeSWITCH coding conventions
  - NULL checks for all variable reads
  - All three bridge types covered
  - No memory leaks
  - Tested on development environment
  - Verified CDR variables appear correctly
  - Load tested for performance impact

  Related Documentation

  - JIRA: TEL-6792
  - Base branch: telnyx/telephony/deploy-development
  - Target branch: telnyx/telephony/deploy-development
