### PR TITLE
ENGDESK-50102: Sync encoder mode with configured mode-set

### DIFF
--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -418,6 +418,17 @@ static switch_status_t switch_amrwb_init(switch_codec_t *codec, switch_codec_fla
 
 				fmtptmp_pos = switch_snprintf(fmtptmp, sizeof(fmtptmp), "mode-set=%s", modes);
 			}
+
+			/* When carrier omits mode-set, sync enc_mode with configured mode-set
+			 * so the encoder does not exceed the modes advertised in our answer SDP. */
+			if (globals.context.enc_modes) {
+				for (i = SWITCH_AMRWB_MODES-2; i > -1; i--) {
+					if (globals.context.enc_modes & (1 << i)) {
+						context->enc_mode = (switch_byte_t) i;
+						break;
+					}
+				}
+			}
 		}
 
 		if (globals.adjust_bitrate) {


### PR DESCRIPTION
### Problem

When the remote party's SDP offer **does not** include `mode-set` in the AMR-WB fmtp, `mod_amrwb` puts the configured `mode-set=0,1,2` in the answer SDP but leaves the encoder at the hardcoded default mode 8 (23.85 kbps). This causes the B2BUA to send AMR-WB frames outside the advertised mode-set, leading to choppy/distorted audio on the carrier side.

### Root Cause

In `switch_amrwb_init()`, when the carrier omits `mode-set`:

1. `context->enc_mode` is set to `globals.default_bitrate` = mode 8 (hardcoded `AMRWB_BITRATE_24K`)
2. The `else` branch builds `mode-set=0,1,2` for the answer SDP from `globals.context.enc_modes` (XML config)
3. **`context->enc_mode` is never updated** to match — it stays at mode 8

When the carrier *does* include `mode-set` in its offer, a different code path correctly selects the highest offered mode. The bug only affects carriers that omit `mode-set`.

### Evidence (from pcap analysis)

| Stream | Direction | AMR-WB Mode | Expected |
|--------|-----------|-------------|----------|
| Inbound | Carrier → B2BUA | FT=2 (mode 2, 12.65 kbps) ✅ | Carrier honors answer SDP `mode-set=0,1,2` |
| Outbound | B2BUA → Carrier | FT=8 (mode 8, 23.85 kbps) ❌ | Should be mode 2 per SDP |

### Fix

After building the `mode-set` string for the answer SDP in the `else` branch, set `context->enc_mode` to the highest mode in the configured mode-set (`globals.context.enc_modes`). This ensures the encoder matches the advertised SDP.

### Impact

- **Low risk** — only affects the code path where the carrier omits `mode-set` in its offer
- No behavior change for calls where the carrier includes `mode-set` (existing code path handles this correctly)
- Encoder output now matches the SDP answer

### Testing

- Verified with `amrwb_debug` enabled: encoder should now output FT=2 (mode 2) instead of FT=8 when `mode-set=0,1,2` is configured and carrier omits `mode-set`

---

Target: `telnyx/telephony/deploy-development`