### PR TITLE
TEL-6952: Fix null ICE candidate IP in SDP for inbound SIP with ICE

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -10468,10 +10468,16 @@ static void gen_ice(switch_core_session_t *session, switch_media_type_t type, co
 
 	if (!zstr(ip)) {
 		engine->ice_out.cands[0][0].con_addr = switch_core_session_strdup(session, ip);
+	} else if (!zstr(engine->local_sdp_ip) && !engine->ice_out.cands[0][0].con_addr) {
+		/* Fallback: use the engine's local SDP IP when caller passes NULL.
+		 * Prevents (null) in ICE candidate lines for inbound SIP with ICE. */
+		engine->ice_out.cands[0][0].con_addr = switch_core_session_strdup(session, engine->local_sdp_ip);
 	}
 
 	if (port) {
 		engine->ice_out.cands[0][0].con_port = port;
+	} else if (engine->local_sdp_port && !engine->ice_out.cands[0][0].con_port) {
+		engine->ice_out.cands[0][0].con_port = engine->local_sdp_port;
 	}
 
 	engine->ice_out.cands[0][0].generation = "0";


### PR DESCRIPTION
## Summary

Fixes broken ICE candidate lines in 183/200 SDP responses when inbound SIP includes ICE candidates. The response contained `(null) 0` for the IP and port.

## Root Cause

`gen_ice()` receives NULL ip from early call sites → `con_addr` stays NULL → SDP has `(null) 0` candidates.

## Fix

Fallback to `engine->local_sdp_ip` / `local_sdp_port` when ip is NULL and con_addr not previously set. 6 lines, purely additive. No b2bua-rtc regression (CF_ICE never set on its inbound legs).

## Evidence

21 occurrences on tel-fl1-prox-prod-703 (v98.0). Asterisk sends ICE, FS responds with (null) 0 candidates, STUN 400 errors continuously.

## Jira
https://telnyx.atlassian.net/browse/TEL-6952