### PR TITLE
TEL-6927: NUA bridge API fixes for mod_dynamic_gateway

### DIFF
--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -40,8 +40,9 @@ typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name, vo
 typedef void (*switch_telnyx_sofia_release_profile_func)(void *profile_handle);
 
 /* Get the SIP URL for a named mod_sofia profile (e.g. "IP:PORT").
+ * When use_tls is true, returns the TLS IP:PORT instead.
  * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success. */
-typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, char *buf, switch_size_t buflen);
+typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 /* NUA event handler callback for external modules that own NUA handles.
  *
@@ -119,7 +120,7 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t 
 
 SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle);
 SWITCH_DECLARE(void) switch_telnyx_sofia_release_profile(void *profile_handle);
-SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen);
+SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
 	int event, int status, const char *phrase,

--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -33,6 +33,10 @@ typedef switch_bool_t (*switch_telnyx_on_add_media_bug_func)(switch_media_bug_t*
  * The returned pointer is valid as long as the profile is alive. */
 typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name);
 
+/* Get the SIP URL for a named mod_sofia profile (e.g. "sip:mod_sofia@IP:PORT").
+ * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success. */
+typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, char *buf, switch_size_t buflen);
+
 /* Registration handler callback for external registration engines.
  * When set, mod_sofia dispatches nua_r_register/nua_r_unregister events to this handler
  * before processing them internally. Sofia-SIP types are passed as void* to avoid
@@ -64,6 +68,7 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_on_add_media_bug_func switch_telnyx_on_add_media_bug;
 	switch_telnyx_sofia_register_handler_func switch_telnyx_sofia_register_handler;
 	switch_telnyx_sofia_find_nua_func switch_telnyx_sofia_find_nua;
+	switch_telnyx_sofia_find_profile_url_func switch_telnyx_sofia_find_profile_url;
 } switch_telnyx_event_dispatch_t;
 
 SWITCH_DECLARE(void) switch_telnyx_init(switch_memory_pool_t *pool);
@@ -97,6 +102,7 @@ SWITCH_DECLARE(void) switch_telnyx_channel_event_set_basic_data(switch_channel_t
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t **list, switch_media_bug_t *bug, const char* function, const char* target);
 
 SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name);
+SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen);
 
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
 	int event, int status, const char *phrase,

--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -28,20 +28,35 @@ typedef switch_bool_t (*switch_telnyx_on_media_timeout_func)(switch_channel_t*, 
 typedef void (*switch_telnyx_channel_event_set_basic_data_func)(switch_channel_t*, switch_event_t*);
 typedef switch_bool_t (*switch_telnyx_on_add_media_bug_func)(switch_media_bug_t**, switch_media_bug_t*, const char*, const char*);
 
-/* Get the NUA handle for a named mod_sofia profile. Returns nua_t* as void*.
- * Returns NULL if the profile is not found or not running.
- * The returned pointer is valid as long as the profile is alive. */
-typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name);
+/* Acquire a ref-counted NUA handle for a named mod_sofia profile.
+ * Returns nua_t* as void*. The caller MUST call switch_telnyx_sofia_release_profile()
+ * when done using the NUA pointer to release the read-lock on the profile.
+ * The profile_handle output parameter receives an opaque handle that must be
+ * passed to the release function. Returns NULL if profile is not found/running. */
+typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name, void **profile_handle);
 
-/* Get the SIP URL for a named mod_sofia profile (e.g. "sip:mod_sofia@IP:PORT").
+/* Release the profile read-lock acquired by switch_telnyx_sofia_find_nua().
+ * Must be called once for every successful find_nua call. */
+typedef void (*switch_telnyx_sofia_release_profile_func)(void *profile_handle);
+
+/* Get the SIP URL for a named mod_sofia profile (e.g. "IP:PORT").
  * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success. */
 typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, char *buf, switch_size_t buflen);
 
