### PR TITLE
TEL-6894: Fix trickle ICE DTLS failure when controlling agent nominates TURN relay

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5298,17 +5298,17 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 		//return SWITCH_STATUS_SUCCESS;
 	//}
 
-	if (trickle_on) {
-		if (engine->ice_in.is_chosen[0] && engine->ice_in.is_chosen[1]) {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG, "check_ice(): Trickle ICE candidates already chosen, skip ICE processing\n");
-			return SWITCH_STATUS_SUCCESS;
-		}
-	} 
-
-	engine->ice_in.chosen[0] = 0;
-	engine->ice_in.chosen[1] = 0;
-	engine->ice_in.is_chosen[0] = 0;
-	engine->ice_in.is_chosen[1] = 0;
+	if (trickle_on && engine->ice_in.is_chosen[0] && engine->ice_in.is_chosen[1] &&
+		!switch_channel_test_flag(smh->session->channel, CF_REINVITE)) {
+		/* Accumulate candidates; skip shortcut on reinvite (stale chosen pair). */
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG,
+			"check_ice(): Trickle ICE candidates already chosen, accumulating new candidates\n");
+	} else {
+		engine->ice_in.chosen[0] = 0;
+		engine->ice_in.chosen[1] = 0;
+		engine->ice_in.is_chosen[0] = 0;
+		engine->ice_in.is_chosen[1] = 0;
+	}
 	if (!trickle_on) {
 		engine->ice_in.cand_idx[0] = 0;
 		engine->ice_in.cand_idx[1] = 0;
@@ -5578,6 +5578,11 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 	}
 
 	if (!ice_seen && !cand_seen) {
+		return SWITCH_STATUS_SUCCESS;
+	}
+
+	/* Candidates already chosen; skip re-selection. USE-CANDIDATE handles switching. */
+	if (trickle_on && engine->ice_in.is_chosen[0] && engine->ice_in.is_chosen[1]) {
 		return SWITCH_STATUS_SUCCESS;
 	}
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1259,6 +1259,32 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG6, "Got USE-CANDIDATE on %s cand %s:%d\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port);
 					}
 				}
+
+				/* RFC 8445: controlled agent must accept the nominated pair. */
+				if (ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE)) {
+					/* Once DTLS is established, don't switch addresses from competing nominations. */
+					if (rtp_session->dtls && rtp_session->dtls->state >= DS_READY && rtp_session->ice.ready) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+							"USE-CANDIDATE: DTLS already READY, ignoring %s nomination from %s:%d\n",
+							rtp_type(rtp_session), from_host, from_port);
+					} else {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+							"USE-CANDIDATE: switching %s ice dest from current to nominated %s:%d\n",
+							rtp_type(rtp_session), from_host, from_port);
+						switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
+
+						/* Update DTLS remote addr so Client Hello goes to the right place. */
+						if (rtp_session->dtls && rtp_session->dtls->remote_addr) {
+							if (switch_sockaddr_info_get(&rtp_session->dtls->remote_addr, from_host, SWITCH_UNSPEC, from_port, 0, rtp_session->pool) == SWITCH_STATUS_SUCCESS) {
+								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+									"USE-CANDIDATE: updated DTLS remote addr to %s:%d\n", from_host, from_port);
+							} else {
+								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+									"USE-CANDIDATE: failed to resolve DTLS remote addr %s:%d\n", from_host, from_port);
+							}
+						}
+					}
+				}
 			}
 			break;
 		case SWITCH_STUN_ATTR_ERROR_CODE:
@@ -4102,10 +4128,60 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 		char tmp_buf2[80] = "";
 		const char *host_from = switch_get_addr(tmp_buf1, sizeof(tmp_buf1), rtp_session->from_addr);
 		const char *host_ice_cur_addr = switch_get_addr(tmp_buf2, sizeof(tmp_buf2), rtp_session->ice.addr);
+		switch_port_t from_port = switch_sockaddr_get_port(rtp_session->from_addr);
+		int nominated = 0;
 
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Got DTLS packet from [%s] whilst current ICE negotiated address is [%s]. Ignored.\n", host_from, host_ice_cur_addr);
+		/* Accept DTLS from a USE-CANDIDATE nominated address (e.g. relay). */
+		if (zstr(host_from)) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+				"Got DTLS packet from unresolvable address. Ignored.\n");
+			return 0;
+		}
 
