### PR TITLE
TEL-6860: Trigger b2bua builder on every code change

### DIFF
--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
       - name: Delete branch in downstream repos
-        if: github.event_name == 'delete' && github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'deploy-') || startsWith(github.event.ref, 'release-') || startsWith(github.event.ref, 'telnyx/telephony/deploy-') || startsWith(github.event.ref, 'telnyx/telephony/release-'))
+        if: github.event_name == 'delete' && github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'deploy-') || startsWith(github.event.ref, 'release-') || startsWith(github.event.ref, 'telnyx/telephony/deploy-') || startsWith(github.event.ref, 'telnyx/telephony/release-')) && github.event.ref != 'deploy-development'
         env:
           GH_TOKEN: ${{ secrets.GIT_TOKEN }}
           RAW_BRANCH: ${{ github.event.ref }}

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -21,6 +21,39 @@ jobs:
   trigger:
     runs-on: telnyx-small
     steps:
+      - name: Create branch in downstream repos
+        env:
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.ref_name }}"
+          # Strip telnyx/telephony/ prefix — downstream branches use the short form
+          BRANCH="${BRANCH#telnyx/telephony/}"
+          ORG="team-telnyx"
+          SOURCE="${{ github.event.repository.name }}"
+
+          # Determine targets
+          TARGETS=("telnyx_b2bua_builder")
+          if [ "$SOURCE" = "mod_telnyx_rtc" ]; then
+            TARGETS+=("b2bua-rtc")
+          else
+            TARGETS+=("b2bua")
+          fi
+
+          for target in "${TARGETS[@]}"; do
+            # Get default branch SHA
+            DEFAULT=$(gh api "repos/$ORG/$target" --jq '.default_branch')
+            SHA=$(gh api "repos/$ORG/$target/git/ref/heads/$DEFAULT" --jq '.object.sha')
+
+            # Create branch (ignore error if already exists)
+            if gh api "repos/$ORG/$target/git/refs" \
+                 -f "ref=refs/heads/$BRANCH" \
+                 -f "sha=$SHA" 2>/dev/null; then
+              echo "✅ Created $BRANCH in $target"
+            else
+              echo "ℹ️ Branch $BRANCH may already exist in $target (skipped)"
+            fi
+          done
       - name: Trigger upstream build
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -1,0 +1,44 @@
+name: Trigger telnyx_b2bua_builder
+on:
+  push:
+    branches:
+      - master
+      - main
+      - deploy-*
+      - release-*
+      - telnyx/telephony/deploy-*
+      - telnyx/telephony/release-*
+  pull_request:
+    branches:
+      - telnyx/telephony/master
+      - telnyx/telephony/main
+      - telnyx/telephony/deploy-*
+      - telnyx/telephony/release-*
+      - deploy-*
+      - release-*
+
+jobs:
+  trigger:
+    runs-on: telnyx-small
+    steps:
+      - name: Trigger upstream build
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GIT_TOKEN }}
+          script: |
+            const rawBranch = context.eventName === 'pull_request'
+              ? context.payload.pull_request.head.ref
+              : context.ref.replace('refs/heads/', '');
+            // Strip telnyx/telephony/ prefix — builder branches use the short form (e.g. deploy-tel-1234)
+            const branchName = rawBranch.replace('telnyx/telephony/', '');
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'team-telnyx',
+              repo: 'telnyx_b2bua_builder',
+              event_type: 'upstream-build',
+              client_payload: {
+                branch: branchName,
+                source_repo: context.repo.repo,
+                run_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              }
+            });

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: telnyx-small
     steps:
       - name: Trigger upstream build
         uses: actions/github-script@v6

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: telnyx-small
     steps:
       - name: Create branch in downstream repos
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && (startsWith(github.ref_name, 'deploy-') || startsWith(github.ref_name, 'release-') || startsWith(github.ref_name, 'telnyx/telephony/deploy-') || startsWith(github.ref_name, 'telnyx/telephony/release-'))
         env:
           GH_TOKEN: ${{ secrets.GIT_TOKEN }}
           RAW_BRANCH: ${{ github.ref_name }}
@@ -32,34 +32,34 @@ jobs:
           set -euo pipefail
           BRANCH="${RAW_BRANCH#telnyx/telephony/}"
           ORG="team-telnyx"
-
-          # Determine targets
-          TARGETS=("telnyx_b2bua_builder")
-          if [ "$SOURCE" = "mod_telnyx_rtc" ]; then
-            TARGETS+=("b2bua-rtc")
-          else
-            TARGETS+=("b2bua")
-          fi
+          TARGETS=("telnyx_b2bua_builder" "b2bua" "b2bua-rtc")
+          ERRORS=0
 
           for target in "${TARGETS[@]}"; do
-            # Get default branch SHA
             DEFAULT=$(gh api "repos/$ORG/$target" --jq '.default_branch')
             SHA=$(gh api "repos/$ORG/$target/git/ref/heads/$DEFAULT" --jq '.object.sha')
 
