### PR TITLE
ENGDESK-49495: Restrict ICE auto-change to negotiated candidates only

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1681,29 +1681,36 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					channel = switch_core_session_get_channel(rtp_session->session);
 				}
 
-				ice->missed_count = 0;
-				ice->rready = 1;
-
-				if (cur_idx > -1) {
+				/* ENGDESK-49495: Only allow auto-change if source IP matches a known ICE candidate.
+				 * This prevents DTLS path mismatch when STUN arrives from an IP not in the negotiated SDP.
+				 * The STUN response is still sent (required by ICE), but we don't change the RTP/DTLS destination. */
+				if (cur_idx < 0) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+							"Skipping auto-change for %s stun/%s/dtls - source %s:%u is not a negotiated ICE candidate (current: %s:%u)\n",
+							rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp",
+							from_host, from_port, host2, port2);
+				} else {
+					ice->missed_count = 0;
+					ice->rready = 1;
 					ice->ice_params->chosen[ice->proto] = cur_idx;
+
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+							"Auto Changing %s stun/%s/dtls port from %s:%u to %s:%u idx:%d\n", rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp",
+							host2, port2,
+							from_host, from_port, cur_idx);
+
+					switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
+					switch_core_media_gen_key_frame(rtp_session->session);
+
+					switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
+
+					ice->cand_responsive = is_responsive;
+					if (ice->cand_responsive) {
+						ice->initializing = 0;
+					}
+
+					ice->last_ok = now;
 				}
-
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
-						"Auto Changing %s stun/%s/dtls port from %s:%u to %s:%u idx:%d\n", rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp",
-						host2, port2,
-						from_host, from_port, cur_idx);
-
-				switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
-				switch_core_media_gen_key_frame(rtp_session->session);
-
-				switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
-
-				ice->cand_responsive = is_responsive;
-				if (ice->cand_responsive) {
-					ice->initializing = 0;
-				}
-
-				ice->last_ok = now;
 			}
 
 			if (!switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED) || cmp || do_adj) {


### PR DESCRIPTION
## Summary

Restricts ICE auto-change to only accept STUN Binding Requests from known ICE candidates (from SDP or trickle ICE). STUN from unknown IPs will still receive a response (required by ICE RFC), but will not trigger a change of RTP/DTLS destination.

## Problem

A DTLS handshake failure occurred because:
1. Voice SDK sent STUN from a TURN relay IP (`64.16.248.199`) **not included in the SDP**
2. b2bua-rtc auto-changed RTP/DTLS destination to that IP
3. Voice SDK responded to DTLS from its direct/srflx IP (`102.218.8.246`)
4. DTLS handshake failed due to source IP mismatch (security requirement)

## Root Cause Analysis

The client's SDP only contained:
- `10.4.248.248:52332` (host - dropped by ACL)
- `102.218.8.246:52332` (srflx - chosen)

No relay candidate was negotiated, yet the client sent STUN from `64.16.248.199:60158` with valid ICE credentials.

## Fix

Before allowing auto-change, verify the STUN source IP matches a known candidate:
- If `cur_idx >= 0` (match found): proceed with auto-change
- If `cur_idx < 0` (no match): log warning, skip auto-change, still send STUN response

## Testing

- [x] Verified fix prevents auto-change from unknown IPs
- [ ] Verify existing network reconnection scenarios still work (ENGDESK-48822)

## Related

- Fixes: [ENGDESK-49495](https://telnyx.atlassian.net/browse/ENGDESK-49495)
- Related: [ENGDESK-48822](https://telnyx.atlassian.net/browse/ENGDESK-48822) (original auto-change feature)

[ENGDESK-49495]: https://telnyx.atlassian.net/browse/ENGDESK-49495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