### PR TITLE
TEL-6970: Replace malloc/free trickle ICE merge with direct read under ice_mutex

### DIFF
--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -869,7 +869,6 @@ SWITCH_DECLARE(uint32_t) switch_rtp_get_ms_per_packet(switch_rtp_t *rtp_session)
 SWITCH_DECLARE(uint32_t) switch_rtp_get_us_per_packet(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_using_timer(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_prepare_trickle_ice(switch_rtp_t *rtp_session, ice_proto_t proto, ice_t *ice_params);
-SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t *rtp, const switch_rtp_ice_cand_t **out_vec);
 SWITCH_DECLARE(uint32_t) switch_rtp_get_new_ssrc(switch_rtp_t *rtp_session);
 /*!
   \}
@@ -887,3 +886,13 @@ SWITCH_END_EXTERN_C
  * For VIM:
  * vim:set softtabstop=4 shiftwidth=4 tabstop=4 noet:
  */
+
+/**
+ * Merge remote trickle ICE candidates from RTP ice_params into engine->ice_in under ice_mutex.
+ *
+ * @param rtp         The RTP session to read candidates from
+ * @param session     The core session (for pool allocations via switch_core_session_strdup)
+ * @param ice_in      Pointer to the engine's ice_in structure to write into
+ * @return            Number of new candidates merged
+ */
+SWITCH_DECLARE(int) switch_rtp_merge_remote_ice_candidates_into_engine(switch_rtp_t *rtp, switch_core_session_t *session, ice_t *ice_in);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5148,9 +5148,6 @@ static int trickle_merge_rtp_remote_into_engine(switch_media_handle_t *smh, swit
 	switch_rtp_engine_t *engine;
 	switch_rtp_t *rtp;
 	int added = 0;
-	const switch_rtp_ice_cand_t *srcv = NULL;
-	uint32_t rc = 0;
-
 
 	if (!smh || !session) {
 		return 0;
@@ -5166,63 +5163,8 @@ static int trickle_merge_rtp_remote_into_engine(switch_media_handle_t *smh, swit
 		return 0;
 	}
 
-
-	rc = switch_rtp_get_remote_ice_candidates(rtp, &srcv);
-	if (!rc || !srcv) {
-		return 0;
-	}
-
-	{
-		uint32_t i;
-		for (i = 0; i < rc; ++i) {
-			const switch_rtp_ice_cand_t *src = &srcv[i];
-			int comp = src->component_id;
-			int cid;
-			int j, idx;
-			icand_t *dst;
-			icand_t *e;
-
-			if (comp < 1 || comp > 2) {
-				continue;
-			}
-			cid = comp - 1;
-
-			for (j = 0; j < engine->ice_in.cand_idx[cid]; ++j) {
-				e = &engine->ice_in.cands[j][cid];
-				if (e->component_id == comp &&
-				    e->con_addr && !strcmp(e->con_addr, src->ip) &&
-				    e->con_port == (switch_port_t)src->port) {
-					goto next_src;
-				}
-			}
-
-			idx = engine->ice_in.cand_idx[cid];
-			if (idx >= MAX_CAND) {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
-				                  "Trickle ICE: drop remote cand (foundation=%s %s:%d comp=%d) — capacity full\n",
-				                  src->foundation, src->ip, src->port, comp);
-				goto next_src;
-			}
-
-			dst = &engine->ice_in.cands[idx][cid];
-			dst->foundation   = switch_core_session_strdup(session, src->foundation);
-			dst->component_id = src->component_id;
-			dst->transport    = switch_core_session_strdup(session, src->transport);
-			dst->priority     = (uint32_t)src->priority;
-			dst->con_addr     = switch_core_session_strdup(session, src->ip);
-			dst->con_port     = (switch_port_t)src->port;
-			dst->cand_type    = switch_core_session_strdup(session, src->cand_type);
-			dst->raddr        = zstr(src->rel_addr) ? NULL : switch_core_session_strdup(session, src->rel_addr);
-			dst->rport        = (switch_port_t)src->rel_port;
-			dst->ready        = 1;
-
-			engine->ice_in.cand_idx[cid] = idx + 1;
-			added++;
-
-		next_src:
-			;
-		}
-	}
+	/* Merge directly under ice_mutex — no intermediate malloc/free */
+	added = switch_rtp_merge_remote_ice_candidates_into_engine(rtp, session, &engine->ice_in);
 
 	if (added) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
@@ -5230,11 +5172,6 @@ static int trickle_merge_rtp_remote_into_engine(switch_media_handle_t *smh, swit
 		                  added,
 		                  type == SWITCH_MEDIA_TYPE_AUDIO ? "audio" :
 		                  type == SWITCH_MEDIA_TYPE_VIDEO ? "video" : "text");
-	}
-
-	/* Free the malloc'd candidate vec from switch_rtp_get_remote_ice_candidates */
-	if (srcv) {
-		free((void *)srcv);
 	}
 
 	return added;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -11776,123 +11776,99 @@ SWITCH_DECLARE(void) switch_rtp_prepare_trickle_ice(switch_rtp_t *rtp_session,  
 	switch_mutex_unlock(rtp_session->ice_mutex);
 }
 
-SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t *rtp, const switch_rtp_ice_cand_t **out_vec)
+
+SWITCH_DECLARE(int) switch_rtp_merge_remote_ice_candidates_into_engine(switch_rtp_t *rtp, switch_core_session_t *session, ice_t *ice_in)
 {
 	const switch_rtp_ice_t *ices[2] = { NULL, NULL };
 	const int comp_id_for_ice[2] = { 1, 2 };
-	switch_rtp_t *rtp_nc;   /* cast off const to allow ice_mutex lock */
-	switch_rtp_ice_cand_t *vec = NULL;
-	uint32_t total = 0;
+	int added = 0;
 	int i, cid;
 
-	if (!rtp || !out_vec) {
+	if (!rtp || !session || !ice_in) {
 		return 0;
 	}
 
 	if (!rtp->pool) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "switch_rtp_get_remote_ice_candidates(): NULL pool for RTP %p\n", (void *)rtp);
-		*out_vec = NULL;
 		return 0;
 	}
 
