### PR TITLE
TELCORE-248 / TEL-6872: Cherry-pick elastic jitter buffer fixes from SignalWire PR #2337

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -352,6 +352,7 @@ SWITCH_DECLARE(void) switch_core_media_resume(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_init(void);
 SWITCH_DECLARE(void) switch_core_media_deinit(void);
 SWITCH_DECLARE(void) switch_core_media_set_stats(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_export_jb_stats(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_sync_stats(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_session_wake_video_thread(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_session_clear_crypto(switch_core_session_t *session);

--- a/src/include/switch_jitterbuffer.h
+++ b/src/include/switch_jitterbuffer.h
@@ -67,6 +67,7 @@ SWITCH_DECLARE(void) switch_jb_set_flag(switch_jb_t *jb, switch_jb_flag_t flag);
 SWITCH_DECLARE(void) switch_jb_clear_flag(switch_jb_t *jb, switch_jb_flag_t flag);
 SWITCH_DECLARE(uint32_t) switch_jb_get_nack_success(switch_jb_t *jb);
 SWITCH_DECLARE(uint32_t) switch_jb_get_packets_per_frame(switch_jb_t *jb);
+SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb);
 
 SWITCH_END_EXTERN_C
 #endif

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -552,6 +552,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_debug_jitter_buffer(switch_rtp_t *rtp
 SWITCH_DECLARE(switch_status_t) switch_rtp_deactivate_jitter_buffer(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pause_jitter_buffer(switch_rtp_t *rtp_session, switch_bool_t pause);
 SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer_for_stats(switch_rtp_t *rtp_session);
 
 
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -2553,12 +2553,65 @@ SWITCH_DECLARE(void) switch_core_media_sync_stats(switch_core_session_t *session
 
 }
 
+static void set_jb_stats(switch_core_session_t *session, switch_media_type_t type)
+{
+	switch_media_handle_t *smh;
+	switch_rtp_engine_t *engine;
+	switch_jb_t *jb;
+	const char *type_str = (type == SWITCH_MEDIA_TYPE_AUDIO) ? "audio" :
+	                       (type == SWITCH_MEDIA_TYPE_VIDEO) ? "video" : "text";
+
+	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+			"set_jb_stats(%s): no media handle\n", type_str);
+		return;
+	}
+
+	engine = &smh->engines[type];
+	if (!engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+			"set_jb_stats(%s): no rtp_session\n", type_str);
+		return;
+	}
+
+	/* Use _for_stats variant which bypasses switch_rtp_ready() check
+	 * since RTP session may not be "ready" during hangup but JB still exists */
+	jb = switch_rtp_get_jitter_buffer_for_stats(engine->rtp_session);
+	if (jb) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+			"set_jb_stats(%s): exporting JB stats\n", type_str);
+		switch_jb_export_stats(jb);
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+			"set_jb_stats(%s): no jitter buffer\n", type_str);
+	}
+}
+
+SWITCH_DECLARE(void) switch_core_media_export_jb_stats(switch_core_session_t *session)
+{
+	if (!session->media_handle) {
+		return;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+		"switch_core_media_export_jb_stats() exporting JB stats before hangup handlers\n");
+
+	/* Export jitter buffer stats so they're available in hangup hooks */
+	set_jb_stats(session, SWITCH_MEDIA_TYPE_AUDIO);
+	set_jb_stats(session, SWITCH_MEDIA_TYPE_VIDEO);
+	set_jb_stats(session, SWITCH_MEDIA_TYPE_TEXT);
+}
+
 SWITCH_DECLARE(void) switch_core_media_set_stats(switch_core_session_t *session)
 {
+	switch_channel_t *channel = switch_core_session_get_channel(session);
 
 	if (!session->media_handle) {
 		return;
 	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+		"[%s] switch_core_media_set_stats() called\n", switch_channel_get_name(channel));
 
 	switch_core_media_sync_stats(session);
 

--- a/src/switch_core_state_machine.c
+++ b/src/switch_core_state_machine.c
@@ -881,6 +881,9 @@ SWITCH_DECLARE(void) switch_core_session_hangup_state(switch_core_session_t *ses
 	switch_channel_set_timestamps(session->channel);
 	switch_channel_set_callstate(session->channel, CCS_HANGUP);
 
+	/* Export JB stats before hangup handlers run, while JB still exists */
+	switch_core_media_export_jb_stats(session);
+
 	STATE_MACRO(hangup, "HANGUP");
 
 	switch_core_media_set_stats(session);

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -77,6 +77,16 @@ typedef struct switch_jb_stats_s {
 	uint32_t buffering_skip;
 	int estimate_ms;
 	int buffer_size_ms;
+	/* Elastic algorithm activity */
+	uint32_t grew;          /* count of frame_len increases */
+	uint32_t shrunk;        /* count of frame_len decreases */
+	uint32_t grow_to_max;   /* count of times grow hit max_frame_len */
+	uint32_t at_min_ms;     /* cumulative ms parked at min_frame_len */
+	uint32_t at_max_ms;     /* cumulative ms parked at max_frame_len */
+	switch_time_t edge_since; /* us; when current min/max stretch started (0 if not at an edge) */
+	/* Setup vs runtime reset split (set by switch_jb_reset based on jb->media_started) */
+	uint32_t reset_setup;   /* resets that fired before first media packet was put */
+	uint32_t reset_runtime; /* resets that fired after media flow started */
 } switch_jb_stats_t;
 
 typedef struct switch_jb_jitter_s {
@@ -122,6 +132,8 @@ struct switch_jb_s {
 	uint8_t write_init;
 	uint8_t read_init;
 	uint8_t debug_level;
+	uint8_t media_started; /* set on first put_packet; switch_jb_reset uses it to split setup vs runtime resets */
+	uint32_t packets_total; /* lifetime count of put_packet calls — used for expand_ratio */
 	uint16_t next_seq;
 	switch_size_t last_len;
 	switch_inthash_t *missing_seq_hash;
@@ -583,7 +595,32 @@ static void jb_frame_inc_line(switch_jb_t *jb, int i, int line)
 	}
 
 	if (old_frame_len != jb->frame_len) {
+		switch_time_t now = switch_micro_time_now();
+
 		jb_debug(jb, 1, "%d Change framelen from %u to %u\n", line, old_frame_len, jb->frame_len);
+
+		if (jb->jitter.stats.edge_since) {
+			uint32_t held_ms = (uint32_t)((now - jb->jitter.stats.edge_since) / 1000);
+			if (old_frame_len == jb->min_frame_len) {
+				jb->jitter.stats.at_min_ms += held_ms;
+			} else if (old_frame_len == jb->max_frame_len) {
+				jb->jitter.stats.at_max_ms += held_ms;
+			}
+			jb->jitter.stats.edge_since = 0;
+		}
+
+		if (jb->frame_len > old_frame_len) {
+			jb->jitter.stats.grew++;
+			if (jb->frame_len == jb->max_frame_len) {
+				jb->jitter.stats.grow_to_max++;
+			}
+		} else {
+			jb->jitter.stats.shrunk++;
+		}
+
+		if (jb->frame_len == jb->min_frame_len || jb->frame_len == jb->max_frame_len) {
+			jb->jitter.stats.edge_since = now;
+		}
 
 		//if (jb->session) {
 		//	switch_core_session_request_video_refresh(jb->session);
@@ -1170,6 +1207,11 @@ SWITCH_DECLARE(void) switch_jb_debug_level(switch_jb_t *jb, uint8_t level)
 SWITCH_DECLARE(void) switch_jb_reset(switch_jb_t *jb)
 {
 	jb->jitter.stats.reset++;
+	if (jb->media_started) {
+		jb->jitter.stats.reset_runtime++;
+	} else {
+		jb->jitter.stats.reset_setup++;
+	}
 	jb->jitter.stats.expand_frame_len = 0;
 
 	if (jb->type == SJB_VIDEO) {
@@ -1304,6 +1346,20 @@ SWITCH_DECLARE(switch_status_t) switch_jb_set_frames(switch_jb_t *jb, uint32_t m
 		jb->frame_len = jb->min_frame_len;
 	}
 
+	/* Floor/ceiling just moved — flush the in-flight at-edge timer and re-stamp if still at an edge. */
+	if (jb->jitter.stats.edge_since) {
+		uint32_t held_ms = (uint32_t)((switch_micro_time_now() - jb->jitter.stats.edge_since) / 1000);
+		if (jb->frame_len == jb->min_frame_len) {
+			jb->jitter.stats.at_min_ms += held_ms;
+		} else if (jb->frame_len == jb->max_frame_len) {
+			jb->jitter.stats.at_max_ms += held_ms;
+		}
+		jb->jitter.stats.edge_since = 0;
+	}
+	if (jb->frame_len == jb->min_frame_len || jb->frame_len == jb->max_frame_len) {
+		jb->jitter.stats.edge_since = switch_micro_time_now();
+	}
+
 	switch_mutex_unlock(jb->mutex);
 
 	return SWITCH_STATUS_SUCCESS;
@@ -1327,6 +1383,7 @@ SWITCH_DECLARE(switch_status_t) switch_jb_create(switch_jb_t **jbp, switch_jb_ty
 	jb->pool = pool;
 	jb->type = type;
 	jb->highest_frame_len = jb->frame_len;
+	jb->jitter.stats.edge_since = switch_micro_time_now();
 
 	if (jb->type == SJB_VIDEO) {
 		switch_core_inthash_init(&jb->missing_seq_hash);
@@ -1421,6 +1478,62 @@ SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb)
 
 	/* Export elastic buffer info */
 	switch_channel_set_variable_printf(jb->channel, "rtp_jb_elastic", "%s", jb->elastic ? "true" : "false");
+
+	/* Flush any in-flight time-at-edge into the cumulative counters.
+	 * Re-stamp edge_since so a later export call doesn't undercount if the JB is still alive. */
+	if (jb->jitter.stats.edge_since) {
+		switch_time_t now = switch_micro_time_now();
+		uint32_t held_ms = (uint32_t)((now - jb->jitter.stats.edge_since) / 1000);
+		if (jb->frame_len == jb->min_frame_len) {
+			jb->jitter.stats.at_min_ms += held_ms;
+			jb->jitter.stats.edge_since = now;
+		} else if (jb->frame_len == jb->max_frame_len) {
+			jb->jitter.stats.at_max_ms += held_ms;
+			jb->jitter.stats.edge_since = now;
+		} else {
+			jb->jitter.stats.edge_since = 0;
+		}
+	}
+
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_grew", "%u", jb->jitter.stats.grew);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_shrunk", "%u", jb->jitter.stats.shrunk);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_grow_to_max", "%u", jb->jitter.stats.grow_to_max);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_at_min_ms", "%u", jb->jitter.stats.at_min_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_at_max_ms", "%u", jb->jitter.stats.at_max_ms);
+
+	/* Setup vs runtime reset split */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_setup", "%u", jb->jitter.stats.reset_setup);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_runtime", "%u", jb->jitter.stats.reset_runtime);
+
+	/* Lifetime packets seen + expand ratio (pct of audio that was concealed) */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_packets_total", "%u", jb->packets_total);
+	{
+		double expand_ratio_pct = 0.0;
+		if (packet_ms && jb->packets_total) {
+			expand_ratio_pct = (double)jb->jitter.stats.expand * 100.0 / (double)jb->packets_total;
+		}
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ratio_pct", "%.2f", expand_ratio_pct);
+
+		switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(jb->channel), SWITCH_LOG_INFO,
+			"switch_jb_export_stats: type=%s elastic=%s "
+			"frame_len=%u/%u/%u/%u(min/cur/highest/max) "
+			"miss_pct=%.2f consec_miss=%u "
+			"jitter_est_ms=%u jitter_max_ms=%u buffer_size_ms=%u "
+			"reset=%u setup=%u runtime=%u (too_big=%u too_expanded=%u missing_frames=%u ts_jump=%u error=%u) "
+			"grew=%u shrunk=%u grow_to_max=%u at_min_ms=%u at_max_ms=%u "
+			"packets=%u expand_ratio_pct=%.2f\n",
+			jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"),
+			jb->elastic ? "true" : "false",
+			jb->min_frame_len, jb->frame_len, jb->highest_frame_len, jb->max_frame_len,
+			jb->period_miss_pct, jb->consec_miss_count,
+			jb->jitter.stats.estimate_ms, jb->jitter.stats.jitter_max_ms, jb->jitter.stats.buffer_size_ms,
+			jb->jitter.stats.reset, jb->jitter.stats.reset_setup, jb->jitter.stats.reset_runtime,
+			jb->jitter.stats.reset_too_big, jb->jitter.stats.reset_too_expanded,
+			jb->jitter.stats.reset_missing_frames, jb->jitter.stats.reset_ts_jump, jb->jitter.stats.reset_error,
+			jb->jitter.stats.grew, jb->jitter.stats.shrunk, jb->jitter.stats.grow_to_max,
+			jb->jitter.stats.at_min_ms, jb->jitter.stats.at_max_ms,
+			jb->packets_total, expand_ratio_pct);
+	}
 
 	switch_mutex_unlock(jb->mutex);
 }
@@ -1556,6 +1669,8 @@ SWITCH_DECLARE(switch_status_t) switch_jb_put_packet(switch_jb_t *jb, switch_rtp
 		jb->highest_dropped_ts = 0;
 	}
 
+	jb->media_started = 1;
+	jb->packets_total++;
 
 	if (!want) want = got;
 

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -37,6 +37,8 @@
 #define RENACK_TIME 100000
 #define MAX_FRAME_PADDING 2
 #define MAX_MISSING_SEQ 20
+#define MAX_DROPOUT 3000
+#define MAX_CONSECUTIVE_MISS 100
 #define jb_debug(_jb, _level, _format, ...) if (_jb->debug_level >= _level) switch_log_printf(SWITCH_CHANNEL_SESSION_LOG_CLEAN(_jb->session), SWITCH_LOG_ALERT, "JB:%p:%s:%d/%d lv:%d ln:%.4d sz:%.3u/%.3u/%.3u/%.3u c:%.3u %.3u/%.3u/%.3u/%.3u %.2f%% ->" _format, (void *) _jb, (jb->type == SJB_TEXT ? "txt" : (jb->type == SJB_AUDIO ? "aud" : "vid")), _jb->allocated_nodes, _jb->visible_nodes, _level, __LINE__,  _jb->min_frame_len, _jb->max_frame_len, _jb->frame_len, _jb->complete_frames, _jb->period_count, _jb->consec_good_count, _jb->period_good_count, _jb->consec_miss_count, _jb->period_miss_count, _jb->period_miss_pct, __VA_ARGS__)
 
 //const char *TOKEN_1 = "ONE";
@@ -68,7 +70,9 @@ typedef struct switch_jb_stats_s {
 	uint32_t size_est;
 	uint32_t acceleration;
 	uint32_t expand;
+	uint32_t consecutive_miss;
 	uint32_t jitter_max_ms;
+	uint32_t buffering_skip;
 	int estimate_ms;
 	int buffer_size_ms;
 } switch_jb_stats_t;
@@ -796,8 +800,8 @@ static inline void increment_seq(switch_jb_t *jb)
 
 static inline void decrement_seq(switch_jb_t *jb)
 {
-	jb->last_target_seq = jb->target_seq;
 	jb->target_seq = htons((ntohs(jb->target_seq) - 1));
+	jb->last_target_seq = htons((ntohs(jb->target_seq) - 1));
 }
 
 static inline void set_read_seq(switch_jb_t *jb, uint16_t seq)
@@ -942,9 +946,12 @@ static inline int check_jb_size(switch_jb_t *jb)
 
 		seq_hs = ntohs(np->packet.header.seq);
 		if (target_seq_hs > seq_hs) {
-			hide_node(np, SWITCH_FALSE);
-			old++;
-			continue;
+			uint16_t udelta = target_seq_hs - seq_hs;
+			if (udelta > 1 && udelta < MAX_DROPOUT) {
+				hide_node(np, SWITCH_FALSE);
+				old++;
+				continue;
+			}
 		}
 
 		if (count == 0) {
@@ -1594,12 +1601,13 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 		switch_goto_status(SWITCH_STATUS_BREAK, end);
 	}
 
-	if (jb->complete_frames < jb->frame_len) {
+	if (!jb->elastic && (jb->complete_frames < jb->frame_len)) {
 
 		switch_jb_poll(jb);
 
 		if (!jb->flush) {
 			jb_debug(jb, 2, "BUFFERING %u/%u\n", jb->complete_frames , jb->frame_len);
+			jb->jitter.stats.buffering_skip++;
 			switch_goto_status(SWITCH_STATUS_MORE_DATA, end);
 		}
 	}
@@ -1724,6 +1732,16 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 						jb_debug(jb, 2, "%s", "Frame not found suggest PLC\n");
 					}
 
+					if (jb->elastic) {
+						jb->jitter.stats.consecutive_miss++;
+						if (jb->jitter.stats.consecutive_miss > MAX_CONSECUTIVE_MISS) {
+							jb->jitter.stats.reset_missing_frames++;
+							jb->jitter.stats.consecutive_miss = 0;
+							jb->elastic = SWITCH_FALSE;
+							switch_jb_reset(jb);
+							switch_goto_status(SWITCH_STATUS_RESTART, end);
+						}
+					}
 					plc = 1;
 					switch_goto_status(SWITCH_STATUS_NOTFOUND, end);
 				}
@@ -1754,6 +1772,8 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 
 		packet->header.seq = seq;
 		packet->header.ts = ts;
+	} else {
+		jb->jitter.stats.consecutive_miss = 0;
 	}
 
 	switch_mutex_unlock(jb->mutex);

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -983,23 +983,10 @@ static inline int check_jb_size(switch_jb_t *jb)
 
 	/* update the stats every x packets */
 	if (target_seq_hs % 50 == 0) {
-		int packet_ms = jb->jitter.samples_per_frame / (jb->jitter.samples_per_second / 1000);
-
 		jb->jitter.stats.estimate_ms = (*jb->jitter.estimate) / jb->jitter.samples_per_second * 1000;
-		if (jb->channel) {
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_max_ms", "%u", jb->jitter.stats.size_max * packet_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_est_ms", "%u", jb->jitter.stats.size_est * packet_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", jb->jitter.stats.acceleration * packet_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", jb->jitter.stats.expand * packet_ms);
-		}
 
 		if (jb->jitter.stats.jitter_max_ms < jb->jitter.stats.estimate_ms) {
 			jb->jitter.stats.jitter_max_ms = jb->jitter.stats.estimate_ms;
-		}
-
-		if (jb->channel) {
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", jb->jitter.stats.jitter_max_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_est_ms", "%u", jb->jitter.stats.estimate_ms);
 		}
 	}
 