-		return 0;
+		if (rtp_session->ice.ice_params) {
+			int ci;
+			for (ci = 0; ci < rtp_session->ice.ice_params->cand_idx[rtp_session->ice.proto]; ci++) {
+				icand_t *c = &rtp_session->ice.ice_params->cands[ci][rtp_session->ice.proto];
+				if (c->use_candidate && c->con_addr &&
+				    !strcmp(c->con_addr, host_from) &&
+				    c->con_port == from_port) {
+					nominated = 1;
+					break;
+				}
+			}
+		}
+
+		if (!nominated) {
+			if (dtls->state < DS_READY) {
+				/* Pre-READY: accept DTLS from any source (fingerprint auth suffices). */
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"DTLS HANDSHAKE: accepting packet from [%s] (ICE negotiated [%s], DTLS state=%d)\n",
+					host_from, host_ice_cur_addr, dtls->state);
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"Got DTLS packet from [%s] whilst current ICE negotiated address is [%s]. Ignored.\n",
+					host_from, host_ice_cur_addr);
+				return 0;
+			}
+		}
+
+		/* Once DTLS is established, don't flip-flop the address from competing nominations. */
+		if (dtls->state >= DS_READY && rtp_session->ice.ready) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+				"DTLS already READY, ignoring late nomination from [%s:%d] (current [%s]).\n",
+				host_from, from_port, host_ice_cur_addr);
+		} else {
+			/* Nominated addr - accept and update ice dest (pre-READY only). */
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+				"DTLS from nominated USE-CANDIDATE addr [%s:%d], switching from [%s]. Accepted.\n",
+				host_from, from_port, host_ice_cur_addr);
+			switch_rtp_change_ice_dest(rtp_session, &rtp_session->ice, host_from, from_port);
+			if (dtls->remote_addr) {
+				if (switch_sockaddr_info_get(&dtls->remote_addr, host_from, SWITCH_UNSPEC, from_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "DTLS: failed to resolve nominated addr %s:%d\n", host_from, from_port);
+				}
+			}
+		}
 	}
 
 	if (dtls->bytes > 0 && dtls->data) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -763,7 +763,7 @@ static void switch_rtp_change_ice_dest(switch_rtp_t *rtp_session, switch_rtp_ice
 	int i;
 	uint8_t ice_cand_found_idx = 0;
 
-	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
 		if (!strcmp(host, ice->ice_params->cands[i][ice->proto].con_addr) && port == ice->ice_params->cands[i][ice->proto].con_port) {
 			ice_cand_found_idx = i;
 		}
@@ -1253,7 +1253,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		case SWITCH_STUN_ATTR_USE_CAND:
 			{
 				ice->rready = 1;
-				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
+				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
 					if (!strcmp(ice->ice_params->cands[i][ice->proto].con_addr, from_host) && ice->ice_params->cands[i][ice->proto].con_port == from_port) {
 						ice->ice_params->cands[i][ice->proto].use_candidate = 1;
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG6, "Got USE-CANDIDATE on %s cand %s:%d\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port);
@@ -4140,7 +4140,7 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 
 		if (rtp_session->ice.ice_params) {
 			int ci;
-			for (ci = 0; ci < rtp_session->ice.ice_params->cand_idx[rtp_session->ice.proto]; ci++) {
+			for (ci = 0; ci < rtp_session->ice.ice_params->cand_idx[rtp_session->ice.proto]; ++ci) {
 				icand_t *c = &rtp_session->ice.ice_params->cands[ci][rtp_session->ice.proto];
 				if (c->use_candidate && c->con_addr &&
 				    !strcmp(c->con_addr, host_from) &&
@@ -4151,29 +4151,25 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 			}
 		}
 
-		if (!nominated) {
-			if (dtls->state < DS_READY) {
-				/* Pre-READY: accept DTLS from any source (fingerprint auth suffices). */
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
-					"DTLS HANDSHAKE: accepting packet from [%s] (ICE negotiated [%s], DTLS state=%d)\n",
-					host_from, host_ice_cur_addr, dtls->state);
-			} else {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
-					"Got DTLS packet from [%s] whilst current ICE negotiated address is [%s]. Ignored.\n",
-					host_from, host_ice_cur_addr);
-				return 0;
-			}
-		}
-
-		/* Once DTLS is established, don't flip-flop the address from competing nominations. */
-		if (dtls->state >= DS_READY && rtp_session->ice.ready) {
+		if (!nominated && dtls->state < DS_READY) {
+			/* Pre-READY: accept non-nominated DTLS for handshake (fingerprint auth) but don't switch dest. */
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
-				"DTLS already READY, ignoring late nomination from [%s:%d] (current [%s]).\n",
+				"DTLS packet from [%s] (not nominated), processing for handshake (current ICE [%s]).\n",
+				host_from, host_ice_cur_addr);
+		} else if (!nominated) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+				"Got DTLS packet from [%s] whilst current ICE negotiated address is [%s]. Ignored.\n",
+				host_from, host_ice_cur_addr);
+			return 0;
+		} else if (dtls->state >= DS_READY && rtp_session->ice.ready) {
+			/* DTLS established + ICE settled: don't flip-flop from competing nominations. */
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+				"DTLS READY + ICE settled, ignoring nomination from [%s:%d] (current [%s]).\n",
 				host_from, from_port, host_ice_cur_addr);
 		} else {
-			/* Nominated addr - accept and update ice dest (pre-READY only). */
+			/* Nominated addr - accept and update ice dest (pre-READY or ICE restarting). */
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
-				"DTLS from nominated USE-CANDIDATE addr [%s:%d], switching from [%s]. Accepted.\n",
+				"DTLS from nominated addr [%s:%d], switching from [%s]. Accepted.\n",
 				host_from, from_port, host_ice_cur_addr);
 			switch_rtp_change_ice_dest(rtp_session, &rtp_session->ice, host_from, from_port);
 			if (dtls->remote_addr) {


### PR DESCRIPTION
Three coordinated fixes for DTLS handshake failure when the ICE controlling agent (WebRTC client) nominates a TURN relay pair instead of the direct srflx candidate FS initially chose:

1. check_ice(): Remove early return that blocked relay candidates from being stored during trickle ICE. Accumulate new candidates without resetting existing choices.

2. handle_ice(): When USE-CANDIDATE arrives from a different address than current ice.addr, switch to the nominated pair via switch_rtp_change_ice_dest() and update dtls->remote_addr per RFC 8445.

3. do_dtls(): Accept DTLS packets from any candidate with use_candidate=1, not just current ice.addr. Update ice dest on the fly for late-arriving nominations.