-            # Create branch — log result either way
-            HTTP_CODE=$(gh api "repos/$ORG/$target/git/refs" \
-                 -f "ref=refs/heads/$BRANCH" \
-                 -f "sha=$SHA" \
-                 --silent -i 2>&1 | head -1 | awk '{print $2}') || true
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"ref\":\"refs/heads/$BRANCH\",\"sha\":\"$SHA\"}" \
+              "https://api.github.com/repos/$ORG/$target/git/refs")
 
             if [ "$HTTP_CODE" = "201" ]; then
-              echo "✅ [$SOURCE] Created $BRANCH in $target"
+              echo "Created $BRANCH in $target"
             elif [ "$HTTP_CODE" = "422" ]; then
-              echo "ℹ️ [$SOURCE] Branch $BRANCH already exists in $target (skipped)"
+              echo "Branch $BRANCH already exists in $target (skipped)"
             else
-              echo "⚠️ [$SOURCE] Failed to create $BRANCH in $target (HTTP $HTTP_CODE)"
+              echo "Failed to create $BRANCH in $target (HTTP $HTTP_CODE)"
+              ERRORS=$((ERRORS + 1))
             fi
           done
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "$ERRORS branch creation(s) failed -- blocking dispatch"
+            exit 1
+          fi
       - name: Delete branch in downstream repos
         if: github.event_name == 'delete' && github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'deploy-') || startsWith(github.event.ref, 'release-') || startsWith(github.event.ref, 'telnyx/telephony/deploy-') || startsWith(github.event.ref, 'telnyx/telephony/release-'))
         env:
@@ -70,26 +70,20 @@ jobs:
           set -euo pipefail
           BRANCH="${RAW_BRANCH#telnyx/telephony/}"
           ORG="team-telnyx"
-
-          # Determine targets (same routing as creation)
-          TARGETS=("telnyx_b2bua_builder")
-          if [ "$SOURCE" = "mod_telnyx_rtc" ]; then
-            TARGETS+=("b2bua-rtc")
-          else
-            TARGETS+=("b2bua")
-          fi
+          TARGETS=("telnyx_b2bua_builder" "b2bua" "b2bua-rtc")
 
           for target in "${TARGETS[@]}"; do
-            HTTP_CODE=$(gh api "repos/$ORG/$target/git/refs/heads/$BRANCH" \
-                 -X DELETE \
-                 --silent -i 2>&1 | head -1 | awk '{print $2}') || true
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X DELETE \
+              -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/$ORG/$target/git/refs/heads/$BRANCH")
 
             if [ "$HTTP_CODE" = "204" ]; then
-              echo "🗑️ [$SOURCE] Deleted $BRANCH from $target"
+              echo "Deleted $BRANCH from $target"
             elif [ "$HTTP_CODE" = "422" ] || [ "$HTTP_CODE" = "404" ]; then
-              echo "ℹ️ [$SOURCE] Branch $BRANCH not found in $target (already deleted or never existed)"
+              echo "Branch $BRANCH not found in $target (already deleted or never existed)"
             else
-              echo "⚠️ [$SOURCE] Failed to delete $BRANCH from $target (HTTP $HTTP_CODE)"
+              echo "Failed to delete $BRANCH from $target (HTTP $HTTP_CODE)"
             fi
           done
       - name: Trigger upstream build
@@ -101,7 +95,7 @@ jobs:
             const rawBranch = context.eventName === 'pull_request'
               ? context.payload.pull_request.head.ref
               : context.ref.replace('refs/heads/', '');
-            // Strip telnyx/telephony/ prefix — builder branches use the short form (e.g. deploy-tel-1234)
+            // Strip telnyx/telephony/ prefix -- builder branches use the short form (e.g. deploy-tel-1234)
             const branchName = rawBranch.replace('telnyx/telephony/', '');
 
             await github.rest.repos.createDispatchEvent({

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: telnyx-small
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger upstream build
         uses: actions/github-script@v6

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -8,6 +8,7 @@ on:
       - release-*
       - telnyx/telephony/deploy-*
       - telnyx/telephony/release-*
+  delete:
   pull_request:
     branches:
       - telnyx/telephony/master
@@ -59,7 +60,40 @@ jobs:
               echo "⚠️ [$SOURCE] Failed to create $BRANCH in $target (HTTP $HTTP_CODE)"
             fi
           done
+      - name: Delete branch in downstream repos
+        if: github.event_name == 'delete' && github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'deploy-') || startsWith(github.event.ref, 'release-') || startsWith(github.event.ref, 'telnyx/telephony/deploy-') || startsWith(github.event.ref, 'telnyx/telephony/release-'))
+        env:
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+          RAW_BRANCH: ${{ github.event.ref }}
+          SOURCE: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          BRANCH="${RAW_BRANCH#telnyx/telephony/}"
+          ORG="team-telnyx"
+
+          # Determine targets (same routing as creation)
+          TARGETS=("telnyx_b2bua_builder")
+          if [ "$SOURCE" = "mod_telnyx_rtc" ]; then
+            TARGETS+=("b2bua-rtc")
+          else
+            TARGETS+=("b2bua")
+          fi
+
+          for target in "${TARGETS[@]}"; do
+            HTTP_CODE=$(gh api "repos/$ORG/$target/git/refs/heads/$BRANCH" \
+                 -X DELETE \
+                 --silent -i 2>&1 | head -1 | awk '{print $2}') || true
+
+            if [ "$HTTP_CODE" = "204" ]; then
+              echo "🗑️ [$SOURCE] Deleted $BRANCH from $target"
+            elif [ "$HTTP_CODE" = "422" ] || [ "$HTTP_CODE" = "404" ]; then
+              echo "ℹ️ [$SOURCE] Branch $BRANCH not found in $target (already deleted or never existed)"
+            else
+              echo "⚠️ [$SOURCE] Failed to delete $BRANCH from $target (HTTP $HTTP_CODE)"
+            fi
+          done
       - name: Trigger upstream build
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/trigger-b2bua-builder.yml
+++ b/.github/workflows/trigger-b2bua-builder.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: telnyx-small
     steps:
       - name: Create branch in downstream repos
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+          RAW_BRANCH: ${{ github.ref_name }}
+          SOURCE: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
-          BRANCH="${{ github.ref_name }}"
-          # Strip telnyx/telephony/ prefix — downstream branches use the short form
-          BRANCH="${BRANCH#telnyx/telephony/}"
+          BRANCH="${RAW_BRANCH#telnyx/telephony/}"
           ORG="team-telnyx"