@@ -1102,19 +1089,6 @@ SWITCH_DECLARE(void) switch_jb_set_jitter_estimator(switch_jb_t *jb, double *jit
 {
 	if (jb && jitter) {
 		memset(&jb->jitter, 0, sizeof(switch_jb_jitter_t));
-		if (jb->channel) {
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", 0);
-		}
 
 		jb->jitter.estimate = jitter;
 		jb->jitter.samples_per_frame = samples_per_frame;
@@ -1197,14 +1171,6 @@ SWITCH_DECLARE(void) switch_jb_reset(switch_jb_t *jb)
 {
 	jb->jitter.stats.reset++;
 	jb->jitter.stats.expand_frame_len = 0;
-	if (jb->channel) {
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", jb->jitter.stats.reset);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", jb->jitter.stats.reset_too_big);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_expanded", "%u", jb->jitter.stats.reset_too_expanded);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", jb->jitter.stats.reset_missing_frames);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", jb->jitter.stats.reset_ts_jump);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", jb->jitter.stats.reset_error);
-	}
 
 	if (jb->type == SJB_VIDEO) {
 		switch_mutex_lock(jb->mutex);
@@ -1376,6 +1342,87 @@ SWITCH_DECLARE(switch_status_t) switch_jb_create(switch_jb_t **jbp, switch_jb_ty
 	*jbp = jb;
 
 	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb)
+{
+	int packet_ms = 0;
+
+	if (!jb || !jb->channel) {
+		return;
+	}
+
+	switch_mutex_lock(jb->mutex);
+
+	switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(jb->channel), SWITCH_LOG_INFO,
+		"switch_jb_export_stats: type=%s elastic=%s reset_count=%u\n",
+		jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"),
+		jb->elastic ? "true" : "false",
+		jb->jitter.stats.reset);
+
+	/* Export jitter buffer configuration */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_type", "%s",
+		jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"));
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_min_frame_len", "%u", jb->min_frame_len);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_frame_len", "%u", jb->max_frame_len);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_cur_frame_len", "%u", jb->frame_len);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_highest_frame_len", "%u", jb->highest_frame_len);
+
+	/* Export buffer state */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_visible_nodes", "%u", jb->visible_nodes);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_allocated_nodes", "%u", jb->allocated_nodes);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_complete_frames", "%u", jb->complete_frames);
+
+	/* Export miss/hit statistics */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_miss_count", "%u", jb->period_miss_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consec_miss_count", "%u", jb->consec_miss_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_good_count", "%u", jb->period_good_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consec_good_count", "%u", jb->consec_good_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_miss_pct", "%.2f", jb->period_miss_pct);
+
+	/* Export jitter estimator statistics */
+	if (jb->jitter.samples_per_frame && jb->jitter.samples_per_second) {
+		packet_ms = jb->jitter.samples_per_frame / (jb->jitter.samples_per_second / 1000);
+	}
+
+	if (jb->jitter.estimate && jb->jitter.samples_per_second) {
+		jb->jitter.stats.estimate_ms = (*jb->jitter.estimate) / jb->jitter.samples_per_second * 1000;
+	}
+
+	if (packet_ms) {
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_max_ms", "%u", jb->jitter.stats.size_max * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_est_ms", "%u", jb->jitter.stats.size_est * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", jb->jitter.stats.acceleration * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", jb->jitter.stats.expand * packet_ms);
+	}
+
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_buffering_skip", "%u", jb->jitter.stats.buffering_skip);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", jb->jitter.stats.jitter_max_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_est_ms", "%u", jb->jitter.stats.estimate_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_buffer_size_ms", "%u", jb->jitter.stats.buffer_size_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_frame_len", "%d", jb->jitter.stats.expand_frame_len);
+
+	/* Export reset statistics */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", jb->jitter.stats.reset);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", jb->jitter.stats.reset_too_big);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_expanded", "%u", jb->jitter.stats.reset_too_expanded);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", jb->jitter.stats.reset_missing_frames);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", jb->jitter.stats.reset_ts_jump);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", jb->jitter.stats.reset_error);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consecutive_miss", "%u", jb->jitter.stats.consecutive_miss);
+
+	/* Export video-specific statistics */
+	if (jb->type == SJB_VIDEO) {
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_nack_saved_the_day", "%u", jb->nack_saved_the_day);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_nack_didnt_save_the_day", "%u", jb->nack_didnt_save_the_day);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_packet_len", "%u", jb->max_packet_len);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_packet_count", "%u", jb->packet_count);
+	}
+
+	/* Export elastic buffer info */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_elastic", "%s", jb->elastic ? "true" : "false");
+
+	switch_mutex_unlock(jb->mutex);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_jb_destroy(switch_jb_t **jbp)

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -840,7 +840,7 @@ static inline void increment_seq(switch_jb_t *jb)
 static inline void decrement_seq(switch_jb_t *jb)
 {
 	jb->target_seq = htons((ntohs(jb->target_seq) - 1));
-	jb->last_target_seq = htons((ntohs(jb->target_seq) - 1));
+	jb->last_target_seq = jb->target_seq;
 }
 
 static inline void set_read_seq(switch_jb_t *jb, uint16_t seq)
