### PR TITLE
TEL-6778: Fix handle_update channel variable scope to be per-session

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -7111,7 +7111,7 @@ static void sofia_handle_sip_r_invite(switch_core_session_t *session, int status
 		}
 
 		if (status > 180 && to_handle_update) {
-			nua_set_params(nua, NUTAG_APPL_METHOD("UPDATE"), TAG_END());
+			nua_set_hparams(nh, NUTAG_APPL_METHOD("UPDATE"), TAG_END());
 		}
 
 		if (status == 100 && !sofia_test_flag(tech_pvt, TFLAG_100_UEPOCH_SET)) {
@@ -11636,7 +11636,7 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 		to_handle_update = sofia_test_pflag(profile, PFLAG_HANDLE_UPDATE);
 	}
 	if (to_handle_update) {
-		nua_set_params(nua, NUTAG_APPL_METHOD("UPDATE"), TAG_END());
+		nua_set_hparams(nh, NUTAG_APPL_METHOD("UPDATE"), TAG_END());
 	}
 
 	switch_channel_set_variable_printf(channel, "sip_local_network_addr", "%s", profile->extsipip ? profile->extsipip : profile->sipip);


### PR DESCRIPTION
## Problem

The `handle_update` channel variable is intended to control UPDATE handling per-session, but it was modifying the NUA agent (profile-wide) instead of the NUA handle (per-dialog).

When any session set `handle_update=true`, it called `nua_set_params(nua, NUTAG_APPL_METHOD("UPDATE"))` which applied `APPL_METHOD("UPDATE")` globally to the entire sofia profile. This caused:

- All sessions on the profile to receive `nua_i_update` callbacks, not just the intended session
- No reversal — once set, the flag persisted even after the originating session hung up
- Unexpected UPDATE handling failures for sessions without the channel variable set

## Fix

Replace `nua_set_params(nua, ...)` with `nua_set_hparams(nh, ...)` in both locations:

- `sofia_handle_sip_r_invite()` — response handler (status > 180)
- `sofia_handle_sip_i_invite()` — incoming INVITE handler

`nua_set_hparams()` sets `NUTAG_APPL_METHOD("UPDATE")` on the nua **handle** (per-dialog/per-session) instead of the nua **agent** (per-profile). libsofia-sip's `nua_handle_preferences_t` already supports `nhp_appl_method` at handle level.