-          SOURCE="${{ github.event.repository.name }}"
 
           # Determine targets
           TARGETS=("telnyx_b2bua_builder")
@@ -45,13 +45,18 @@ jobs:
             DEFAULT=$(gh api "repos/$ORG/$target" --jq '.default_branch')
             SHA=$(gh api "repos/$ORG/$target/git/ref/heads/$DEFAULT" --jq '.object.sha')
 
-            # Create branch (ignore error if already exists)
-            if gh api "repos/$ORG/$target/git/refs" \
+            # Create branch — log result either way
+            HTTP_CODE=$(gh api "repos/$ORG/$target/git/refs" \
                  -f "ref=refs/heads/$BRANCH" \
-                 -f "sha=$SHA" 2>/dev/null; then
-              echo "✅ Created $BRANCH in $target"
+                 -f "sha=$SHA" \
+                 --silent -i 2>&1 | head -1 | awk '{print $2}') || true
+
+            if [ "$HTTP_CODE" = "201" ]; then
+              echo "✅ [$SOURCE] Created $BRANCH in $target"
+            elif [ "$HTTP_CODE" = "422" ]; then
+              echo "ℹ️ [$SOURCE] Branch $BRANCH already exists in $target (skipped)"
             else
-              echo "ℹ️ Branch $BRANCH may already exist in $target (skipped)"
+              echo "⚠️ [$SOURCE] Failed to create $BRANCH in $target (HTTP $HTTP_CODE)"
             fi
           done
       - name: Trigger upstream build


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to `freeswitch` that automatically triggers the `telnyx_b2bua_builder` whenever code is pushed to tracked branches. This ensures a new b2bua deb package is built whenever FreeSWITCH changes.

## Tracked Branches

\`\`\`yaml
push / pull_request:
  branches:
    - master
    - main
    - deploy-*
    - release-*
    - telnyx/telephony/deploy-*
    - telnyx/telephony/release-*
\`\`\`

Note: FreeSWITCH uses `telnyx/telephony/` prefixed branch names (e.g. `telnyx/telephony/deploy-tel-1234`), while the builder and other module repos use the short form (`deploy-tel-1234`).

## Branch Name Translation

The workflow strips the `telnyx/telephony/` prefix before sending to the builder, so the builder receives the correct short branch name:

\`\`\`javascript
const rawBranch = context.eventName === 'pull_request'
  ? context.payload.pull_request.head.ref
  : context.ref.replace('refs/heads/', '');
// Strip telnyx/telephony/ prefix — builder branches use the short form (e.g. deploy-tel-1234)
const branchName = rawBranch.replace('telnyx/telephony/', '');
\`\`\`

So `telnyx/telephony/deploy-tel-1234` → builder receives `deploy-tel-1234`, which matches the builder's branch and the `FS_BRANCH=telnyx/telephony/deploy-tel-1234` the Makefile constructs.

## How It Works

Sends a `repository_dispatch` event (`upstream-build`) to `telnyx_b2bua_builder` with the branch name in `client_payload.branch`. The builder checks out that branch and builds the deb package.

## Authentication

Uses `GIT_TOKEN` (org-level PAT with `repo` scope). `github.token` was confirmed to return `404` for cross-repo dispatch. `workflow_dispatch` was also attempted but fails with `Resource not accessible by personal access token` (token lacks `actions:write` on the builder repo).

## Runner

Uses `telnyx-small`. Note: the original freeswitch PR (#525) had the runner stuck in `QUEUED` for 19+ hours — this was a temporary runner availability issue for the `freeswitch` repo, not a code problem.

## Related PRs

- `telnyx_b2bua_builder` → https://github.com/team-telnyx/telnyx_b2bua_builder/pull/133 (must be merged to master first for upstream triggers to checkout the correct branch)
- `mod_telnyx` → https://github.com/team-telnyx/mod_telnyx/pull/57