@@ -1404,6 +1404,19 @@ SWITCH_DECLARE(switch_status_t) switch_jb_create(switch_jb_t **jbp, switch_jb_ty
 SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb)
 {
 	int packet_ms = 0;
+	double expand_ratio_pct = 0.0;
+	double jitter_est_val = 0.0;
+	switch_channel_t *channel;
+	switch_jb_type_t type;
+	switch_bool_t elastic;
+	uint32_t min_frame_len, max_frame_len, frame_len, highest_frame_len;
+	uint32_t visible_nodes, allocated_nodes, complete_frames;
+	uint32_t period_miss_count, consec_miss_count, period_good_count, consec_good_count;
+	double period_miss_pct;
+	uint32_t samples_per_frame, samples_per_second;
+	uint32_t packets_total;
+	uint32_t nack_saved, nack_missed, max_pkt_len, pkt_count;
+	switch_jb_stats_t stats;
 
 	if (!jb || !jb->channel) {
 		return;
@@ -1411,131 +1424,163 @@ SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb)
 
 	switch_mutex_lock(jb->mutex);
 
-	switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(jb->channel), SWITCH_LOG_INFO,
-		"switch_jb_export_stats: type=%s elastic=%s reset_count=%u\n",
-		jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"),
-		jb->elastic ? "true" : "false",
-		jb->jitter.stats.reset);
+	/* Snapshot all fields needed for channel writes under the mutex,
+	 * then unlock before touching channel-side APIs to avoid lock-order inversion */
+	channel = jb->channel;
+	type = jb->type;
+	elastic = jb->elastic;
+	min_frame_len = jb->min_frame_len;
+	max_frame_len = jb->max_frame_len;
+	frame_len = jb->frame_len;
+	highest_frame_len = jb->highest_frame_len;
+	visible_nodes = jb->visible_nodes;
+	allocated_nodes = jb->allocated_nodes;
+	complete_frames = jb->complete_frames;
+	period_miss_count = jb->period_miss_count;
+	consec_miss_count = jb->consec_miss_count;
+	period_good_count = jb->period_good_count;
+	consec_good_count = jb->consec_good_count;
+	period_miss_pct = jb->period_miss_pct;
+	samples_per_frame = jb->jitter.samples_per_frame;
+	samples_per_second = jb->jitter.samples_per_second;
+	packets_total = jb->packets_total;
+	nack_saved = jb->nack_saved_the_day;
+	nack_missed = jb->nack_didnt_save_the_day;
+	max_pkt_len = jb->max_packet_len;
+	pkt_count = jb->packet_count;
+	stats = jb->jitter.stats;  /* struct copy */
 
