### PR TITLE
TEL-6923: Increase XML-RPC max connections from 192 to 512

### DIFF
--- a/libs/xmlrpc-c/include/xmlrpc-c/abyss.h
+++ b/libs/xmlrpc-c/include/xmlrpc-c/abyss.h
@@ -585,7 +585,6 @@ MIMETypeGuessFromFile(const char * const filename);
 ** Maximum number of simultaneous connections
 *********************************************************************/
 
-// TEL-6923: Increase max connections to 512
 #define MAX_CONN    512
 
 /*********************************************************************

--- a/libs/xmlrpc-c/include/xmlrpc-c/abyss.h
+++ b/libs/xmlrpc-c/include/xmlrpc-c/abyss.h
@@ -585,8 +585,8 @@ MIMETypeGuessFromFile(const char * const filename);
 ** Maximum number of simultaneous connections
 *********************************************************************/
 
-// 128 + 64 Max connections
-#define MAX_CONN    192
+// TEL-6923: Increase max connections to 512
+#define MAX_CONN    512
 
 /*********************************************************************
 ** General purpose definitions


### PR DESCRIPTION
Increases the XML-RPC abyss server MAX_CONN limit from 192 to 512.

### Changes
- libs/xmlrpc-c/include/xmlrpc-c/abyss.h: MAX_CONN 192 → 512

### Context
Previous increase bumped from 128 to 192. This change further increases to 512 to handle growing XML-RPC API call volume.

### Related
- Companion PR in tel-core-alerts raises the xmlrpc_limit_capacity alert threshold to 461 (90% of 512).