### PR TITLE
TEL-6834 , ENGDESK-44823: Fix eavesdrop duplicate audio in call recordings

### DIFF
--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -942,10 +942,11 @@ SWITCH_STANDARD_APP(eavesdrop_function)
 		const char *bridge_partner = switch_channel_get_variable(channel, "eavesdrop_bridge_partner");
 
 		if (enable_dtmf) {
+			flags &= ~(ED_DTMF | ED_DTMF_EVENTS_ONLY);
 			if (!strcasecmp(enable_dtmf, "events")) {
-				flags = ED_DTMF_EVENTS_ONLY;
-			} else {
-				flags = switch_true(enable_dtmf) ? ED_DTMF : ED_NONE;
+				flags |= ED_DTMF_EVENTS_ONLY;
+			} else if (switch_true(enable_dtmf)) {
+				flags |= ED_DTMF;
 			}
 		}
 

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -768,15 +768,31 @@ cnt_with_cng:
 			int prune = 0;
 			switch_frame_t *read_demux_frames[MAX_READ_DEMUX];
 			int read_demux_count = 0;
+			uint8_t *read_demux_data = NULL;
 
 			switch_thread_rwlock_rdlock(session->bug_rwlock);
 
-			/* Collect all read_demux_frames inside rdlock (eavesdrop bugs NULL theirs after use) */
+			/* Collect all read_demux_frames inside rdlock (bugs NULL theirs after use) */
 			{
 				switch_media_bug_t *dbp;
 				for (dbp = session->bugs; dbp; dbp = dbp->next) {
 					if (dbp->read_demux_frame && read_demux_count < MAX_READ_DEMUX) {
 						read_demux_frames[read_demux_count++] = dbp->read_demux_frame;
+					}
+				}
+			}
+
+			/* Pre-compute unmerged read frame once for all READ_STREAM bugs without their own demux */
+			if (read_demux_count > 0) {
+				read_demux_data = malloc(read_frame->datalen);
+				if (read_demux_data) {
+					int i;
+					memcpy(read_demux_data, read_frame->data, read_frame->datalen);
+					for (i = 0; i < read_demux_count; i++) {
+						uint32_t samples = read_frame->datalen / 2 / read_demux_frames[i]->channels;
+						switch_unmerge_sln((int16_t *)read_demux_data, samples,
+											read_demux_frames[i]->data, samples,
+											read_demux_frames[i]->channels);
 					}
 				}
 			}
@@ -808,7 +824,7 @@ cnt_with_cng:
 				if (bp->ready && switch_test_flag(bp, SMBF_READ_STREAM)) {
 					switch_mutex_lock(bp->read_mutex);
 					if (bp->read_demux_frame) {
-						/* Bug has its own demux (e.g. eavesdrop bug itself) */
+						/* Bug has its own demux — unmerge only its own */
 						uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];
 						int bytes = read_frame->datalen;
 						uint32_t datalen = 0;
@@ -821,19 +837,9 @@ cnt_with_cng:
 
 						switch_buffer_write(bp->raw_read_buffer, data, datalen);
 						bp->read_demux_frame = NULL;
-					} else if (read_demux_count > 0) {
-						/* Bug without its own demux (e.g. recording) — unmerge ALL collected demux frames */
-						uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];
-						int i;
-
-						memcpy(data, read_frame->data, read_frame->datalen);
-						for (i = 0; i < read_demux_count; i++) {
-							uint32_t samples = read_frame->datalen / 2 / read_demux_frames[i]->channels;
-							switch_unmerge_sln((int16_t *)data, samples,
-												read_demux_frames[i]->data, samples,
-												read_demux_frames[i]->channels);
-						}
-						switch_buffer_write(bp->raw_read_buffer, data, read_frame->datalen);
+					} else if (read_demux_data) {
+						/* Pre-computed unmerged frame — all demux audio removed */
+						switch_buffer_write(bp->raw_read_buffer, read_demux_data, read_frame->datalen);
 					} else {
 						switch_buffer_write(bp->raw_read_buffer, read_frame->data, read_frame->datalen);
 					}
