### PR TITLE
TEL-6927: Add switch_telnyx_sofia_find_nua and register handler dispatch

### DIFF
--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -28,6 +28,21 @@ typedef switch_bool_t (*switch_telnyx_on_media_timeout_func)(switch_channel_t*, 
 typedef void (*switch_telnyx_channel_event_set_basic_data_func)(switch_channel_t*, switch_event_t*);
 typedef switch_bool_t (*switch_telnyx_on_add_media_bug_func)(switch_media_bug_t**, switch_media_bug_t*, const char*, const char*);
 
+/* Get the NUA handle for a named mod_sofia profile. Returns nua_t* as void*.
+ * Returns NULL if the profile is not found or not running.
+ * The returned pointer is valid as long as the profile is alive. */
+typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name);
+
+/* Registration handler callback for external registration engines.
+ * When set, mod_sofia dispatches nua_r_register/nua_r_unregister events to this handler
+ * before processing them internally. Sofia-SIP types are passed as void* to avoid
+ * pulling sofia-sip headers into the core.
+ * Returns SWITCH_TRUE if the event was handled, SWITCH_FALSE to fall through to mod_sofia. */
+typedef switch_bool_t (*switch_telnyx_sofia_register_handler_func)(
+	int event, int status, const char *phrase,
+	void *nua, void *nh, void *hmagic,
+	const void *sip, void *tags);
+
 typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_hangup_cause_to_sip_func switch_telnyx_hangup_cause_to_sip;
 	switch_telnyx_sofia_on_init_func switch_telnyx_sofia_on_init;
@@ -47,6 +62,8 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_on_media_timeout_func switch_telnyx_on_media_timeout;
 	switch_telnyx_channel_event_set_basic_data_func switch_telnyx_channel_event_set_basic_data;
 	switch_telnyx_on_add_media_bug_func switch_telnyx_on_add_media_bug;
+	switch_telnyx_sofia_register_handler_func switch_telnyx_sofia_register_handler;
+	switch_telnyx_sofia_find_nua_func switch_telnyx_sofia_find_nua;
 } switch_telnyx_event_dispatch_t;
 
 SWITCH_DECLARE(void) switch_telnyx_init(switch_memory_pool_t *pool);
@@ -78,6 +95,13 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_sip_cause_to_q850(int status, switch
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sip_on_media_timeout(switch_channel_t* channel, switch_rtp_t* rtp_session);
 SWITCH_DECLARE(void) switch_telnyx_channel_event_set_basic_data(switch_channel_t *channel, switch_event_t *event);
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t **list, switch_media_bug_t *bug, const char* function, const char* target);
+
+SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name);
+
+SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
+	int event, int status, const char *phrase,
+	void *nua, void *nh, void *hmagic,
+	const void *sip, void *tags);
 
 SWITCH_END_EXTERN_C
 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7046,6 +7046,20 @@ char *sofia_stir_shaken_as_create_identity_header(switch_core_session_t *session
 }
 
 
+/* Return the NUA handle for a named sofia profile */
+static void *sofia_find_nua_by_profile(const char *profile_name)
+{
+	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+	void *nua;
+
+	if (!profile) return NULL;
+
+	nua = (void *)profile->nua;
+	sofia_glue_release_profile(profile);
+
+	return nua;
+}
+
 SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 {
 	switch_chat_interface_t *chat_interface;
@@ -7300,6 +7314,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	
 	//sofia_endpoint_interface->recover_callback = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_call_recover = sofia_recover_callback;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_nua = sofia_find_nua_by_profile;
 
 	management_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_MANAGEMENT_INTERFACE);
 	management_interface->relative_oid = "1001";

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -42,6 +42,7 @@
 #include "mod_sofia.h"
 #include <switch_ssl.h>
 #include "prometheus_metrics.h"
+#include "switch_telnyx.h"
 
 
 extern su_log_t tport_log[];
@@ -2525,6 +2526,18 @@ void sofia_event_callback(nua_event_t event,
 	uint32_t sess_count = switch_core_session_count();
 	uint32_t sess_max = switch_core_session_limit(0);
 	
+	/* External handle dispatch: if an external module (e.g. mod_dynamic_gateway)
+	 * owns this handle, dispatch ALL events to it — not just register/unregister.
+	 * The handler identifies its own handles via a magic sentinel and returns
+	 * SWITCH_TRUE to consume the event, preventing mod_sofia from misinterpreting
+	 * the handle's magic pointer as a sofia_private_t. */
+	if (switch_telnyx_sofia_register_handler(
+			(int)event, status, phrase,
+			(void *)nua, (void *)nh, (void *)sofia_private,
+			(const void *)sip, (void *)tags) == SWITCH_TRUE) {
+		return;
+	}
+
 	switch(event) {
 	case nua_i_active:
 		{

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -246,3 +246,22 @@ switch_bool_t switch_telnyx_on_add_media_bug(switch_media_bug_t **list, switch_m
 	}
 	return SWITCH_FALSE;
 }
+switch_bool_t switch_telnyx_sofia_register_handler(
+	int event, int status, const char *phrase,
+	void *nua, void *nh, void *hmagic,
+	const void *sip, void *tags)
+{
+	if (_event_dispatch.switch_telnyx_sofia_register_handler) {
+		return _event_dispatch.switch_telnyx_sofia_register_handler(
+			event, status, phrase, nua, nh, hmagic, sip, tags);
+	}
+	return SWITCH_FALSE;
+}
+
+void * switch_telnyx_sofia_find_nua(const char *profile_name)
+{
+	if (_event_dispatch.switch_telnyx_sofia_find_nua) {
+		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name);
+	}
+	return NULL;
+}


### PR DESCRIPTION
Add switch_telnyx_sofia_find_nua() to expose mod_sofia profile NUA handles to external modules, and switch_telnyx_sofia_register_handler() to intercept NUA events for externally-owned handles. Expand the dispatch in sofia_event_callback to call the handler for all NUA events, not just register/unregister, so external modules can safely own handles on mod_sofia's NUA without misinterpreted magic pointers.