### PR TITLE
ENGDESK-49417: Fix CF_AVPF not set for RTP/SAVPF offers

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -7072,6 +7072,9 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 		if (m->m_proto == sdp_proto_extended_srtp || m->m_proto == sdp_proto_extended_rtp) {
 			got_webrtc++;
 			switch_core_session_set_ice(session);
+			/* Set CF_AVPF early for SAVPF/AVPF offers.
+			 * set_ice() may not set it if DTLS is not yet parsed. */
+			switch_channel_set_flag(session->channel, CF_AVPF);
 		}
 
 		if (m->m_proto == sdp_proto_srtp || m->m_proto == sdp_proto_extended_srtp) {


### PR DESCRIPTION
## Problem

Inbound WebRTC calls to b2bua-rtc fail with `INCOMPATIBLE_DESTINATION` because the 200 OK SDP has `m=audio 0 RTP/SAVPF 19` (rejected audio).

## Root Cause

When the remote SDP uses `RTP/SAVPF` (not `UDP/TLS/RTP/SAVPF`), `CF_AVPF` was never set on the channel. `switch_core_session_set_ice()` only sets `CF_AVPF` when `switch_core_media_has_crypto()` returns true, but at the point in SDP parsing where `set_ice()` is called, `CF_DTLS` has not been set yet (fingerprint parsing happens later in the same loop), and `CF_AVPF_MOZ` is only set for `UDP/TLS/RTP/SAVPF`.

This caused the local SDP to use `RTP/SAVP` instead of `RTP/SAVPF`, and SOA rejected the audio stream due to the offer/answer profile mismatch.

## Fix

Set `CF_AVPF` unconditionally when `m->m_proto` is `sdp_proto_extended_srtp` or `sdp_proto_extended_rtp`, since these protocols inherently indicate AVPF capability. The flag is idempotent (bitwise OR), so no issue if `set_ice()` also sets it later.

Jira: ENGDESK-49417