### PR TITLE
TEL-6718: Fix transfer_extension CRIT log spam in switch_channel.c:1580

### DIFF
--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -2361,11 +2361,15 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_session_transfer(switch_core_session_
 		switch_channel_add_variable_var_check(channel, SWITCH_TRANSFER_HISTORY_VARIABLE, new_profile->transfer_source, SWITCH_FALSE, SWITCH_STACK_PUSH);
 		switch_channel_set_variable_var_check(channel, SWITCH_TRANSFER_SOURCE_VARIABLE, new_profile->transfer_source, SWITCH_FALSE);
 		
-		/* Set flag to indicate transfer is in progress and store transfer details */
+		/* Set flag to indicate transfer is in progress and store transfer details.
+		 * Use SWITCH_FALSE for var_check since these values are stored as-is for
+		 * transfer event tracking. The extension may legitimately contain unexpanded
+		 * variable references (e.g. from ESL uuid_transfer commands) which would
+		 * otherwise trigger CRIT logs at switch_channel.c:1580 (TEL-6718). */
 		switch_channel_set_variable(channel, "transfer_in_progress", "true");
-		switch_channel_set_variable(channel, "transfer_extension", extension);
-		switch_channel_set_variable(channel, "transfer_dialplan", use_dialplan);
-		switch_channel_set_variable(channel, "transfer_context", use_context);
+		switch_channel_set_variable_var_check(channel, "transfer_extension", extension, SWITCH_FALSE);
+		switch_channel_set_variable_var_check(channel, "transfer_dialplan", use_dialplan, SWITCH_FALSE);
+		switch_channel_set_variable_var_check(channel, "transfer_context", use_context, SWITCH_FALSE);
 		
 		/* Also set global variables that will be inherited by originated channels */
 		switch_core_set_variable("transfer_originating_uuid", switch_core_session_get_uuid(session));


### PR DESCRIPTION
## Problem

The ENGDESK-43915 commit (6d3c0ea) added transfer event tracking in switch_ivr_session_transfer() using switch_channel_set_variable(), which defaults to var_check=SWITCH_TRUE.

When the transfer extension contains unexpanded ${...} references (e.g. from ESL uuid_transfer commands where variables aren't expanded), switch_string_var_check_const() detects the pattern and logs a CRIT at switch_channel.c:1580:

```
[CRIT] switch_channel.c:1580 Invalid data (${transfer_extension} contains a variable)
```

This accounts for **97.67% of all CRIT logs** in b2bua — massive log noise that obscures real issues.

## Root Cause

switch_channel_set_variable() is a macro that expands to switch_channel_set_variable_var_check(..., SWITCH_TRUE). The var_check validates that the VALUE being set doesn't contain ${...} patterns. When it does, it refuses to set the variable and logs CRIT.

The transfer tracking variables (transfer_extension, transfer_dialplan, transfer_context) are purely informational — stored for transfer event tracking. They don't need variable content validation.

## Fix

Use switch_channel_set_variable_var_check() with SWITCH_FALSE for the three transfer tracking variables. This is consistent with the existing pattern on the lines immediately above:
```c
switch_channel_set_variable_var_check(channel, SWITCH_TRANSFER_SOURCE_VARIABLE, new_profile->transfer_source, SWITCH_FALSE);
```

## Risk Assessment

**Very low risk:**
- Only affects transfer event tracking variables, not call flow logic
- The transfer_in_progress flag (set to literal "true") still uses the default var_check since it can't contain ${}
- The underlying transfer operation (destination_number, caller_profile, routing) is unaffected — those are set via switch_core_strdup() without var_check
- Follows the same pattern already used for SWITCH_TRANSFER_SOURCE_VARIABLE and SWITCH_TRANSFER_HISTORY_VARIABLE

## Test Plan

1. Trigger a transfer via ESL with an extension containing ${...}: uuid_transfer <uuid> ${some_var}
2. Verify no CRIT log at switch_channel.c:1580
3. Verify the transfer::complete / transfer::failed events still fire with correct data
4. Monitor CRIT log volume after deployment — expect ~97.67% reduction

## Jira

https://telnyx.atlassian.net/browse/TEL-6718

*— 🦀 Analysis by Council of Claws (Dev)*