-/* Registration handler callback for external registration engines.
- * When set, mod_sofia dispatches nua_r_register/nua_r_unregister events to this handler
- * before processing them internally. Sofia-SIP types are passed as void* to avoid
- * pulling sofia-sip headers into the core.
- * Returns SWITCH_TRUE if the event was handled, SWITCH_FALSE to fall through to mod_sofia. */
+/* NUA event handler callback for external modules that own NUA handles.
+ *
+ * When set, mod_sofia dispatches ALL NUA events to this handler before its own
+ * processing. This is necessary because external modules bind their own structs
+ * (not sofia_private_t) to NUA handles — if mod_sofia processed these events,
+ * it would dereference the wrong struct type.
+ *
+ * The handler identifies its own handles via a magic sentinel in hmagic and
+ * returns SWITCH_TRUE to consume the event, SWITCH_FALSE to fall through.
+ *
+ * Performance: mod_sofia pre-filters by event type — only register/unregister
+ * responses and inbound events on handles with non-NULL hmagic are dispatched.
+ * Call-path events (INVITE, BYE, ACK, etc.) on mod_sofia's own handles are
+ * never dispatched to this handler. */
 typedef switch_bool_t (*switch_telnyx_sofia_register_handler_func)(
 	int event, int status, const char *phrase,
 	void *nua, void *nh, void *hmagic,
@@ -68,6 +83,7 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_on_add_media_bug_func switch_telnyx_on_add_media_bug;
 	switch_telnyx_sofia_register_handler_func switch_telnyx_sofia_register_handler;
 	switch_telnyx_sofia_find_nua_func switch_telnyx_sofia_find_nua;
+	switch_telnyx_sofia_release_profile_func switch_telnyx_sofia_release_profile;
 	switch_telnyx_sofia_find_profile_url_func switch_telnyx_sofia_find_profile_url;
 } switch_telnyx_event_dispatch_t;
 
@@ -101,7 +117,8 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_sip_on_media_timeout(switch_channel_
 SWITCH_DECLARE(void) switch_telnyx_channel_event_set_basic_data(switch_channel_t *channel, switch_event_t *event);
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t **list, switch_media_bug_t *bug, const char* function, const char* target);
 
-SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name);
+SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle);
+SWITCH_DECLARE(void) switch_telnyx_sofia_release_profile(void *profile_handle);
 SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen);
 
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7076,17 +7076,23 @@ static void sofia_release_profile_handle(void *profile_handle)
 }
 
 /* Return the SIP URL (sip:mod_sofia@IP:PORT) for a named sofia profile */
-static switch_status_t sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen)
+static switch_status_t sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
 {
 	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+	const char *ip;
+	int port;
 
 	if (!profile) return SWITCH_STATUS_FALSE;
 
-	if (profile->extsipip) {
-		snprintf(buf, buflen, "%s:%d", profile->extsipip, profile->extsipport);
+	ip = profile->extsipip ? profile->extsipip : profile->sipip;
+
+	if (use_tls) {
+		port = profile->tls_sip_port;
 	} else {
-		snprintf(buf, buflen, "%s:%d", profile->sipip, profile->sip_port);
+		port = profile->extsipip ? profile->extsipport : profile->sip_port;
 	}
+
+	snprintf(buf, buflen, "%s:%d", ip, port);
 
 	sofia_glue_release_profile(profile);
 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7046,18 +7046,33 @@ char *sofia_stir_shaken_as_create_identity_header(switch_core_session_t *session
 }
 
 
-/* Return the NUA handle for a named sofia profile */
-static void *sofia_find_nua_by_profile(const char *profile_name)
+/* Acquire a ref-counted NUA handle for a named sofia profile.
+ * The profile read-lock is held until sofia_release_profile_handle() is called.
+ * This prevents the profile (and its NUA) from being destroyed while in use. */
+static void *sofia_find_nua_by_profile(const char *profile_name, void **profile_handle)
 {
 	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
-	void *nua;
 
+	if (profile_handle) *profile_handle = NULL;
 	if (!profile) return NULL;
 
-	nua = (void *)profile->nua;
-	sofia_glue_release_profile(profile);
+	/* Return the profile as an opaque handle — caller must release it */
+	if (profile_handle) {
+		*profile_handle = (void *)profile;
+	} else {
+		/* No handle output — caller can't release, so release now (legacy) */
+		sofia_glue_release_profile(profile);
+	}
 
-	return nua;
+	return (void *)profile->nua;
+}
+
+/* Release the profile read-lock acquired by sofia_find_nua_by_profile() */
+static void sofia_release_profile_handle(void *profile_handle)
+{
+	if (profile_handle) {
+		sofia_glue_release_profile((sofia_profile_t *)profile_handle);
+	}
 }
 
 /* Return the SIP URL (sip:mod_sofia@IP:PORT) for a named sofia profile */
@@ -7333,6 +7348,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	//sofia_endpoint_interface->recover_callback = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_call_recover = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_nua = sofia_find_nua_by_profile;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_release_profile = sofia_release_profile_handle;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_profile_url = sofia_find_profile_url;
 
 	management_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_MANAGEMENT_INTERFACE);

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7060,6 +7060,24 @@ static void *sofia_find_nua_by_profile(const char *profile_name)
 	return nua;
 }
 