@@ -850,6 +856,9 @@ cnt_with_cng:
 				}
 			}
 			switch_thread_rwlock_unlock(session->bug_rwlock);
+			if (read_demux_data) {
+				free(read_demux_data);
+			}
 			if (prune) {
 				switch_core_media_bug_prune(session);
 			}

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -785,7 +785,8 @@ cnt_with_cng:
 			/* Pre-compute unmerged read frame once for all READ_STREAM bugs without their own demux */
 			if (read_demux_count > 0) {
 				read_demux_data = malloc(read_frame->datalen);
-				if (read_demux_data) {
+				switch_assert(read_demux_data);
+				{
 					int i;
 					memcpy(read_demux_data, read_frame->data, read_frame->datalen);
 					for (i = 0; i < read_demux_count; i++) {
@@ -856,9 +857,7 @@ cnt_with_cng:
 				}
 			}
 			switch_thread_rwlock_unlock(session->bug_rwlock);
-			if (read_demux_data) {
-				free(read_demux_data);
-			}
+			switch_safe_free(read_demux_data);
 			if (prune) {
 				switch_core_media_bug_prune(session);
 			}

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -36,6 +36,8 @@
 #include <switch.h>
 #include "private/switch_core_pvt.h"
 
+#define MAX_READ_DEMUX 8
+
 SWITCH_DECLARE(void) switch_core_gen_encoded_silence(unsigned char *data, const switch_codec_implementation_t *read_impl, switch_size_t len)
 {
 	unsigned char g729_filler[] = {
@@ -764,7 +766,20 @@ cnt_with_cng:
 			switch_media_bug_t *bp;
 			switch_bool_t ok = SWITCH_TRUE;
 			int prune = 0;
+			switch_frame_t *read_demux_frames[MAX_READ_DEMUX];
+			int read_demux_count = 0;
+
 			switch_thread_rwlock_rdlock(session->bug_rwlock);
+
+			/* Collect all read_demux_frames inside rdlock (eavesdrop bugs NULL theirs after use) */
+			{
+				switch_media_bug_t *dbp;
+				for (dbp = session->bugs; dbp; dbp = dbp->next) {
+					if (dbp->read_demux_frame && read_demux_count < MAX_READ_DEMUX) {
+						read_demux_frames[read_demux_count++] = dbp->read_demux_frame;
+					}
+				}
+			}
 
 			for (bp = session->bugs; bp; bp = bp->next) {
 				ok = SWITCH_TRUE;
@@ -793,6 +808,7 @@ cnt_with_cng:
 				if (bp->ready && switch_test_flag(bp, SMBF_READ_STREAM)) {
 					switch_mutex_lock(bp->read_mutex);
 					if (bp->read_demux_frame) {
+						/* Bug has its own demux (e.g. eavesdrop bug itself) */
 						uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];
 						int bytes = read_frame->datalen;
 						uint32_t datalen = 0;
@@ -805,6 +821,19 @@ cnt_with_cng:
 
 						switch_buffer_write(bp->raw_read_buffer, data, datalen);
 						bp->read_demux_frame = NULL;
+					} else if (read_demux_count > 0) {
+						/* Bug without its own demux (e.g. recording) — unmerge ALL collected demux frames */
+						uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];
+						int i;
+
+						memcpy(data, read_frame->data, read_frame->datalen);
+						for (i = 0; i < read_demux_count; i++) {
+							uint32_t samples = read_frame->datalen / 2 / read_demux_frames[i]->channels;
+							switch_unmerge_sln((int16_t *)data, samples,
+												read_demux_frames[i]->data, samples,
+												read_demux_frames[i]->channels);
+						}
+						switch_buffer_write(bp->raw_read_buffer, data, read_frame->datalen);
 					} else {
 						switch_buffer_write(bp->raw_read_buffer, read_frame->data, read_frame->datalen);
 					}

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -2383,37 +2383,6 @@ static switch_bool_t eavesdrop_callback(switch_media_bug_t *bug, void *user_data
 				void *data_to_write = frame.data;
 				uint32_t datalen_to_write = frame.datalen;
 
-				/* Unmerge eavesdrop READ audio to prevent echo */
-				if (switch_test_flag(ep, ED_MUX_READ) && ep->demux_frame.data && ep->demux_frame.datalen > 0 && frame.datalen > 0) {
-					uint32_t frame_samples = frame.datalen / 2 / frame.channels;
-					uint32_t demux_samples = ep->demux_frame.datalen / 2 / ep->demux_frame.channels;
-
-					if (frame_samples == demux_samples && frame.channels == ep->demux_frame.channels) {
-						uint8_t unmerged_data[SWITCH_MAX_L16];
-						uint32_t unmerged_samples;
-						
-						memcpy(unmerged_data, frame.data, frame.datalen);
-						
-						unmerged_samples = switch_unmerge_sln((int16_t *)unmerged_data, frame_samples,
-						                                       (int16_t *)ep->demux_frame.data, demux_samples,
-						                                       frame.channels);
-						
-						frame.data = unmerged_data;
-						frame.datalen = unmerged_samples * 2 * frame.channels;
-						frame.samples = unmerged_samples;
-						data_to_write = unmerged_data;
-						datalen_to_write = frame.datalen;
-						
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG10,
-						                  "Eavesdrop READ_PING: Unmerged eavesdrop READ audio (%u samples, %u bytes)\n",
-						                  unmerged_samples, frame.datalen);
-
-						ep->demux_frame.data = NULL;
-						ep->demux_frame.datalen = 0;
-						ep->demux_frame.samples = 0;
-					}
-				}
-
 				/* Apply resampling if needed */
 				if (ep->tread_impl.actual_samples_per_second != ep->read_impl.actual_samples_per_second &&
 				    ep->resampler && frame.datalen > 0) {


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                  
                                                                                                                                                                                                           
  When eavesdrop with both bridge flags (eavesdrop_bridge_aleg=true + eavesdrop_bridge_bleg=true) is active, coach audio is merged into both the READ and WRITE paths of the target channel. The recording
  bug captures frames after this merge, causing coach audio to appear on both stereo channels — heard as echo/duplication.

  **Two root causes were identified and fixed:**

  - Flag preservation (mod_dptools.c): The eavesdrop_enable_dtmf handling used flags = (full assignment) which wiped the initial ED_DEMUX_READ flag. Changed to flags &= / flags |= to only manipulate
  DTMF-related bits, preserving the demux flag. This was the reason demux never activated in production.
  - Demux propagation (switch_core_io.c): The existing read_demux_frame unmerge only applied to the eavesdrop bug's own READ_STREAM processing — the recording bug never benefited from it. Added a
  pre-collection of all demux frames (supporting multiple concurrent eavesdrop sessions) and applied switch_unmerge_sln for each one to all downstream READ_STREAM bugs like recording.

  **With both fixes, the recording captures:**
  - READ channel: clean callee (bleg) audio — coach audio unmerged
  - WRITE channel: caller (aleg) + coach audio — preserves coach audio on one channel

  Coach audio appears exactly once in the recording — no duplication, no loss.

  **Test plan**

  - Build and deploy to test environment
  - Set up a call with eavesdrop (bridge_aleg=true, bridge_bleg=true, enable_dtmf=false)
  - Verify recording: coach audio on write channel only, not duplicated on both
  - Verify eavesdrop still works: coach can whisper/bridge to both parties in real-time
  - Test with two concurrent eavesdrop sessions on the same target — both coaches unmerged from read channel