-	/* Export jitter buffer configuration */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_type", "%s",
-		jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"));
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_min_frame_len", "%u", jb->min_frame_len);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_frame_len", "%u", jb->max_frame_len);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_cur_frame_len", "%u", jb->frame_len);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_highest_frame_len", "%u", jb->highest_frame_len);
-
-	/* Export buffer state */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_visible_nodes", "%u", jb->visible_nodes);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_allocated_nodes", "%u", jb->allocated_nodes);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_complete_frames", "%u", jb->complete_frames);
-
-	/* Export miss/hit statistics */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_miss_count", "%u", jb->period_miss_count);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consec_miss_count", "%u", jb->consec_miss_count);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_good_count", "%u", jb->period_good_count);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consec_good_count", "%u", jb->consec_good_count);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_miss_pct", "%.2f", jb->period_miss_pct);
-
-	/* Export jitter estimator statistics */
-	if (jb->jitter.samples_per_frame && jb->jitter.samples_per_second) {
-		packet_ms = jb->jitter.samples_per_frame / (jb->jitter.samples_per_second / 1000);
+	if (jb->jitter.estimate && samples_per_second) {
+		jitter_est_val = *jb->jitter.estimate;
 	}
 
-	if (jb->jitter.estimate && jb->jitter.samples_per_second) {
-		jb->jitter.stats.estimate_ms = (*jb->jitter.estimate) / jb->jitter.samples_per_second * 1000;
+	if (samples_per_frame && samples_per_second) {
+		packet_ms = samples_per_frame / (samples_per_second / 1000);
 	}
 
-	if (packet_ms) {
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_max_ms", "%u", jb->jitter.stats.size_max * packet_ms);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_est_ms", "%u", jb->jitter.stats.size_est * packet_ms);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", jb->jitter.stats.acceleration * packet_ms);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", jb->jitter.stats.expand * packet_ms);
+	if (jitter_est_val && samples_per_second) {
+		stats.estimate_ms = (int)(jitter_est_val / samples_per_second * 1000);
 	}
 
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_buffering_skip", "%u", jb->jitter.stats.buffering_skip);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", jb->jitter.stats.jitter_max_ms);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_est_ms", "%u", jb->jitter.stats.estimate_ms);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_buffer_size_ms", "%u", jb->jitter.stats.buffer_size_ms);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_frame_len", "%d", jb->jitter.stats.expand_frame_len);
-
-	/* Export reset statistics */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", jb->jitter.stats.reset);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", jb->jitter.stats.reset_too_big);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_expanded", "%u", jb->jitter.stats.reset_too_expanded);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", jb->jitter.stats.reset_missing_frames);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", jb->jitter.stats.reset_ts_jump);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", jb->jitter.stats.reset_error);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consecutive_miss", "%u", jb->jitter.stats.consecutive_miss);
-
-	/* Export video-specific statistics */
-	if (jb->type == SJB_VIDEO) {
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_nack_saved_the_day", "%u", jb->nack_saved_the_day);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_nack_didnt_save_the_day", "%u", jb->nack_didnt_save_the_day);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_packet_len", "%u", jb->max_packet_len);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_packet_count", "%u", jb->packet_count);
-	}
-
-	/* Export elastic buffer info */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_elastic", "%s", jb->elastic ? "true" : "false");
-
-	/* Flush any in-flight time-at-edge into the cumulative counters.
-	 * Re-stamp edge_since so a later export call doesn't undercount if the JB is still alive. */
-	if (jb->jitter.stats.edge_since) {
+	/* Flush in-flight time-at-edge — modifies jb state, must be under mutex */
+	if (stats.edge_since) {
 		switch_time_t now = switch_micro_time_now();
-		uint32_t held_ms = (uint32_t)((now - jb->jitter.stats.edge_since) / 1000);
-		if (jb->frame_len == jb->min_frame_len) {
+		uint32_t held_ms = (uint32_t)((now - stats.edge_since) / 1000);
+		if (frame_len == min_frame_len) {
 			jb->jitter.stats.at_min_ms += held_ms;
 			jb->jitter.stats.edge_since = now;
-		} else if (jb->frame_len == jb->max_frame_len) {
+			stats.at_min_ms = jb->jitter.stats.at_min_ms;
+		} else if (frame_len == max_frame_len) {
 			jb->jitter.stats.at_max_ms += held_ms;
 			jb->jitter.stats.edge_since = now;
+			stats.at_max_ms = jb->jitter.stats.at_max_ms;
 		} else {
 			jb->jitter.stats.edge_since = 0;
+			stats.edge_since = 0;
 		}
 	}
 
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_grew", "%u", jb->jitter.stats.grew);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_shrunk", "%u", jb->jitter.stats.shrunk);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_grow_to_max", "%u", jb->jitter.stats.grow_to_max);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_at_min_ms", "%u", jb->jitter.stats.at_min_ms);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_at_max_ms", "%u", jb->jitter.stats.at_max_ms);
-
-	/* Setup vs runtime reset split */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_setup", "%u", jb->jitter.stats.reset_setup);
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_runtime", "%u", jb->jitter.stats.reset_runtime);
-
-	/* Lifetime packets seen + expand ratio (pct of audio that was concealed) */
-	switch_channel_set_variable_printf(jb->channel, "rtp_jb_packets_total", "%u", jb->packets_total);
-	{
-		double expand_ratio_pct = 0.0;
-		if (packet_ms && jb->packets_total) {
-			expand_ratio_pct = (double)jb->jitter.stats.expand * 100.0 / (double)jb->packets_total;
-		}
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ratio_pct", "%.2f", expand_ratio_pct);
-
-		switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(jb->channel), SWITCH_LOG_INFO,
-			"switch_jb_export_stats: type=%s elastic=%s "
-			"frame_len=%u/%u/%u/%u(min/cur/highest/max) "
-			"miss_pct=%.2f consec_miss=%u "
-			"jitter_est_ms=%u jitter_max_ms=%u buffer_size_ms=%u "
-			"reset=%u setup=%u runtime=%u (too_big=%u too_expanded=%u missing_frames=%u ts_jump=%u error=%u) "
-			"grew=%u shrunk=%u grow_to_max=%u at_min_ms=%u at_max_ms=%u "
-			"packets=%u expand_ratio_pct=%.2f\n",
-			jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"),
-			jb->elastic ? "true" : "false",
-			jb->min_frame_len, jb->frame_len, jb->highest_frame_len, jb->max_frame_len,
-			jb->period_miss_pct, jb->consec_miss_count,
-			jb->jitter.stats.estimate_ms, jb->jitter.stats.jitter_max_ms, jb->jitter.stats.buffer_size_ms,
-			jb->jitter.stats.reset, jb->jitter.stats.reset_setup, jb->jitter.stats.reset_runtime,
-			jb->jitter.stats.reset_too_big, jb->jitter.stats.reset_too_expanded,
-			jb->jitter.stats.reset_missing_frames, jb->jitter.stats.reset_ts_jump, jb->jitter.stats.reset_error,
-			jb->jitter.stats.grew, jb->jitter.stats.shrunk, jb->jitter.stats.grow_to_max,
-			jb->jitter.stats.at_min_ms, jb->jitter.stats.at_max_ms,
-			jb->packets_total, expand_ratio_pct);
+	if (packet_ms && packets_total) {
+		expand_ratio_pct = (double)stats.expand * 100.0 / (double)packets_total;
 	}
 
 	switch_mutex_unlock(jb->mutex);
