### PR TITLE
TEL-6830: Suppress Q.850 Reason header when SIP Reason exists from dialplan

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -537,9 +537,15 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 			if ((val = switch_channel_get_variable(tech_pvt->channel, "sip_reason"))) {
 				reason = switch_core_session_sprintf(session, "%s", val);
 			} else {
-				/* TEL-6830: Check partner channel for SIP-protocol Reason header */
-				val = switch_channel_get_variable_partner(channel, "sip_reason");
-				if (!zstr(val) && !strncasecmp(val, "SIP;", 4)) {
+				/* TEL-6830: Copy partner sip_reason only for Network Blocked (D52 scenario, matching TEL-6811 pattern) */
+				val = NULL;
+				{
+					const char *partner_phrase = switch_channel_get_variable_partner(channel, "sip_hangup_phrase");
+					if (!zstr(partner_phrase) && !strcasecmp(partner_phrase, "Network Blocked")) {
+						val = switch_channel_get_variable_partner(channel, "sip_reason");
+					}
+				}
+				if (!zstr(val)) {
 					switch_channel_set_variable(channel, "sip_reason", val);
 					reason = switch_core_session_sprintf(session, "%s", val);
 				} else if ((switch_channel_test_flag(channel, CF_INTERCEPT) || cause == SWITCH_CAUSE_PICKED_OFF || cause == SWITCH_CAUSE_LOSE_RACE)

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -537,17 +537,14 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 			if ((val = switch_channel_get_variable(tech_pvt->channel, "sip_reason"))) {
 				reason = switch_core_session_sprintf(session, "%s", val);
 			} else {
-				/* TEL-6830: Copy partner sip_reason only for Network Blocked (D52 scenario, matching TEL-6811 pattern) */
-				val = NULL;
-				{
-					const char *partner_phrase = switch_channel_get_variable_partner(channel, "sip_hangup_phrase");
-					if (!zstr(partner_phrase) && !strcasecmp(partner_phrase, "Network Blocked")) {
-						val = switch_channel_get_variable_partner(channel, "sip_reason");
-					}
+				/* TEL-6830: Check if dialplan explicitly suppressed Q.850 Reason header */
+				const char *no_q850 = switch_channel_get_variable(channel, "sip_no_q850_reason");
+				if (!switch_true(no_q850)) {
+					no_q850 = switch_channel_get_variable_partner(channel, "sip_no_q850_reason");
 				}
-				if (!zstr(val)) {
-					switch_channel_set_variable(channel, "sip_reason", val);
-					reason = switch_core_session_sprintf(session, "%s", val);
+				if (switch_true(no_q850)) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+						"TEL-6830: Q.850 Reason suppressed by sip_no_q850_reason variable\n");
 				} else if ((switch_channel_test_flag(channel, CF_INTERCEPT) || cause == SWITCH_CAUSE_PICKED_OFF || cause == SWITCH_CAUSE_LOSE_RACE)
 					&& !switch_true(switch_channel_get_variable(channel, "ignore_completed_elsewhere"))) {
 					reason = switch_core_session_sprintf(session, "SIP;cause=200;text=\"Call completed elsewhere\"");

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -537,7 +537,12 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 			if ((val = switch_channel_get_variable(tech_pvt->channel, "sip_reason"))) {
 				reason = switch_core_session_sprintf(session, "%s", val);
 			} else {
-				if ((switch_channel_test_flag(channel, CF_INTERCEPT) || cause == SWITCH_CAUSE_PICKED_OFF || cause == SWITCH_CAUSE_LOSE_RACE)
+				/* TEL-6830: Check partner channel for SIP-protocol Reason header */
+				val = switch_channel_get_variable_partner(channel, "sip_reason");
+				if (!zstr(val) && !strncasecmp(val, "SIP;", 4)) {
+					switch_channel_set_variable(channel, "sip_reason", val);
+					reason = switch_core_session_sprintf(session, "%s", val);
+				} else if ((switch_channel_test_flag(channel, CF_INTERCEPT) || cause == SWITCH_CAUSE_PICKED_OFF || cause == SWITCH_CAUSE_LOSE_RACE)
 					&& !switch_true(switch_channel_get_variable(channel, "ignore_completed_elsewhere"))) {
 					reason = switch_core_session_sprintf(session, "SIP;cause=200;text=\"Call completed elsewhere\"");
 				} else if ((cause > 0 && cause < 128) || switch_channel_is_custom_q850_code(cause)) {


### PR DESCRIPTION
## Problem
For OB calls rejected by Dialplan with D52 603 Network Blocked, the A-leg receives two Reason headers:
- `Reason: SIP;cause=603` (from dialplan — correct)
- `Reason: Q.850;cause=17` (from B2BUA hangup — incorrect duplicate)

Per Rogelio's request: only the SIP Reason header should appear on the A-leg.

## Fix
In `sofia_on_hangup()`, before generating the Q.850 Reason header fallback, check if the partner channel (B-leg) already has a SIP-protocol Reason header set. If so, copy it to the A-leg channel, which prevents the Q.850 fallback from triggering.

## Testing
- OB call rejected with D52 603 Network Blocked should have ONLY `Reason: SIP;cause=603` on A-leg
- Normal calls without dialplan SIP Reason should still get Q.850 Reason as before (no regression)

Jira: https://telnyx.atlassian.net/browse/TEL-6830