### PR TITLE
TEL-6919: guard NULL attr->a_value in check_ice() to prevent segfault

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5345,7 +5345,7 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 			/* RFC 5888 / RFC 8843: capture BUNDLE mids at session level */
 			if (!strcasecmp(attr->a_name, "group") && attr->a_value && !strncasecmp(attr->a_value, "BUNDLE", 6)) {
 				switch_channel_set_variable(smh->session->channel, "rtp_group_bundle", attr->a_value + 6);
-			} else if (!strcasecmp(attr->a_name, "ice-ufrag")) {
+			} else if (!strcasecmp(attr->a_name, "ice-ufrag") && !zstr(attr->a_value)) {
 				if (is_trickle_recheck) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG,
 						"ice-ufrag: skipping update during trickle recheck (current=%s, sdp=%s)\n",
@@ -5357,14 +5357,14 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 					engine->new_ice = 1;
 				}
 				ice_seen++;
-			} else if (!strcasecmp(attr->a_name, "ice-pwd")) {
+			} else if (!strcasecmp(attr->a_name, "ice-pwd") && !zstr(attr->a_value)) {
 				if (is_trickle_recheck) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG,
 						"ice-pwd: skipping update during trickle recheck\n");
 				} else if (!engine->ice_in.pwd || strcmp(engine->ice_in.pwd, attr->a_value)) {
 					engine->ice_in.pwd = switch_core_session_strdup(smh->session, attr->a_value);
 				}
-			} else if (!strcasecmp(attr->a_name, "ice-options")) {
+			} else if (!strcasecmp(attr->a_name, "ice-options") && !zstr(attr->a_value)) {
 				engine->ice_in.options = switch_core_session_strdup(smh->session, attr->a_value);
 				if (attr->a_value && switch_stristr("trickle", attr->a_value)) {
 					switch_channel_set_variable(smh->session->channel, "sip_trickle_accept", "true");
@@ -5391,7 +5391,7 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 					}
 
 					continue;
-			} else if (!strcasecmp(attr->a_name, "setup")) {
+			} else if (!strcasecmp(attr->a_name, "setup") && !zstr(attr->a_value)) {
 				if (is_trickle_recheck) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_INFO,
 						"a=setup: skipping dtls_controller update during trickle recheck (DTLS state=%d)\n", check_ice_dtls_state);


### PR DESCRIPTION
## Summary

Add `!zstr(attr->a_value)` guards to 4 attribute branches in `check_ice()` (`switch_core_media.c`) that dereference `attr->a_value` without checking for NULL first.

## Problem

A malformed SDP containing `a=ice-ufrag`, `a=ice-pwd`, `a=ice-options`, or `a=setup` with no value causes a `strlen_evex` segfault via `strcmp`/`strcasecmp`/`strdup` calls.

## Fix

Added `&& !zstr(attr->a_value)` to the condition of each branch so the body is skipped when the value is NULL or empty:

- `ice-ufrag` — guards `strcmp` + `strdup`
- `ice-pwd` — guards `strcmp` + `strdup`
- `ice-options` — guards `strdup`
- `setup` — guards `strcasecmp`

## Related

TEL-6896, TEL-6894, ENGDESK-48822

## Jira

[TEL-6919](https://telnyx.atlassian.net/browse/TEL-6919)

[TEL-6919]: https://telnyx.atlassian.net/browse/TEL-6919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