+
+	/* All channel writes and logging below — JB mutex released */
+
+	switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_INFO,
+		"switch_jb_export_stats: type=%s elastic=%s reset_count=%u\n",
+		type == SJB_VIDEO ? "video" : (type == SJB_AUDIO ? "audio" : "text"),
+		elastic ? "true" : "false",
+		stats.reset);
+
+	/* Export jitter buffer configuration */
+	switch_channel_set_variable_printf(channel, "rtp_jb_type", "%s",
+		type == SJB_VIDEO ? "video" : (type == SJB_AUDIO ? "audio" : "text"));
+	switch_channel_set_variable_printf(channel, "rtp_jb_min_frame_len", "%u", min_frame_len);
+	switch_channel_set_variable_printf(channel, "rtp_jb_max_frame_len", "%u", max_frame_len);
+	switch_channel_set_variable_printf(channel, "rtp_jb_cur_frame_len", "%u", frame_len);
+	switch_channel_set_variable_printf(channel, "rtp_jb_highest_frame_len", "%u", highest_frame_len);
+
+	/* Export buffer state */
+	switch_channel_set_variable_printf(channel, "rtp_jb_visible_nodes", "%u", visible_nodes);
+	switch_channel_set_variable_printf(channel, "rtp_jb_allocated_nodes", "%u", allocated_nodes);
+	switch_channel_set_variable_printf(channel, "rtp_jb_complete_frames", "%u", complete_frames);
+
+	/* Export miss/hit statistics */
+	switch_channel_set_variable_printf(channel, "rtp_jb_period_miss_count", "%u", period_miss_count);
+	switch_channel_set_variable_printf(channel, "rtp_jb_consec_miss_count", "%u", consec_miss_count);
+	switch_channel_set_variable_printf(channel, "rtp_jb_period_good_count", "%u", period_good_count);
+	switch_channel_set_variable_printf(channel, "rtp_jb_consec_good_count", "%u", consec_good_count);
+	switch_channel_set_variable_printf(channel, "rtp_jb_period_miss_pct", "%.2f", period_miss_pct);
+
+	/* Export jitter estimator statistics */
+	if (packet_ms) {
+		switch_channel_set_variable_printf(channel, "rtp_jb_size_max_ms", "%u", stats.size_max * packet_ms);
+		switch_channel_set_variable_printf(channel, "rtp_jb_size_est_ms", "%u", stats.size_est * packet_ms);
+		switch_channel_set_variable_printf(channel, "rtp_jb_acceleration_ms", "%u", stats.acceleration * packet_ms);
+		switch_channel_set_variable_printf(channel, "rtp_jb_expand_ms", "%u", stats.expand * packet_ms);
+	}
+
+	switch_channel_set_variable_printf(channel, "rtp_jb_buffering_skip", "%u", stats.buffering_skip);
+	switch_channel_set_variable_printf(channel, "rtp_jb_jitter_max_ms", "%u", stats.jitter_max_ms);
+	switch_channel_set_variable_printf(channel, "rtp_jb_jitter_est_ms", "%u", stats.estimate_ms);
+	switch_channel_set_variable_printf(channel, "rtp_jb_buffer_size_ms", "%u", stats.buffer_size_ms);
+	switch_channel_set_variable_printf(channel, "rtp_jb_expand_frame_len", "%d", stats.expand_frame_len);
+
+	/* Export reset statistics */
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_count", "%u", stats.reset);
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_too_big", "%u", stats.reset_too_big);
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_too_expanded", "%u", stats.reset_too_expanded);
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_missing_frames", "%u", stats.reset_missing_frames);
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_ts_jump", "%u", stats.reset_ts_jump);
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_error", "%u", stats.reset_error);
+	switch_channel_set_variable_printf(channel, "rtp_jb_consecutive_miss", "%u", stats.consecutive_miss);
+
+	/* Export video-specific statistics */
+	if (type == SJB_VIDEO) {
+		switch_channel_set_variable_printf(channel, "rtp_jb_nack_saved_the_day", "%u", nack_saved);
+		switch_channel_set_variable_printf(channel, "rtp_jb_nack_didnt_save_the_day", "%u", nack_missed);
+		switch_channel_set_variable_printf(channel, "rtp_jb_max_packet_len", "%u", max_pkt_len);
+		switch_channel_set_variable_printf(channel, "rtp_jb_packet_count", "%u", pkt_count);
+	}
+
+	/* Export elastic buffer info */
+	switch_channel_set_variable_printf(channel, "rtp_jb_elastic", "%s", elastic ? "true" : "false");
+
+	switch_channel_set_variable_printf(channel, "rtp_jb_grew", "%u", stats.grew);
+	switch_channel_set_variable_printf(channel, "rtp_jb_shrunk", "%u", stats.shrunk);
+	switch_channel_set_variable_printf(channel, "rtp_jb_grow_to_max", "%u", stats.grow_to_max);
+	switch_channel_set_variable_printf(channel, "rtp_jb_at_min_ms", "%u", stats.at_min_ms);
+	switch_channel_set_variable_printf(channel, "rtp_jb_at_max_ms", "%u", stats.at_max_ms);
+
+	/* Setup vs runtime reset split */
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_setup", "%u", stats.reset_setup);
+	switch_channel_set_variable_printf(channel, "rtp_jb_reset_runtime", "%u", stats.reset_runtime);
+
+	/* Lifetime packets seen + expand ratio (pct of audio that was concealed) */
+	switch_channel_set_variable_printf(channel, "rtp_jb_packets_total", "%u", packets_total);
+	switch_channel_set_variable_printf(channel, "rtp_jb_expand_ratio_pct", "%.2f", expand_ratio_pct);
+
+	switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_INFO,
+		"switch_jb_export_stats: type=%s elastic=%s "
+		"frame_len=%u/%u/%u/%u(min/cur/highest/max) "
+		"miss_pct=%.2f consec_miss=%u "
+		"jitter_est_ms=%u jitter_max_ms=%u buffer_size_ms=%u "
+		"reset=%u setup=%u runtime=%u (too_big=%u too_expanded=%u missing_frames=%u ts_jump=%u error=%u) "
+		"grew=%u shrunk=%u grow_to_max=%u at_min_ms=%u at_max_ms=%u "
+		"packets=%u expand_ratio_pct=%.2f\n",
+		type == SJB_VIDEO ? "video" : (type == SJB_AUDIO ? "audio" : "text"),
+		elastic ? "true" : "false",
+		min_frame_len, frame_len, highest_frame_len, max_frame_len,
+		period_miss_pct, consec_miss_count,
+		stats.estimate_ms, stats.jitter_max_ms, stats.buffer_size_ms,
+		stats.reset, stats.reset_setup, stats.reset_runtime,
+		stats.reset_too_big, stats.reset_too_expanded,
+		stats.reset_missing_frames, stats.reset_ts_jump, stats.reset_error,
+		stats.grew, stats.shrunk, stats.grow_to_max,
+		stats.at_min_ms, stats.at_max_ms,
+		packets_total, expand_ratio_pct);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_jb_destroy(switch_jb_t **jbp)

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -62,6 +62,7 @@ typedef struct switch_jb_node_s {
 
 typedef struct switch_jb_stats_s {
 	uint32_t reset_too_big;
+	uint32_t reset_too_expanded;
 	uint32_t reset_missing_frames;
 	uint32_t reset_ts_jump;
 	uint32_t reset_error;
@@ -70,6 +71,7 @@ typedef struct switch_jb_stats_s {
 	uint32_t size_est;
 	uint32_t acceleration;
 	uint32_t expand;
+	int32_t expand_frame_len;
 	uint32_t consecutive_miss;
 	uint32_t jitter_max_ms;
 	uint32_t buffering_skip;
@@ -1052,6 +1054,7 @@ static inline switch_status_t jb_next_packet_by_seq_with_acceleration(switch_jb_
 					}
 
 					jb->jitter.stats.acceleration++;
+					jb->jitter.stats.expand_frame_len--;
 
 					return jb_next_packet_by_seq(jb, nodep);
 				} else {
@@ -1193,9 +1196,11 @@ SWITCH_DECLARE(void) switch_jb_debug_level(switch_jb_t *jb, uint8_t level)
 SWITCH_DECLARE(void) switch_jb_reset(switch_jb_t *jb)
 {
 	jb->jitter.stats.reset++;
+	jb->jitter.stats.expand_frame_len = 0;
 	if (jb->channel) {
 		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", jb->jitter.stats.reset);
 		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", jb->jitter.stats.reset_too_big);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_expanded", "%u", jb->jitter.stats.reset_too_expanded);
 		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", jb->jitter.stats.reset_missing_frames);
 		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", jb->jitter.stats.reset_ts_jump);
 		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", jb->jitter.stats.reset_error);
@@ -1719,11 +1724,23 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 
 						jb->jitter.stats.estimate_ms = (int)((*jb->jitter.estimate) / ((jb->jitter.samples_per_second)) * 1000);
 						jb->jitter.stats.buffer_size_ms = (int)((visible_not_old * jb->jitter.samples_per_frame) / (jb->jitter.samples_per_second / 1000));
-						/* When playing PLC, we take the oportunity to expand the buffer if the jitter buffer is smaller than the 3x the estimated jitter. */
-						if (jb->jitter.stats.buffer_size_ms < (3 * jb->jitter.stats.estimate_ms)) {
-							jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms EXPAND [plc]\n",
-									 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms);
+						if (jb->jitter.stats.expand_frame_len < 0) jb->jitter.stats.expand_frame_len = 0;
+
+						if (jb->jitter.stats.expand_frame_len > jb->max_frame_len) {
+							jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms RESET TOO EXPANDED [%d>%d] target seq[%u]\n",
+									 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms,
+									 jb->jitter.stats.expand_frame_len, jb->max_frame_len, ntohs(jb->target_seq));
+							jb->jitter.stats.reset_too_expanded++;
+							jb->jitter.stats.expand_frame_len = 0;
+							switch_jb_reset(jb);
+							switch_goto_status(SWITCH_STATUS_RESTART, end);
+						} else if (jb->jitter.stats.buffer_size_ms < (3 * jb->jitter.stats.estimate_ms)) {
+							/* When playing PLC, expand the buffer if smaller than 3x the estimated jitter. */
+							jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms EXPAND [plc] target_seq[%u] expand[%d]\n",
+									 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms,
+									 ntohs(jb->target_seq), jb->jitter.stats.expand_frame_len);
 							jb->jitter.stats.expand++;
+							jb->jitter.stats.expand_frame_len++;
 							decrement_seq(jb);
 						} else {
 							jb_debug(jb, 2, "%s", "Frame not found suggest PLC\n");

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -1781,15 +1781,20 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 							jb->jitter.stats.expand_frame_len = 0;
 							switch_jb_reset(jb);
 							switch_goto_status(SWITCH_STATUS_RESTART, end);
-						} else if (jb->jitter.stats.buffer_size_ms < (3 * jb->jitter.stats.estimate_ms)) {
-							/* When playing PLC, expand the buffer if smaller than 3x the estimated jitter. */
-							jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms EXPAND [plc] target_seq[%u] expand[%d]\n",
-									 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms,
-									 ntohs(jb->target_seq), jb->jitter.stats.expand_frame_len);
-							jb->jitter.stats.expand++;
-							jb->jitter.stats.expand_frame_len++;
-							decrement_seq(jb);
-						} else {
+					} else if (jb->jitter.stats.buffer_size_ms < (3 * jb->jitter.stats.estimate_ms)) {
+						/* When playing PLC, expand the buffer if smaller than 3x the estimated jitter. */
+						jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms EXPAND [plc] target_seq[%u] expand[%d]\n",
+								 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms,
+								 ntohs(jb->target_seq), jb->jitter.stats.expand_frame_len);
+						jb->jitter.stats.expand++;
+						jb->jitter.stats.expand_frame_len++;
+						decrement_seq(jb);
+					} else if (jb->jitter.stats.expand_frame_len >= jb->max_frame_len) {
+						jb->jitter.stats.reset_error++;
+						jb->jitter.stats.expand_frame_len = 0;
+						switch_jb_reset(jb);
+						switch_goto_status(SWITCH_STATUS_RESTART, end);
+					} else {
 							jb_debug(jb, 2, "%s", "Frame not found suggest PLC\n");
 						}
 					} else {
@@ -1798,13 +1803,16 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 
 					if (jb->elastic) {
 						jb->jitter.stats.consecutive_miss++;
-						if (jb->jitter.stats.consecutive_miss > MAX_CONSECUTIVE_MISS) {
-							jb->jitter.stats.reset_missing_frames++;
-							jb->jitter.stats.consecutive_miss = 0;
-							jb->elastic = SWITCH_FALSE;
-							switch_jb_reset(jb);
-							switch_goto_status(SWITCH_STATUS_RESTART, end);
-						}
+					if (jb->jitter.stats.consecutive_miss > MAX_CONSECUTIVE_MISS) {
+						jb_debug(jb, SWITCH_LOG_ALERT, "JITTER elastic DISABLED after %u consecutive misses, reset_missing_frames=%u target_seq[%u]\n",
+								 jb->jitter.stats.consecutive_miss, jb->jitter.stats.reset_missing_frames + 1, ntohs(jb->target_seq));
+						jb->jitter.stats.reset_missing_frames++;
+						jb->jitter.stats.consecutive_miss = 0;
+						jb->elastic = SWITCH_FALSE;
+						jb->frame_len = jb->min_frame_len;
+						switch_jb_reset(jb);
+						switch_goto_status(SWITCH_STATUS_RESTART, end);
+					}
 					}
 					plc = 1;
 					switch_goto_status(SWITCH_STATUS_NOTFOUND, end);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -7166,7 +7166,7 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 
 	tries++;
 
-	if (tries > 20) {
+	if (tries > 20 && !(switch_channel_var_true(switch_core_session_get_channel(rtp_session->session), "rtp_jitter_buffer_accelerate"))) {
 		if (rtp_session->jb && !rtp_session->pause_jb && jb_valid(rtp_session)) {
 			switch_jb_reset(rtp_session->jb);
 		}
@@ -8892,7 +8892,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 			rtp_session->read_pollfd) {
 
 			if (rtp_session->jb && !rtp_session->pause_jb && jb_valid(rtp_session)) {
-				while (switch_poll(rtp_session->read_pollfd, 1, &fdr, 0) == SWITCH_STATUS_SUCCESS) {
+				while (switch_rtp_ready(rtp_session) && switch_poll(rtp_session->read_pollfd, 1, &fdr, 0) == SWITCH_STATUS_SUCCESS) {
 					status = read_rtp_packet(rtp_session, &bytes, flags, pmapP, SWITCH_STATUS_SUCCESS, SWITCH_FALSE);
 
 					if (status == SWITCH_STATUS_GENERR) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -5872,6 +5872,17 @@ SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer(switch_rtp_t *rtp_ses
 	return rtp_session->jb ? rtp_session->jb : rtp_session->vb;
 }
 
+SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer_for_stats(switch_rtp_t *rtp_session)
+{
+	/* Bypass ready check - used for stats export during shutdown
+	 * when rtp_session may not be "ready" but JB still exists */
+	if (!rtp_session) {
+		return NULL;
+	}
+
+	return rtp_session->jb ? rtp_session->jb : rtp_session->vb;
+}
+
 SWITCH_DECLARE(switch_status_t) switch_rtp_pause_jitter_buffer(switch_rtp_t *rtp_session, switch_bool_t pause)
 {
 	int new_val;
@@ -6399,15 +6410,19 @@ SWITCH_DECLARE(void) switch_rtp_destroy(switch_rtp_t **rtp_session)
 		switch_safe_free(pop);
 	}
 
+	/* Export jitter buffer stats before destroying them */
 	if ((*rtp_session)->jb) {
+		switch_jb_export_stats((*rtp_session)->jb);
 		switch_jb_destroy(&(*rtp_session)->jb);
 	}
 
 	if ((*rtp_session)->vb) {
+		switch_jb_export_stats((*rtp_session)->vb);
 		switch_jb_destroy(&(*rtp_session)->vb);
 	}
 
 	if ((*rtp_session)->vbw) {
+		switch_jb_export_stats((*rtp_session)->vbw);
 		switch_jb_destroy(&(*rtp_session)->vbw);
 	}
 
@@ -7865,15 +7880,19 @@ fork_end:
 	if (rtp_session->flags[SWITCH_RTP_FLAG_KILL_JB]) {
 		rtp_session->flags[SWITCH_RTP_FLAG_KILL_JB] = 0;
 
+		/* Export jitter buffer stats before destroying them */
 		if (rtp_session->jb) {
+			switch_jb_export_stats(rtp_session->jb);
 			switch_jb_destroy(&rtp_session->jb);
 		}
 
 		if (rtp_session->vb) {
+			switch_jb_export_stats(rtp_session->vb);
 			switch_jb_destroy(&rtp_session->vb);
 		}
 
 		if (rtp_session->vbw) {
+			switch_jb_export_stats(rtp_session->vbw);
 			switch_jb_destroy(&rtp_session->vbw);
 		}
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -7160,13 +7160,19 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 	switch_size_t xcheck_jitter = 0;
 	int tries = 0;
 	int block = 0;
+	int accelerate = 0;
 
 	switch_assert(bytes);
+
+	if (rtp_session->session) {
+		accelerate = switch_channel_var_true(switch_core_session_get_channel(rtp_session->session), "rtp_jitter_buffer_accelerate") ? 1 : 0;
+	}
+
  more:
 
 	tries++;
 
-	if (tries > 20 && !(switch_channel_var_true(switch_core_session_get_channel(rtp_session->session), "rtp_jitter_buffer_accelerate"))) {
+	if (tries > 20 && (!accelerate || tries > 100)) {
 		if (rtp_session->jb && !rtp_session->pause_jb && jb_valid(rtp_session)) {
 			switch_jb_reset(rtp_session->jb);
 		}


### PR DESCRIPTION
Cherry-pick select bug fixes from signalwire/freeswitch#2337 (Julien Chavanton).

## Fixes

1. **Sequence rollover in check_jb_size()** — add MAX_DROPOUT guard to prevent
   hiding valid packets near seq 65535→0 wraparound
2. **decrement_seq() ordering** — set last_target_seq after decrement so it
   points to the correct value
3. **Buffering skip gate** — do not block elastic mode with the
   complete_frames < frame_len buffering check
4. **Consecutive miss safety valve** — after MAX_CONSECUTIVE_MISS (100)
   consecutive missed frames, disable elastic mode and reset JB
5. **Unbounded expand protection** — track net expansion via expand_frame_len
   and reset JB when it exceeds max_frame_len
6. **JB stats export** — switch_jb_export_stats() snapshots JB fields under
   mutex, unlocks, then writes channel variables and logs (avoids lock-order
   inversion with channel-side locks from hangup/destroy/KILL_JB contexts)
7. **read_rtp_packet() retry bound** — cache rtp_jitter_buffer_accelerate
   channel var at function entry, keep unconditional hard bound at tries > 100

## Intentionally excluded

- Debug log level changes (INFO→ALERT) — would flood production logs
- Forced acceleration when above max size — needs separate A/B testing (potential
  uninitialized variable issue with packet_vad, drops frames during active speech)

## Testing

- A/B test on canary tankers
- Monitor rtp_jb_* channel variables for regression
- Focus on long-duration calls (seq rollover) and high-jitter scenarios