### PR TITLE
TEL-6880: Fix deadlock between sofia_mutex and codec_read_mutex in answer path

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -895,6 +895,8 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 	const char *call_info = switch_channel_get_variable(channel, "presence_call_info_full");
 	const char *session_id_header = sofia_glue_session_id_header(session, tech_pvt->profile);
 
+	switch_mutex_lock(tech_pvt->sofia_mutex);
+
 	if(sofia_acknowledge_call(session) == SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Dialplan did not acknowledge_call; sent 100 Trying");
 	}
@@ -912,7 +914,9 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 		switch_core_media_set_local_sdp(session, b_sdp, SWITCH_TRUE);
 
 		if (switch_channel_test_flag(tech_pvt->channel, CF_PROXY_MEDIA)) {
-			sofia_media_activate_rtp(tech_pvt);
+			switch_mutex_unlock(tech_pvt->sofia_mutex);
+			sofia_media_activate_rtp_unlocked(tech_pvt);
+			switch_mutex_lock(tech_pvt->sofia_mutex);
 			switch_core_media_patch_sdp(tech_pvt->session);			
 			switch_core_media_proxy_remote_addr(tech_pvt->session, NULL);
 		}
@@ -951,11 +955,13 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 		sofia_set_flag_locked(tech_pvt, TFLAG_ANS);
 		sofia_set_flag_locked(tech_pvt, TFLAG_SDP);
 		switch_channel_mark_answered(channel);     // ... and remember to actually answer the call!
-		return SWITCH_STATUS_SUCCESS;
+		status = SWITCH_STATUS_SUCCESS;
+		goto done;
 	}
 
 	if (sofia_test_flag(tech_pvt, TFLAG_ANS) || switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND) {
-		return SWITCH_STATUS_SUCCESS;
+		status = SWITCH_STATUS_SUCCESS;
+		goto done;
 	}
 
 	b_sdp = switch_channel_get_variable(channel, SWITCH_B_SDP_VARIABLE);
@@ -968,8 +974,11 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 
 		if (switch_channel_test_flag(channel, CF_PROXY_MEDIA)) {
 			switch_core_media_patch_sdp(tech_pvt->session);
-			if (sofia_media_activate_rtp(tech_pvt) != SWITCH_STATUS_SUCCESS) {
-				return SWITCH_STATUS_FALSE;
+			switch_mutex_unlock(tech_pvt->sofia_mutex);
+			status = sofia_media_activate_rtp_unlocked(tech_pvt);
+			switch_mutex_lock(tech_pvt->sofia_mutex);
+			if (status != SWITCH_STATUS_SUCCESS) {
+				goto done;
 			}
 		}
 	} else {
@@ -993,8 +1002,11 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 
 			if (switch_channel_test_flag(channel, CF_PROXY_MEDIA)) {
 				switch_core_media_patch_sdp(tech_pvt->session);
-				if (sofia_media_activate_rtp(tech_pvt) != SWITCH_STATUS_SUCCESS) {
-					return SWITCH_STATUS_FALSE;
+				switch_mutex_unlock(tech_pvt->sofia_mutex);
+				status = sofia_media_activate_rtp_unlocked(tech_pvt);
+				switch_mutex_lock(tech_pvt->sofia_mutex);
+				if (status != SWITCH_STATUS_SUCCESS) {
+					goto done;
 				}
 			}
 		}
@@ -1057,7 +1069,8 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 				}
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "3PCC-PROXY, Done waiting for ACK\n");
-				return SWITCH_STATUS_SUCCESS;
+				status = SWITCH_STATUS_SUCCESS;
+				goto done;
 			}
 		}
 
@@ -1078,21 +1091,22 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 
 				if (zstr(r_sdp) || sofia_media_tech_media(tech_pvt, r_sdp, SDP_OFFER) != SWITCH_STATUS_SUCCESS) {
 					switch_channel_set_variable(channel, SWITCH_ENDPOINT_DISPOSITION_VARIABLE, "CODEC NEGOTIATION ERROR");
-					//switch_mutex_lock(tech_pvt->sofia_mutex);
-					//nua_respond(tech_pvt->nh, SIP_488_NOT_ACCEPTABLE, TAG_END());
-					//switch_mutex_unlock(tech_pvt->sofia_mutex);
-					return SWITCH_STATUS_FALSE;
+					status = SWITCH_STATUS_FALSE;
+					goto done;
 				}
 			}
 		}
 
 		if ((status = switch_core_media_choose_port(tech_pvt->session, SWITCH_MEDIA_TYPE_AUDIO, 0)) != SWITCH_STATUS_SUCCESS) {
 			switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
-			return status;
+			goto done;
 		}
 
 		switch_core_media_gen_local_sdp(session, SDP_ANSWER, NULL, 0, NULL, 0);
