### PR TITLE
TEL-6718: Fix transfer_extension CRIT log spam in switch_channel.c:1580

### DIFF
--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -2365,11 +2365,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_session_transfer(switch_core_session_
 		 * Use SWITCH_FALSE for var_check since these values are stored as-is for
 		 * transfer event tracking. The extension may legitimately contain unexpanded
 		 * variable references (e.g. from ESL uuid_transfer commands) which would
-		 * otherwise trigger CRIT logs at switch_channel.c:1580 (TEL-6718). */
+		 * otherwise trigger CRIT logs at switch_channel.c:1580 . */
 		switch_channel_set_variable(channel, "transfer_in_progress", "true");
 		switch_channel_set_variable_var_check(channel, "transfer_extension", extension, SWITCH_FALSE);
-		switch_channel_set_variable_var_check(channel, "transfer_dialplan", use_dialplan, SWITCH_FALSE);
-		switch_channel_set_variable_var_check(channel, "transfer_context", use_context, SWITCH_FALSE);
+		switch_channel_set_variable(channel, "transfer_dialplan", use_dialplan);
+		switch_channel_set_variable(channel, "transfer_context", use_context);
 		
 		/* Also set global variables that will be inherited by originated channels */
 		switch_core_set_variable("transfer_originating_uuid", switch_core_session_get_uuid(session));

--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -2361,11 +2361,15 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_session_transfer(switch_core_session_
 		switch_channel_add_variable_var_check(channel, SWITCH_TRANSFER_HISTORY_VARIABLE, new_profile->transfer_source, SWITCH_FALSE, SWITCH_STACK_PUSH);
 		switch_channel_set_variable_var_check(channel, SWITCH_TRANSFER_SOURCE_VARIABLE, new_profile->transfer_source, SWITCH_FALSE);
 		
-		/* Set flag to indicate transfer is in progress and store transfer details */
+		/* Set flag to indicate transfer is in progress and store transfer details.
+		 * Use SWITCH_FALSE for var_check since these values are stored as-is for
+		 * transfer event tracking. The extension may legitimately contain unexpanded
+		 * variable references (e.g. from ESL uuid_transfer commands) which would
+		 * otherwise trigger CRIT logs at switch_channel.c:1580 (TEL-6718). */
 		switch_channel_set_variable(channel, "transfer_in_progress", "true");
-		switch_channel_set_variable(channel, "transfer_extension", extension);
-		switch_channel_set_variable(channel, "transfer_dialplan", use_dialplan);
-		switch_channel_set_variable(channel, "transfer_context", use_context);
+		switch_channel_set_variable_var_check(channel, "transfer_extension", extension, SWITCH_FALSE);
+		switch_channel_set_variable_var_check(channel, "transfer_dialplan", use_dialplan, SWITCH_FALSE);
+		switch_channel_set_variable_var_check(channel, "transfer_context", use_context, SWITCH_FALSE);
 		
 		/* Also set global variables that will be inherited by originated channels */
 		switch_core_set_variable("transfer_originating_uuid", switch_core_session_get_uuid(session));


### PR DESCRIPTION
## Summary

Fixes **TEL-6718** — `[CRIT] switch_channel.c:1580 Invalid data (${transfer_extension} contains a variable)` log spam.

## Root Cause

Commit `6d3c0eaf7c` (ENGDESK-43915: Fire FS Events for IVR Transfer) added transfer tracking variables in `switch_ivr_session_transfer()` using `switch_channel_set_variable()`, which defaults to `var_check=SWITCH_TRUE`.

When `extension` contains unexpanded FreeSWITCH `${...}` references (legitimately passed via ESL `uuid_transfer`), `switch_string_var_check_const()` detects `${` and emits the CRIT at `switch_channel.c:1580`.

## Fix

Change the transfer tracking variable writes to use `switch_channel_set_variable_var_check(..., SWITCH_FALSE)` so the metadata is stored as-is:

```c
switch_channel_set_variable_var_check(channel, "transfer_extension", extension, SWITCH_FALSE);
switch_channel_set_variable_var_check(channel, "transfer_dialplan", use_dialplan, SWITCH_FALSE);
switch_channel_set_variable_var_check(channel, "transfer_context", use_context, SWITCH_FALSE);
```

## Why this is safe

- These are informational transfer-tracking values, not values that need validation/expansion.
- `SWITCH_TRANSFER_SOURCE_VARIABLE` already uses `SWITCH_FALSE` in the same function.
- This prevents false-positive CRITs without changing transfer behavior.

## Test Plan

1. Trigger `uuid_transfer` with an extension containing `${var}`.
2. Verify no CRIT at `switch_channel.c:1580`.
3. Verify transfer events still contain `Transfer-Extension`, `Transfer-Dialplan`, and `Transfer-Context`.
4. Verify normal transfers remain unchanged.

*— 🦀 Analysis by Council of Claws (Dev, Orchestrator)*