### PR TITLE
TEL-6560: Fix recording thread deadlock during session teardown

### DIFF
--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -38,6 +38,10 @@
 #include <speex/speex_preprocess.h>
 #include <speex/speex_echo.h>
 
+/* Timeout in microseconds for recording thread condition waits.
+   Allows periodic re-check of channel state to avoid deadlock during session teardown. */
+#define RECORDING_THREAD_COND_TIMEOUT_US 1000000
+
 struct switch_ivr_dmachine_binding {
 	char *digits;
 	char *repl;
@@ -1428,7 +1432,7 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 
 			if (switch_core_session_read_lock(rh->recording_session) != SWITCH_STATUS_SUCCESS) {
 				/* Wait until recording is reverted to the original session */
-				switch_thread_cond_wait(rh->cond, rh->cond_mutex);
+				switch_thread_cond_timedwait(rh->cond, rh->cond_mutex, RECORDING_THREAD_COND_TIMEOUT_US);
 				continue;
 			}
 
@@ -1463,7 +1467,7 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 		if (!inuse) {
 			switch_mutex_unlock(rh->buffer_mutex);
 			if (rh->thread_ready) {
-				switch_thread_cond_wait(rh->cond, rh->cond_mutex);
+				switch_thread_cond_timedwait(rh->cond, rh->cond_mutex, RECORDING_THREAD_COND_TIMEOUT_US);
 			}
 			continue;
 		}


### PR DESCRIPTION
## Problem

The recording thread in `switch_ivr_async.c` uses `switch_thread_cond_wait()` to block while waiting for data or session transfer completion. During session teardown, this can deadlock: the recording thread holds a session read lock and blocks indefinitely on `cond_wait`, while the teardown path needs that lock to proceed and would signal the condition variable — creating a circular dependency.

## Fix

Replace both `switch_thread_cond_wait()` calls in `recording_thread()` with `switch_thread_cond_timedwait()` using a 1-second timeout. This allows the thread to periodically re-check channel state (`switch_channel_down_nosig`) and exit cleanly when the session is being torn down, releasing the read lock.

A `RECORDING_THREAD_COND_TIMEOUT_US` macro is introduced for the timeout value to allow easy tuning.

## Changes

- `src/switch_ivr_async.c`: Add `RECORDING_THREAD_COND_TIMEOUT_US` macro (1s), replace two `cond_wait` → `cond_timedwait` calls in `recording_thread()`

## Testing

- Verify recording works normally (no behavioral change under normal conditions — timedwait just adds a periodic wakeup)
- Verify sessions with active recordings tear down cleanly without hanging