### PR TITLE
TEL-6898: Add media bug ext_flags to skip read demux for eavesdrop bugs

### DIFF
--- a/src/include/private/switch_core_pvt.h
+++ b/src/include/private/switch_core_pvt.h
@@ -191,6 +191,7 @@ struct switch_media_bug {
 	switch_core_session_t *session;
 	void *user_data;
 	uint32_t flags;
+	uint32_t ext_flags;
 	uint16_t weight;
 	uint8_t ready;
 	uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];

--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -294,6 +294,17 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add(_In_ switch_core_sessi
 														  _In_opt_ void *user_data,
 														  _In_ time_t stop_time, _In_ switch_media_bug_flag_t flags, _Out_ switch_media_bug_t **new_bug);
 
+SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add_ex(_In_ switch_core_session_t *session,
+															 _In_ const char *function,
+															 _In_ const char *target,
+															 _In_ switch_media_bug_callback_t callback,
+															 _In_opt_ void *user_data,
+															 _In_ time_t stop_time, _In_ switch_media_bug_flag_t flags,
+															 _In_ switch_media_bug_ext_flag_t ext_flags,
+															 _Out_ switch_media_bug_t **new_bug);
+
+SWITCH_DECLARE(switch_bool_t) switch_core_media_bug_test_ext_flag(switch_media_bug_t *bug, uint32_t ext_flag);
+
 /*!
  * \brief Get the weight of a media bug
  * \param bug The media bug to get the weight from

--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -1996,6 +1996,12 @@ typedef enum {
 } switch_media_bug_flag_enum_t;
 typedef uint32_t switch_media_bug_flag_t;
 
+typedef enum {
+	SMBF_EXT_NONE = 0,
+	SMBF_EXT_NO_READ_DEMUX = (1 << 0)
+} switch_media_bug_ext_flag_enum_t;
+typedef uint32_t switch_media_bug_ext_flag_t;
+
 /*!
   \enum switch_file_flag_t
   \brief File flags

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -838,8 +838,8 @@ cnt_with_cng:
 
 						switch_buffer_write(bp->raw_read_buffer, data, datalen);
 						bp->read_demux_frame = NULL;
-					} else if (read_demux_data) {
-						/* Pre-computed unmerged frame — all demux audio removed */
+					} else if (read_demux_data && !switch_core_media_bug_test_ext_flag(bp, SMBF_EXT_NO_READ_DEMUX)) {
+						/* Pre-computed unmerged frame for bugs without SMBF_EXT_NO_READ_DEMUX */
 						switch_buffer_write(bp->raw_read_buffer, read_demux_data, read_frame->datalen);
 					} else {
 						switch_buffer_write(bp->raw_read_buffer, read_frame->data, read_frame->datalen);

--- a/src/switch_core_media_bug.c
+++ b/src/switch_core_media_bug.c
@@ -833,6 +833,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_bug_push_spy_frame(switch_medi
 }
 
 #define MAX_BUG_BUFFER 1024 * 512
+
 SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add(switch_core_session_t *session,
 														  const char *function,
 														  const char *target,
@@ -840,6 +841,24 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add(switch_core_session_t 
 														  void *user_data, time_t stop_time,
 														  switch_media_bug_flag_t flags,
 														  switch_media_bug_t **new_bug)
+{
+	return switch_core_media_bug_add_ex(session, function, target, callback,
+										user_data, stop_time, flags, SMBF_EXT_NONE, new_bug);
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_core_media_bug_test_ext_flag(switch_media_bug_t *bug, uint32_t ext_flag)
+{
+	return (bug->ext_flags & ext_flag) ? SWITCH_TRUE : SWITCH_FALSE;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add_ex(switch_core_session_t *session,
+															 const char *function,
+															 const char *target,
+															 switch_media_bug_callback_t callback,
+															 void *user_data, time_t stop_time,
+															 switch_media_bug_flag_t flags,
+															 switch_media_bug_ext_flag_t ext_flags,
+															 switch_media_bug_t **new_bug)
 {
 	switch_media_bug_t *bug, *bp;
 	switch_size_t bytes;
@@ -916,6 +935,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add(switch_core_session_t 
 	bug->user_data = user_data;
 	bug->session = session;
 	bug->flags = flags;
+	bug->ext_flags = ext_flags;
 	bug->weight = 0;
 	bug->function = "N/A";
 	bug->target = "N/A";

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -2879,10 +2879,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_eavesdrop_session(switch_core_session
 		}
 
 
-		if (switch_core_media_bug_add(tsession, "eavesdrop", uuid,
-									  eavesdrop_callback, ep, 0,
-									  read_flags | write_flags | SMBF_READ_PING | SMBF_THREAD_LOCK | SMBF_NO_PAUSE | stereo_flag | pos_flag,
-									  &bug) != SWITCH_STATUS_SUCCESS) {
+		if (switch_core_media_bug_add_ex(tsession, "eavesdrop", uuid,
+										 eavesdrop_callback, ep, 0,
+										 read_flags | write_flags | SMBF_READ_PING | SMBF_THREAD_LOCK | SMBF_NO_PAUSE | stereo_flag | pos_flag,
+										 SMBF_EXT_NO_READ_DEMUX,
+										 &bug) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Cannot attach bug\n");
 			goto end;
 		}


### PR DESCRIPTION
## Problem

PR #512 (TEL-6834) fixed duplicate whisper audio in call recordings by
propagating a pre-computed demuxed read frame to all READ_STREAM bugs.               
However, this also stripped whisper audio from other eavesdrop listeners
(e.g. the representative), causing them to lose the AI agent's audio.

## Fix

Introduce a media bug extension flags system (`switch_media_bug_ext_flag_t`)
to allow bugs to opt out of receiving demuxed read frames. Eavesdrop bugs
are created with `SMBF_EXT_NO_READ_DEMUX` via `switch_core_media_bug_add_ex()` ,
so they receive the original merged audio. Recording bugs continue to
receive demuxed audio through the existing `switch_core_media_bug_add()` path.

## Changes

- `switch_types.h` — New `switch_media_bug_ext_flag_t` enum
- `switch_core_pvt.h` — `ext_flags` field on media bug struct
- `switch_core.h` — `switch_core_media_bug_add_ex()` and `switch_core_media_bug_test_ext_ flag()` declarations
- `switch_core_media_bug.c` — `_add` becomes wrapper, `_add_ex` is the full implementation
- `switch_core_io.c` — Gate demux on `SMBF_EXT_NO_READ_DEMUX`
- `switch_ivr_async.c` — Eavesdrop uses `_add_ex` with `SMBF_EXT_NO_READ_DEMUX`