### PR TITLE
TEL-6784: Fix handle_update responding with SDP to SDP-less UPDATE in 3PCC

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -9773,6 +9773,8 @@ void sofia_handle_sip_i_update(nua_t *nua, sofia_profile_t *profile, nua_handle_
 					return;
 				}
 			}
+		} else {
+			has_valid_sdp = SWITCH_FALSE;
 		}
 	}
 


### PR DESCRIPTION
## Problem

When processing a SIP UPDATE without SDP in a 3PCC (Third Party Call Control) scenario, FreeSWITCH responds with a 200 OK containing stale SDP from the original session negotiation. The UAS interprets this as a media renegotiation and terminates the call.

## Root Cause

In `sofia_handle_sip_i_update()`, `has_valid_sdp` is initialized to `SWITCH_TRUE` but never set to `SWITCH_FALSE` when the incoming UPDATE has no SDP payload. The `TAG_IF(has_valid_sdp, ...)` guards in the response path then include stale SDP in the 200 OK.

## Fix

Set `has_valid_sdp = SWITCH_FALSE` when the UPDATE contains no SDP, so the 200 OK is sent without a SDP body. This complies with RFC 3311 Section 4.1 — if an UPDATE contains no offer, the response MUST NOT contain an offer.

## Testing

- UPDATE without SDP in 3PCC scenario → 200 OK without SDP (no call termination)
- UPDATE with SDP → existing behavior unchanged (200 OK with negotiated SDP)
- UPDATE with duplicate SDP → existing behavior unchanged (200 OK with current SDP)