-	rtp_nc = (switch_rtp_t *)rtp;
+	switch_mutex_lock(rtp->ice_mutex);
 
-	/* Hold ice_mutex for the entire read. Otherwise a concurrent
-	 * switch_rtp_internal_add_remote_candidate() can grow cand_idx between the
-	 * size computation and the fill loop, producing a buffer overflow on vec[]
-	 * and heap corruption. */
-	switch_mutex_lock(rtp_nc->ice_mutex);
-
-	ices[0] = rtp->ice.ice_params      ? &rtp->ice      : NULL;  /* RTP  */
-	ices[1] = rtp->rtcp_ice.ice_params ? &rtp->rtcp_ice : NULL;  /* RTCP */
+	ices[0] = rtp->ice.ice_params      ? &rtp->ice      : NULL;
+	ices[1] = rtp->rtcp_ice.ice_params ? &rtp->rtcp_ice : NULL;
 
 	if (!ices[0] && !ices[1]) {
-		switch_mutex_unlock(rtp_nc->ice_mutex);
-		*out_vec = NULL;
+		switch_mutex_unlock(rtp->ice_mutex);
 		return 0;
 	}
 
 	for (i = 0; i < 2; ++i) {
 		const switch_rtp_ice_t *ice = ices[i];
+		int comp_id = comp_id_for_ice[i];
+		uint32_t n, ii;
+
 		if (!ice || !ice->ice_params) continue;
+
 		cid = (ice->proto >= 0 && ice->proto <= 1) ? ice->proto : 0;
-		total += (uint32_t)ice->ice_params->cand_idx[cid];
-	}
+		n = (uint32_t)ice->ice_params->cand_idx[cid];
 
