### PR TITLE
TEL-6956: Fix double-free in mod_xml_rpc shutdown when port is in use.

### DIFF
--- a/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
+++ b/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
@@ -1384,7 +1384,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_xml_rpc_runtime)
 		globals.running = 0;
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to start HTTP Port %d\n", globals.port);
 		xmlrpc_registry_free(globals.registryP);
-		MIMETypeTerm();
+		globals.registryP = NULL;
 
 		switch_core_global_mutex_unlock();
 		return SWITCH_STATUS_TERM;
@@ -1433,16 +1433,19 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_xml_rpc_shutdown)
 	/* Cann't find a way to stop the websockets, use this for a workaround before finding the real one that works */
 	stop_all_websockets();
 
-	/* this makes the worker thread (ServerRun) stop */
-	ServerTerminate(&globals.abyssServer);
+	if (globals.registryP) {
+		/* this makes the worker thread (ServerRun) stop */
+		ServerTerminate(&globals.abyssServer);
 
-	do {
-		switch_yield(100000);
-	} while (globals.running);
+		do {
+			switch_yield(100000);
+		} while (globals.running);
 
-	ServerFree(&globals.abyssServer);
-	xmlrpc_registry_free(globals.registryP);
-	MIMETypeTerm();
+		ServerFree(&globals.abyssServer);
+		xmlrpc_registry_free(globals.registryP);
+		globals.registryP = NULL;
+		MIMETypeTerm();
+	}
 
 	switch_mutex_lock(globals.mutex);
 	

--- a/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
+++ b/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
@@ -1438,9 +1438,17 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_xml_rpc_shutdown)
 		/* this makes the worker thread (ServerRun) stop */
 		ServerTerminate(&globals.abyssServer);
 
-		do {
-			switch_yield(100000);
-		} while (globals.running);
+		{
+			int retries = 100; /* 100 * 100ms = 10s max */
+			while (globals.running && retries-- > 0) {
+				switch_yield(100000);
+			}
+			if (globals.running) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT,
+					"ServerRun did not exit within 10s after ServerTerminate; aborting to allow restart\n");
+				abort();
+			}
+		}
 
 		ServerFree(&globals.abyssServer);
 		xmlrpc_registry_free(globals.registryP);

--- a/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
+++ b/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
@@ -1383,6 +1383,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_xml_rpc_runtime)
 	if (ServerInit(&globals.abyssServer) != TRUE) {
 		globals.running = 0;
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to start HTTP Port %d\n", globals.port);
+		ServerFree(&globals.abyssServer);
 		xmlrpc_registry_free(globals.registryP);
 		globals.registryP = NULL;
 
@@ -1444,8 +1445,9 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_xml_rpc_shutdown)
 		ServerFree(&globals.abyssServer);
 		xmlrpc_registry_free(globals.registryP);
 		globals.registryP = NULL;
-		MIMETypeTerm();
 	}
+
+	MIMETypeTerm();
 
 	switch_mutex_lock(globals.mutex);
 	


### PR DESCRIPTION
When ServerInit fails (e.g. configured port already bound), the runtime function freed globals.registryP without nulling it and returned SWITCH_STATUS_TERM, which only exits the runtime thread loop -- the module stays loaded. mod_xml_rpc_shutdown then called xmlrpc_registry_free on the dangling pointer, crashing in xmlrpc_methodListDestroy with munmap_chunk(): invalid pointer.

Null registryP after the failure-path free, and gate the abyss/registry/ mime teardown in shutdown on registryP so partially-initialized state isn't double-freed (MIMETypeTerm also abort()s if called twice).