### PR TITLE
TEL-6821: Fix RTP port resource leak and improve cleanup logic

### DIFF
--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -406,18 +406,12 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
     return SWITCH_CAUSE_SUCCESS;
 
 fail:
-     if (tech_pvt) {
-        if (tech_pvt->read_codec.implementation) {
-			switch_core_codec_destroy(&tech_pvt->read_codec);
-		}
-
-		if (tech_pvt->write_codec.implementation) {
-			switch_core_codec_destroy(&tech_pvt->write_codec);
-		}
-    }
-
     if (*new_session) {
+        // Session was created, channel_on_destroy handles all cleanup
         switch_core_session_destroy(new_session);
+    } else if (local_port != 0) {
+        // Session creation failed but port was already allocated
+        switch_rtp_release_port(local_addr, local_port);
     }
     return SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER;
 }
@@ -445,11 +439,16 @@ static switch_status_t channel_on_destroy(switch_core_session_t *session)
 		if (tech_pvt->write_codec.implementation) {
 			switch_core_codec_destroy(&tech_pvt->write_codec);
 		}
-	}
 
-    if (tech_pvt->local_port != 0) {
-        switch_rtp_release_port(tech_pvt->local_address, tech_pvt->local_port);
-    }
+		// Clean up RTP session or release port
+		if (tech_pvt->rtp_session) {
+			// Destroy RTP session (releases port internally)
+			switch_rtp_destroy(&tech_pvt->rtp_session);
+		} else if (tech_pvt->local_port != 0) {
+			// Port was allocated but RTP session was never created
+			switch_rtp_release_port(tech_pvt->local_address, tech_pvt->local_port);
+		}
+	}
 
     return SWITCH_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Fixed two issues in mod_sofia/rtp.c:

1. Port Resource Leak in channel_outgoing_channel(): When channel_outgoing_channel() allocates an RTP port but switch_core_session_request() fails, the port was never released, causing port exhaustion over time.

2. Incomplete cleanup in channel_on_destroy(): The destroy handler only released the port directly but never destroyed the RTP session, which could leak RTP resources.

Changes:

fail: label cleanup (lines 408-416):
- Simplified to delegate all cleanup to channel_on_destroy via switch_core_session_destroy() when session exists
- Only handles port release when session creation fails before tech_pvt initialization

channel_on_destroy() improvements (lines 429-454):
- Added proper RTP session destruction via switch_rtp_destroy()
- Falls back to direct port release only if RTP session was never created
- Follows the same pattern as switch_core_media.c

This fix handles all 10 failure scenarios in channel_outgoing_channel:
- Validation failures (lines 295, 302, 325)
- Session creation failure (line 307)
- Codec initialization failures (lines 363, 375)
- Codec setting failures (lines 381, 386)
- RTP session creation failure (line 396)
- Thread launch failure (line 401)

Verified against FreeSWITCH core behavior:
- switch_core_session_destroy() reliably invokes channel_on_destroy()
- tech_pvt is accessible in all failure scenarios where session exists
- Codec destroy is safe even if initialization failed
- No resource leaks or double-free scenarios