-	if (!total) {
-		switch_mutex_unlock(rtp_nc->ice_mutex);
-		*out_vec = NULL;
-		return 0;
-	}
+		for (ii = 0; ii < n; ++ii) {
+			const char *found = ice->ice_params->cands[ii][cid].foundation;
+			const char *addr  = ice->ice_params->cands[ii][cid].con_addr;
+			switch_port_t port = ice->ice_params->cands[ii][cid].con_port;
+			uint32_t prio      = ice->ice_params->cands[ii][cid].priority;
+			const char *ctype  = ice->ice_params->cands[ii][cid].cand_type;
+			const char *transport = ice->ice_params->cands[ii][cid].transport;
+			const char *raddr  = ice->ice_params->cands[ii][cid].raddr;
+			switch_port_t rport = ice->ice_params->cands[ii][cid].rport;
+			int engine_cid = comp_id - 1;
+			int j, idx;
+			icand_t *dst, *e;
 
-	/* Use malloc: vector is short-lived within caller scope. Pool alloc
- 	 * isn’t freed and seems to corrupt the pool on repeated trickle rechecks. */
-	vec = (switch_rtp_ice_cand_t *)malloc(total * sizeof(*vec));
-	switch_assert(vec);
-	memset(vec, 0, total * sizeof(*vec));
+			if (engine_cid < 0 || engine_cid > 1) continue;
 
-	{
-		uint32_t k = 0;
-		for (i = 0; i < 2; ++i) {
-			const switch_rtp_ice_t *ice = ices[i];
-			int comp_id = comp_id_for_ice[i];
-			if (!ice || !ice->ice_params) continue;
-
-			cid = (ice->proto >= 0 && ice->proto <= 1) ? ice->proto : 0;
-			{
-				uint32_t n = (uint32_t)ice->ice_params->cand_idx[cid];
-				uint32_t ii;
-				for (ii = 0; ii < n; ++ii) {
-					const char *found = ice->ice_params->cands[ii][cid].foundation;
-					const char *addr  = ice->ice_params->cands[ii][cid].con_addr;
-					switch_port_t port = ice->ice_params->cands[ii][cid].con_port;
-					uint32_t prio      = ice->ice_params->cands[ii][cid].priority;
-					const char *ctype  = ice->ice_params->cands[ii][cid].cand_type;
-					const char *transport  = ice->ice_params->cands[ii][cid].transport;
-					const char *raddr  = ice->ice_params->cands[ii][cid].raddr;
-					switch_port_t rport = ice->ice_params->cands[ii][cid].rport;
-
-					memset(&vec[k], 0, sizeof(vec[k]));
-
-					vec[k].component_id = comp_id;
-
-					if (found) {
-						switch_copy_string(vec[k].foundation, found, sizeof(vec[k].foundation));
-					}
-
-					switch_copy_string(vec[k].transport, (transport && *transport) ? transport : "udp", sizeof(vec[k].transport));
-
-					vec[k].priority = (unsigned long)prio;
-
-					if (addr) {
-						switch_copy_string(vec[k].ip, addr, sizeof(vec[k].ip));
-					}
-					vec[k].port = (int)port;
-
-					if (ctype) {
-						switch_copy_string(vec[k].cand_type, ctype, sizeof(vec[k].cand_type));
-					}
-
-					if (raddr) {
-						switch_copy_string(vec[k].rel_addr, raddr, sizeof(vec[k].rel_addr));
-					} else {
-						vec[k].rel_addr[0] = '\0';
-					}
-					
-					vec[k].rel_port = (int)rport;
-
-					++k;
+			/* Dedup: skip if already in engine list */
+			for (j = 0; j < ice_in->cand_idx[engine_cid]; ++j) {
+				e = &ice_in->cands[j][engine_cid];
+				if (e->component_id == comp_id &&
+				    e->con_addr && addr && !strcmp(e->con_addr, addr) &&
+				    e->con_port == port) {
+					goto next_merge_cand;
 				}
 			}
+
+			idx = ice_in->cand_idx[engine_cid];
+			if (idx >= MAX_CAND) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+					"Trickle ICE merge: capacity full (%d/%d), dropping %s:%d comp=%d\n",
+					idx, MAX_CAND, addr ? addr : "?", (int)port, comp_id);
+				goto next_merge_cand;
+			}
+
+			dst = &ice_in->cands[idx][engine_cid];
+			dst->foundation   = found ? switch_core_session_strdup(session, found) : NULL;
+			dst->component_id = comp_id;
+			dst->transport    = transport ? switch_core_session_strdup(session, transport) : NULL;
+			dst->priority     = prio;
+			dst->con_addr     = addr ? switch_core_session_strdup(session, addr) : NULL;
+			dst->con_port     = port;
+			dst->cand_type    = ctype ? switch_core_session_strdup(session, ctype) : NULL;
+			dst->raddr        = raddr ? switch_core_session_strdup(session, raddr) : NULL;
+			dst->rport        = rport;
+			dst->ready        = 1;
+
+			ice_in->cand_idx[engine_cid] = idx + 1;
+			added++;
+
+		next_merge_cand:
+			;
 		}
 	}
 
-	switch_mutex_unlock(rtp_nc->ice_mutex);
+	switch_mutex_unlock(rtp->ice_mutex);
 
-	*out_vec = vec;
-	return total;
+	return added;
 }
-
 static inline switch_channel_t *cand_get_channel(const switch_rtp_t *rtp_session)
 {
 	switch_channel_t *ch;


### PR DESCRIPTION
## Summary

Replace the malloc/copy/free pattern in `trickle_merge_rtp_remote_into_engine` with a direct read under `ice_mutex`.

The old path malloc'd a vec, copied candidates, released the lock, then free'd the vec. Under rapid candidate bursts, heap corruption triggered SIGABRT inside `free()/realloc()`, which combined with the DeathHandler `fork()` path caused a full process deadlock.

## Fix

New `switch_rtp_merge_remote_ice_candidates_into_engine` reads `ice_params` and writes directly to `engine->ice_in` under a single `ice_mutex` hold. No malloc, no free, no TOCTOU. Old `switch_rtp_get_remote_ice_candidates` removed (no other callers).