### PR TITLE
TEL-6515: Fix race condition in codec destruction during session teardown.

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -2427,13 +2427,17 @@ SWITCH_DECLARE(void) switch_media_handle_destroy(switch_core_session_t *session)
 		switch_core_timer_destroy(&smh->video_timer);
 	}
 
+	switch_mutex_lock(session->codec_read_mutex);
 	if (switch_core_codec_ready(&a_engine->read_codec)) {
 		switch_core_codec_destroy(&a_engine->read_codec);
 	}
+	switch_mutex_unlock(session->codec_read_mutex);
 
+	switch_mutex_lock(session->codec_write_mutex);
 	if (switch_core_codec_ready(&a_engine->write_codec)) {
 		switch_core_codec_destroy(&a_engine->write_codec);
 	}
+	switch_mutex_unlock(session->codec_write_mutex);
 
 	if (switch_core_codec_ready(&v_engine->read_codec)) {
 		switch_core_codec_destroy(&v_engine->read_codec);


### PR DESCRIPTION
Hold codec_read_mutex and codec_write_mutex while destroying audio codecs in switch_media_handle_destroy to prevent race with read_frame/write_frame.

Without this fix, switch_core_codec_destroy can zero the codec struct (including its mutex) while another thread is still accessing it in switch_core_session_read_frame or switch_core_session_write_frame.