-		if (sofia_media_activate_rtp(tech_pvt) != SWITCH_STATUS_SUCCESS) {
+		switch_mutex_unlock(tech_pvt->sofia_mutex);
+		status = sofia_media_activate_rtp_unlocked(tech_pvt);
+		switch_mutex_lock(tech_pvt->sofia_mutex);
+		if (status != SWITCH_STATUS_SUCCESS) {
 			switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 		}
 
@@ -1203,7 +1217,11 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 		sofia_set_flag_locked(tech_pvt, TFLAG_ANS);
 	}
 
-	return SWITCH_STATUS_SUCCESS;
+	status = SWITCH_STATUS_SUCCESS;
+
+done:
+	switch_mutex_unlock(tech_pvt->sofia_mutex);
+	return status;
 }
 
 static switch_status_t sofia_read_text_frame(switch_core_session_t *session, switch_frame_t **frame, switch_io_flag_t flags, int stream_id)
@@ -2882,7 +2900,14 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 		}
 		break;
 	case SWITCH_MESSAGE_INDICATE_ANSWER:
+		/* Unlock sofia_mutex before sofia_answer_channel to prevent deadlock.
+		 * sofia_answer_channel -> switch_core_media_activate_rtp -> set_codec
+		 * locks codec_read_mutex. The read_frame path holds codec_read_mutex then
+		 * dispatches SIGNAL_DATA which locks sofia_mutex — ABBA deadlock.
+		 * sofia_answer_channel manages its own sofia_mutex locking internally. */
+		switch_mutex_unlock(tech_pvt->sofia_mutex);
 		status = sofia_answer_channel(session);
+		switch_mutex_lock(tech_pvt->sofia_mutex);
 		break;
 	case SWITCH_MESSAGE_INDICATE_PROGRESS:
 		{

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -1029,6 +1029,7 @@ switch_mutex_unlock(obj->flag_mutex);
 void sofia_glue_global_standby(switch_bool_t on);
 
 switch_status_t sofia_media_activate_rtp(private_object_t *tech_pvt);
+switch_status_t sofia_media_activate_rtp_unlocked(private_object_t *tech_pvt);
 
 const char *sofia_media_get_codec_string(private_object_t *tech_pvt);
 

--- a/src/mod/endpoints/mod_sofia/sofia_media.c
+++ b/src/mod/endpoints/mod_sofia/sofia_media.c
@@ -71,6 +71,26 @@ switch_status_t sofia_media_activate_rtp(private_object_t *tech_pvt)
 
 
 
+/* Lock-free variant of sofia_media_activate_rtp for callers that manage
+ * sofia_mutex externally.  Used by sofia_answer_channel to avoid holding
+ * sofia_mutex across switch_core_media_activate_rtp, which acquires
+ * codec_read_mutex — preventing ABBA deadlock with the SIGNAL_DATA
+ * dispatch path (codec_read_mutex -> sofia_mutex). */
+switch_status_t sofia_media_activate_rtp_unlocked(private_object_t *tech_pvt)
+{
+	switch_status_t status;
+
+	status = switch_core_media_activate_rtp(tech_pvt->session);
+
+	if (status == SWITCH_STATUS_SUCCESS) {
+		sofia_set_flag(tech_pvt, TFLAG_RTP);
+		sofia_set_flag(tech_pvt, TFLAG_IO);
+	}
+
+	return status;
+}
+
+
 switch_status_t sofia_media_tech_media(private_object_t *tech_pvt, const char *r_sdp, switch_sdp_type_t type)
 {
 	switch_assert(tech_pvt != NULL);


### PR DESCRIPTION
**Summary**

Fixes ABBA lock ordering inversion causing deadlocks during concurrent uuid_answer XMLRPC calls for the same session.
The Deadlock

 - Path A (Answer): sofia_mutex → codec_read_mutex (via set_codec)
 - Path B (Read frame SIGNAL_DATA): codec_read_mutex → sofia_mutex

When 3 concurrent uuid_answer calls race against a session in park (reading frames), threads deadlock and sessions become "ghost" sessions that never get cleaned up.

**Changes**

   - Add sofia_media_activate_rtp_unlocked() for callers managing sofia_mutex externally
   - sofia_answer_channel() now locks/unlocks sofia_mutex internally instead of expecting the caller to hold it
   - sofia_receive_message() unlocks sofia_mutex before calling sofia_answer_channel, then reacquires after
   - Convert early return statements to goto done for consistent cleanup at function exit

**Prior Art**

Follows the same pattern as TEL-6404 and TEL-6574 (TRANSCODING_NECESSARY and RESAMPLE_EVENT early-exit fixes), and the existing 3PCC unlock/lock pattern at line 1044.

**Testing**

 - Tanker build verification
 - Regression testing on call answer scenarios (proxy media, 3PCC, normal answer)
