### PR TITLE
TEL-6955: Fix TOCTOU race in switch_rtp_get_remote_ice_candidates

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -11780,6 +11780,7 @@ SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t
 {
 	const switch_rtp_ice_t *ices[2] = { NULL, NULL };
 	const int comp_id_for_ice[2] = { 1, 2 };
+	switch_rtp_t *rtp_nc;   /* cast off const to allow ice_mutex lock */
 	switch_rtp_ice_cand_t *vec = NULL;
 	uint32_t total = 0;
 	int i, cid;
@@ -11794,10 +11795,19 @@ SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t
 		return 0;
 	}
 
+	rtp_nc = (switch_rtp_t *)rtp;
+
+	/* Hold ice_mutex for the entire read. Otherwise a concurrent
+	 * switch_rtp_internal_add_remote_candidate() can grow cand_idx between the
+	 * size computation and the fill loop, producing a buffer overflow on vec[]
+	 * and heap corruption. */
+	switch_mutex_lock(rtp_nc->ice_mutex);
+
 	ices[0] = rtp->ice.ice_params      ? &rtp->ice      : NULL;  /* RTP  */
 	ices[1] = rtp->rtcp_ice.ice_params ? &rtp->rtcp_ice : NULL;  /* RTCP */
 
 	if (!ices[0] && !ices[1]) {
+		switch_mutex_unlock(rtp_nc->ice_mutex);
 		*out_vec = NULL;
 		return 0;
 	}
@@ -11810,6 +11820,7 @@ SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t
 	}
 
 	if (!total) {
+		switch_mutex_unlock(rtp_nc->ice_mutex);
 		*out_vec = NULL;
 		return 0;
 	}
@@ -11875,6 +11886,8 @@ SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t
 			}
 		}
 	}
+
+	switch_mutex_unlock(rtp_nc->ice_mutex);
 
 	*out_vec = vec;
 	return total;


### PR DESCRIPTION
## Summary

Under trickle ICE load, concurrent calls to `switch_rtp_internal_add_remote_candidate()` can grow `cand_idx` between the size computation (used for malloc) and the fill loop. The fill loop then writes past the allocated buffer, corrupting glibc heap metadata.

A subsequent `free()` or `malloc()` detects the corruption and calls `abort()`, cascading into a cluster-wide WebSocket deadlock via the process-wide DeathHandler signal path.

## Fix

Acquire `rtp_session->ice_mutex` for the entire read so the size computation and fill loop observe a consistent snapshot of `ice_params`. All three exit paths (no ices, zero total, success) release the lock.

## Evidence

Three canary backtraces (mn1-881, da1-738, de1-826) all crash at `src/switch_core_media.c:5238` in `trickle_merge_rtp_remote_into_engine` with glibc errors:
- `double free or corruption (!prev)` (mn1)
- `free(): corrupted unsorted chunks` (da1)
- orphaned-lock state only (de1 — post-abort cleanup)

Full backtrace analysis: https://telnyx.atlassian.net/browse/TEL-6955