### PR TITLE
ENGDESK-48201: Pace outbound RFC 2833 against wall clock in do_2833.

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -256,6 +256,7 @@ struct switch_rtp_rfc2833_data {
 	unsigned int out_digit_sofar;
 	unsigned int out_digit_sub_sofar;
 	unsigned int out_digit_dur;
+	switch_time_t out_digit_last_progress_us; /* gate against sub-ptime do_2833() wakeups; see ENGDESK-48201 */
 	uint16_t in_digit_seq;
 	uint32_t in_digit_ts;
 	uint32_t last_in_digit_ts;
@@ -6198,6 +6199,22 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 
 	if (rtp_session->dtmf_data.out_digit_dur > 0) {
 		int x, loops = 1;
+		switch_time_t now_us = switch_micro_time_now();
+
+		/* ENGDESK-48201: drop calls less than half a ptime since the last in-flight progress
+		   so a tight-looping read path (e.g. silent peer + SIG_BREAK) can't collapse the digit. */
+		if (rtp_session->dtmf_data.out_digit_last_progress_us &&
+			rtp_session->samples_per_second &&
+			rtp_session->samples_per_interval) {
+			switch_time_t min_us =
+				((switch_time_t) rtp_session->samples_per_interval * 1000000)
+				/ rtp_session->samples_per_second / 2;
+
+			if ((now_us - rtp_session->dtmf_data.out_digit_last_progress_us) < min_us) {
+				return;
+			}
+		}
+		rtp_session->dtmf_data.out_digit_last_progress_us = now_us;
 
 		if (!rtp_session->last_write_ts) {
 			if (rtp_session->timer.timer_interface) {
@@ -6344,6 +6361,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 			rtp_session->dtmf_data.out_digit_sub_sofar = samples;
 			rtp_session->dtmf_data.out_digit_dur = rdigit->duration;
 			rtp_session->dtmf_data.out_digit = rdigit->digit;
+			rtp_session->dtmf_data.out_digit_last_progress_us = switch_micro_time_now(); /* seed gate */
 			rtp_session->dtmf_data.out_digit_packet[0] = (unsigned char) switch_char_to_rfc2833(rdigit->digit);
 			rtp_session->dtmf_data.out_digit_packet[1] = 13;
 			rtp_session->dtmf_data.out_digit_packet[2] = (unsigned char) (rtp_session->dtmf_data.out_digit_sub_sofar >> 8);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -6211,6 +6211,9 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 				/ rtp_session->samples_per_second / 2;
 
 			if ((now_us - rtp_session->dtmf_data.out_digit_last_progress_us) < min_us) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+								  "Skipping do_2833 tick: %" SWITCH_TIME_T_FMT "us since last progress < %" SWITCH_TIME_T_FMT "us min\n",
+								  now_us - rtp_session->dtmf_data.out_digit_last_progress_us, min_us);
 				return;
 			}
 		}


### PR DESCRIPTION
When the b-leg of a bridged call goes silent (no RTP, no comfort noise), the read path that drives do_2833 can wake up many times in close succession (e.g. SIG_BREAK from the audio bridge thread after each queued DTMF digit). Each wakeup unconditionally advances out_digit_sofar by samples_per_interval, regardless of how much wall time has actually elapsed, collapsing the on-the-wire pacing of the digit into a small fraction of its negotiated duration.

Add a wall-clock gate at the top of the in-flight branch: drop calls that arrive less than half of one outbound ptime since the previous in-flight progress. The threshold adapts to runtime ptime / codec changes (samples_per_interval and samples_per_second are read live). The gate only suppresses spurious extra calls — RTP timestamp and sequence progression are unchanged when pacing is normal.

Verified end-to-end with a SIPp repro replaying the original capture against a silent UAS: every digit collapses to <1 ptime without the gate and lands at the expected discrete-tick wall time with it. The active-UAS regression confirms the gate does not block legitimate ticks when the read tick is being driven by real RTP.