+/* Return the SIP URL (sip:mod_sofia@IP:PORT) for a named sofia profile */
+static switch_status_t sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen)
+{
+	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+
+	if (!profile) return SWITCH_STATUS_FALSE;
+
+	if (profile->extsipip) {
+		snprintf(buf, buflen, "%s:%d", profile->extsipip, profile->extsipport);
+	} else {
+		snprintf(buf, buflen, "%s:%d", profile->sipip, profile->sip_port);
+	}
+
+	sofia_glue_release_profile(profile);
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
 SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 {
 	switch_chat_interface_t *chat_interface;
@@ -7315,6 +7333,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	//sofia_endpoint_interface->recover_callback = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_call_recover = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_nua = sofia_find_nua_by_profile;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_profile_url = sofia_find_profile_url;
 
 	management_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_MANAGEMENT_INTERFACE);
 	management_interface->relative_oid = "1001";

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2527,15 +2527,27 @@ void sofia_event_callback(nua_event_t event,
 	uint32_t sess_max = switch_core_session_limit(0);
 	
 	/* External handle dispatch: if an external module (e.g. mod_dynamic_gateway)
-	 * owns this handle, dispatch ALL events to it — not just register/unregister.
-	 * The handler identifies its own handles via a magic sentinel and returns
-	 * SWITCH_TRUE to consume the event, preventing mod_sofia from misinterpreting
-	 * the handle's magic pointer as a sofia_private_t. */
-	if (switch_telnyx_sofia_register_handler(
-			(int)event, status, phrase,
-			(void *)nua, (void *)nh, (void *)sofia_private,
-			(const void *)sip, (void *)tags) == SWITCH_TRUE) {
-		return;
+	 * owns this handle, dispatch the event to it. The handler identifies its own
+	 * handles via a magic sentinel in sofia_private and returns SWITCH_TRUE to
+	 * consume the event, preventing mod_sofia from misinterpreting the handle's
+	 * magic pointer as a sofia_private_t.
+	 *
+	 * Pre-filter: only dispatch events that could belong to external handles.
+	 * Register/unregister responses are the primary use case. We also dispatch
+	 * inbound events (nua_i_*) on handles with non-NULL sofia_private, as
+	 * Sofia-SIP may generate outbound-related events (e.g. nua_i_outbound).
+	 * Call-path events (INVITE, BYE, ACK) on mod_sofia's own handles bypass
+	 * this entirely for zero overhead on the hot path. */
+	if (sofia_private &&
+		(event == nua_r_register || event == nua_r_unregister ||
+		 event == nua_r_authenticate ||
+		 event == nua_i_outbound || event == nua_i_register)) {
+		if (switch_telnyx_sofia_register_handler(
+				(int)event, status, phrase,
+				(void *)nua, (void *)nh, (void *)sofia_private,
+				(const void *)sip, (void *)tags) == SWITCH_TRUE) {
+			return;
+		}
 	}
 
 	switch(event) {

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -265,3 +265,11 @@ void * switch_telnyx_sofia_find_nua(const char *profile_name)
 	}
 	return NULL;
 }
+
+switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen)
+{
+	if (_event_dispatch.switch_telnyx_sofia_find_profile_url) {
+		return _event_dispatch.switch_telnyx_sofia_find_profile_url(profile_name, buf, buflen);
+	}
+	return SWITCH_STATUS_FALSE;
+}

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -258,12 +258,20 @@ switch_bool_t switch_telnyx_sofia_register_handler(
 	return SWITCH_FALSE;
 }
 
-void * switch_telnyx_sofia_find_nua(const char *profile_name)
+void * switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle)
 {
+	if (profile_handle) *profile_handle = NULL;
 	if (_event_dispatch.switch_telnyx_sofia_find_nua) {
-		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name);
+		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name, profile_handle);
 	}
 	return NULL;
+}
+
+void switch_telnyx_sofia_release_profile(void *profile_handle)
+{
+	if (profile_handle && _event_dispatch.switch_telnyx_sofia_release_profile) {
+		_event_dispatch.switch_telnyx_sofia_release_profile(profile_handle);
+	}
 }
 
 switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen)

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -274,10 +274,10 @@ void switch_telnyx_sofia_release_profile(void *profile_handle)
 	}
 }
 
-switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, char *buf, switch_size_t buflen)
+switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
 {
 	if (_event_dispatch.switch_telnyx_sofia_find_profile_url) {
-		return _event_dispatch.switch_telnyx_sofia_find_profile_url(profile_name, buf, buflen);
+		return _event_dispatch.switch_telnyx_sofia_find_profile_url(profile_name, use_tls, buf, buflen);
 	}
 	return SWITCH_STATUS_FALSE;
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
- Add `switch_telnyx_sofia_find_profile_url()` to expose profile SIP/TLS IP:PORT for Contact header construction
- Fix use-after-free: `switch_telnyx_sofia_find_nua()` now returns a ref-counted profile handle with `switch_telnyx_sofia_release_profile()` for release                                                 
- Fix hot-path dispatch: pre-filter NUA events by type — only register/unregister and related events are dispatched to external handlers, zero overhead on call-path events
- Add `use_tls` parameter to profile URL lookup for correct TLS Contact port 