### PR TITLE
TEL-6896: Fix segfault in strcasecmp during trickle ICE candidate dedup

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -11265,6 +11265,17 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 	}
 
 	
+	/* Bail if the session is being torn down — pool and ice_params may be freed imminently */
+	if (rtp_session->session) {
+		switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+		if (channel && (switch_channel_down_nosig(channel) || switch_channel_get_state(channel) >= CS_HANGUP)) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+					"Trickle ICE: session hanging up, dropping candidate (mid=%s idx=%d comp=%d)\n",
+					mid ? mid : "(null)", mline_index, cand->component_id);
+			return SWITCH_STATUS_FALSE;
+		}
+	}
+
 	/* RFC 8838: ignore late trickled candidates after end-of-candidates */
 	if ((ice == &rtp_session->ice && rtp_session->ice.rready) ||
 	    (ice == &rtp_session->rtcp_ice && rtp_session->rtcp_ice.rready)) {
@@ -11274,7 +11285,18 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 		return SWITCH_STATUS_SUCCESS;
 	}
 	
-	if (ice->ice_params) {
+	switch_mutex_lock(rtp_session->ice_mutex);
+
+	/* Re-check ice_params under lock — may have been freed during teardown */
+	if (!ice->ice_params) {
+		switch_mutex_unlock(rtp_session->ice_mutex);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+					"Trickle ICE: ice_params gone after lock (mid=%s idx=%d comp=%d)\n",
+					mid ? mid : "(null)", mline_index, cand->component_id);
+		return SWITCH_STATUS_FALSE;
+	}
+
+	{
 		uint32_t existing = ice->ice_params->cand_idx[ice->proto];
 		for (uint32_t i = 0; i < existing; i++) {
 			const char *e_addr = ice->ice_params->cands[i][ice->proto].con_addr;
@@ -11287,6 +11309,7 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 					!strcasecmp(e_type, cand->cand_type) &&
 					!strcasecmp(e_addr, cand->ip) &&
 					e_port == (switch_port_t)cand->port) {
+					switch_mutex_unlock(rtp_session->ice_mutex);
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
 						"Trickle ICE: dropping duplicate (foundation=%s type=%s %s:%d) mid=%s comp=%d\n",
 						cand->foundation, cand->cand_type, cand->ip, cand->port, mid ? mid : "(null)", cand->component_id);
@@ -11295,6 +11318,7 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 			}
 
 			if (e_addr && !strcasecmp(e_addr, cand->ip) && e_port == (switch_port_t)cand->port) {
+				switch_mutex_unlock(rtp_session->ice_mutex);
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
 							"Trickle ICE: dropping duplicate remote candidate %s:%d (mid=%s idx=%d comp=%d)",
 							cand->ip, cand->port, mid ? mid : "(null)", mline_index, cand->component_id);
@@ -11343,6 +11367,8 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 	if (cand->rel_port) {
 		ice->ice_params->cands[idx][ice->proto].rport = (switch_port_t)cand->rel_port;
 	}
+
+	switch_mutex_unlock(rtp_session->ice_mutex);
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
 					"Trickle ICE: appended remote candidate (mid=%s idx=%d) %s %s:%d prio %lu (component %d)\n",


### PR DESCRIPTION
## Summary

Fixes a segfault in `switch_rtp_internal_add_remote_candidate()` at `switch_rtp.c:11297` where `strcasecmp` crashes on a dangling `con_addr` pointer.

## Root Cause

The dedup loop iterates `ice->ice_params->cands[]` **without holding `ice_mutex`**. If the RTP session is torn down concurrently (session hangup while trickle candidates arrive via WebSocket), `con_addr` becomes freed memory that passes the NULL check but crashes in `strcasecmp`.

## Fix (3 layers of defense)

1. **Session teardown guard** — bail early if channel is in `CS_HANGUP` or below
2. **`ice_mutex` lock** around the entire dedup + insertion block (consistent with every other `ice_params` access in `switch_rtp.c`)
3. **Re-check `ice_params` under lock** — handles race where teardown NULLs it between the pre-check and lock acquisition

All `switch_log_printf` calls moved after `switch_mutex_unlock` to avoid blocking threads.

## Crash Stack

```
client_thread → process_jrpc → telnyx_rtc__candidate_func
  → switch_core_media_trickle_remote_candidate_and_recheck
  → switch_rtp_internal_add_remote_candidate
  → strcasecmp 💥
```

Jira: https://telnyx.atlassian.net/browse/TEL-6896