### PR TITLE
TEL-6976: Add NUA bridge API and TLS profile URL support

### DIFF
--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -869,6 +869,7 @@ SWITCH_DECLARE(uint32_t) switch_rtp_get_ms_per_packet(switch_rtp_t *rtp_session)
 SWITCH_DECLARE(uint32_t) switch_rtp_get_us_per_packet(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_using_timer(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_prepare_trickle_ice(switch_rtp_t *rtp_session, ice_proto_t proto, ice_t *ice_params);
+SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t *rtp, const switch_rtp_ice_cand_t **out_vec);
 SWITCH_DECLARE(uint32_t) switch_rtp_get_new_ssrc(switch_rtp_t *rtp_session);
 /*!
   \}
@@ -886,13 +887,3 @@ SWITCH_END_EXTERN_C
  * For VIM:
  * vim:set softtabstop=4 shiftwidth=4 tabstop=4 noet:
  */
-
-/**
- * Merge remote trickle ICE candidates from RTP ice_params into engine->ice_in under ice_mutex.
- *
- * @param rtp         The RTP session to read candidates from
- * @param session     The core session (for pool allocations via switch_core_session_strdup)
- * @param ice_in      Pointer to the engine's ice_in structure to write into
- * @return            Number of new candidates merged
- */
-SWITCH_DECLARE(int) switch_rtp_merge_remote_ice_candidates_into_engine(switch_rtp_t *rtp, switch_core_session_t *session, ice_t *ice_in);

--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -28,16 +28,36 @@ typedef switch_bool_t (*switch_telnyx_on_media_timeout_func)(switch_channel_t*, 
 typedef void (*switch_telnyx_channel_event_set_basic_data_func)(switch_channel_t*, switch_event_t*);
 typedef switch_bool_t (*switch_telnyx_on_add_media_bug_func)(switch_media_bug_t**, switch_media_bug_t*, const char*, const char*);
 
-/* Get the NUA handle for a named mod_sofia profile. Returns nua_t* as void*.
- * Returns NULL if the profile is not found or not running.
- * The returned pointer is valid as long as the profile is alive. */
-typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name);
+/* Acquire a ref-counted NUA handle for a named mod_sofia profile.
+ * Returns nua_t* as void*. The caller MUST call switch_telnyx_sofia_release_profile()
+ * when done using the NUA pointer to release the read-lock on the profile.
+ * The profile_handle output parameter receives an opaque handle that must be
+ * passed to the release function. Returns NULL if profile is not found/running. */
+typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name, void **profile_handle);
 
-/* Registration handler callback for external registration engines.
- * When set, mod_sofia dispatches nua_r_register/nua_r_unregister events to this handler
- * before processing them internally. Sofia-SIP types are passed as void* to avoid
- * pulling sofia-sip headers into the core.
- * Returns SWITCH_TRUE if the event was handled, SWITCH_FALSE to fall through to mod_sofia. */
+/* Release the profile read-lock acquired by switch_telnyx_sofia_find_nua().
+ * Must be called once for every successful find_nua call. */
+typedef void (*switch_telnyx_sofia_release_profile_func)(void *profile_handle);
+
+/* Get the SIP URL for a named mod_sofia profile (e.g. "IP:PORT").
+ * When use_tls is true, returns the TLS IP:PORT instead.
+ * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success. */
+typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
+
+/* NUA event handler callback for external modules that own NUA handles.
+ *
+ * When set, mod_sofia dispatches ALL NUA events to this handler before its own
+ * processing. This is necessary because external modules bind their own structs
+ * (not sofia_private_t) to NUA handles — if mod_sofia processed these events,
+ * it would dereference the wrong struct type.
+ *
+ * The handler identifies its own handles via a magic sentinel in hmagic and
+ * returns SWITCH_TRUE to consume the event, SWITCH_FALSE to fall through.
+ *
+ * Performance: mod_sofia pre-filters by event type — only register/unregister
+ * responses and inbound events on handles with non-NULL hmagic are dispatched.
+ * Call-path events (INVITE, BYE, ACK, etc.) on mod_sofia's own handles are
+ * never dispatched to this handler. */
 typedef switch_bool_t (*switch_telnyx_sofia_register_handler_func)(
 	int event, int status, const char *phrase,
 	void *nua, void *nh, void *hmagic,
@@ -64,6 +84,8 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_on_add_media_bug_func switch_telnyx_on_add_media_bug;
 	switch_telnyx_sofia_register_handler_func switch_telnyx_sofia_register_handler;
 	switch_telnyx_sofia_find_nua_func switch_telnyx_sofia_find_nua;
+	switch_telnyx_sofia_release_profile_func switch_telnyx_sofia_release_profile;
+	switch_telnyx_sofia_find_profile_url_func switch_telnyx_sofia_find_profile_url;
 } switch_telnyx_event_dispatch_t;
 
 SWITCH_DECLARE(void) switch_telnyx_init(switch_memory_pool_t *pool);
@@ -96,7 +118,9 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_sip_on_media_timeout(switch_channel_
 SWITCH_DECLARE(void) switch_telnyx_channel_event_set_basic_data(switch_channel_t *channel, switch_event_t *event);
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t **list, switch_media_bug_t *bug, const char* function, const char* target);
 
-SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name);
+SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle);
+SWITCH_DECLARE(void) switch_telnyx_sofia_release_profile(void *profile_handle);
+SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
 	int event, int status, const char *phrase,

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7046,18 +7046,57 @@ char *sofia_stir_shaken_as_create_identity_header(switch_core_session_t *session
 }
 
 
-/* Return the NUA handle for a named sofia profile */
-static void *sofia_find_nua_by_profile(const char *profile_name)
+/* Acquire a ref-counted NUA handle for a named sofia profile.
+ * The profile read-lock is held until sofia_release_profile_handle() is called.
+ * This prevents the profile (and its NUA) from being destroyed while in use. */
+static void *sofia_find_nua_by_profile(const char *profile_name, void **profile_handle)
 {
 	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
-	void *nua;
 
+	if (profile_handle) *profile_handle = NULL;
 	if (!profile) return NULL;
 
-	nua = (void *)profile->nua;
+	/* Return the profile as an opaque handle — caller must release it */
+	if (profile_handle) {
+		*profile_handle = (void *)profile;
+	} else {
+		/* No handle output — caller can't release, so release now (legacy) */
+		sofia_glue_release_profile(profile);
+	}
+
+	return (void *)profile->nua;
+}
+
+/* Release the profile read-lock acquired by sofia_find_nua_by_profile() */
+static void sofia_release_profile_handle(void *profile_handle)
+{
+	if (profile_handle) {
+		sofia_glue_release_profile((sofia_profile_t *)profile_handle);
+	}
+}
+
+/* Return the SIP URL (sip:mod_sofia@IP:PORT) for a named sofia profile */
+static switch_status_t sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
+{
+	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+	const char *ip;
+	int port;
+
+	if (!profile) return SWITCH_STATUS_FALSE;
+
+	ip = profile->extsipip ? profile->extsipip : profile->sipip;
+
+	if (use_tls) {
+		port = profile->tls_sip_port;
+	} else {
+		port = profile->extsipip ? profile->extsipport : profile->sip_port;
+	}
+
+	snprintf(buf, buflen, "%s:%d", ip, port);
+
 	sofia_glue_release_profile(profile);
 
-	return nua;
+	return SWITCH_STATUS_SUCCESS;
 }
 
 SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
@@ -7315,6 +7354,8 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	//sofia_endpoint_interface->recover_callback = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_call_recover = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_nua = sofia_find_nua_by_profile;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_release_profile = sofia_release_profile_handle;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_profile_url = sofia_find_profile_url;
 
 	management_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_MANAGEMENT_INTERFACE);
 	management_interface->relative_oid = "1001";

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2527,15 +2527,27 @@ void sofia_event_callback(nua_event_t event,
 	uint32_t sess_max = switch_core_session_limit(0);
 	
 	/* External handle dispatch: if an external module (e.g. mod_dynamic_gateway)
-	 * owns this handle, dispatch ALL events to it — not just register/unregister.
-	 * The handler identifies its own handles via a magic sentinel and returns
-	 * SWITCH_TRUE to consume the event, preventing mod_sofia from misinterpreting
-	 * the handle's magic pointer as a sofia_private_t. */
-	if (switch_telnyx_sofia_register_handler(
-			(int)event, status, phrase,
-			(void *)nua, (void *)nh, (void *)sofia_private,
-			(const void *)sip, (void *)tags) == SWITCH_TRUE) {
-		return;
+	 * owns this handle, dispatch the event to it. The handler identifies its own
+	 * handles via a magic sentinel in sofia_private and returns SWITCH_TRUE to
+	 * consume the event, preventing mod_sofia from misinterpreting the handle's
+	 * magic pointer as a sofia_private_t.
+	 *
+	 * Pre-filter: only dispatch events that could belong to external handles.
+	 * Register/unregister responses are the primary use case. We also dispatch
+	 * inbound events (nua_i_*) on handles with non-NULL sofia_private, as
+	 * Sofia-SIP may generate outbound-related events (e.g. nua_i_outbound).
+	 * Call-path events (INVITE, BYE, ACK) on mod_sofia's own handles bypass
+	 * this entirely for zero overhead on the hot path. */
+	if (sofia_private &&
+		(event == nua_r_register || event == nua_r_unregister ||
+		 event == nua_r_authenticate ||
+		 event == nua_i_outbound || event == nua_i_register)) {
+		if (switch_telnyx_sofia_register_handler(
+				(int)event, status, phrase,
+				(void *)nua, (void *)nh, (void *)sofia_private,
+				(const void *)sip, (void *)tags) == SWITCH_TRUE) {
+			return;
+		}
 	}
 
 	switch(event) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5148,6 +5148,9 @@ static int trickle_merge_rtp_remote_into_engine(switch_media_handle_t *smh, swit
 	switch_rtp_engine_t *engine;
 	switch_rtp_t *rtp;
 	int added = 0;
+	const switch_rtp_ice_cand_t *srcv = NULL;
+	uint32_t rc = 0;
+
 
 	if (!smh || !session) {
 		return 0;
@@ -5163,8 +5166,63 @@ static int trickle_merge_rtp_remote_into_engine(switch_media_handle_t *smh, swit
 		return 0;
 	}
 
-	/* Merge directly under ice_mutex — no intermediate malloc/free */
-	added = switch_rtp_merge_remote_ice_candidates_into_engine(rtp, session, &engine->ice_in);
+
+	rc = switch_rtp_get_remote_ice_candidates(rtp, &srcv);
+	if (!rc || !srcv) {
+		return 0;
+	}
+
+	{
+		uint32_t i;
+		for (i = 0; i < rc; ++i) {
+			const switch_rtp_ice_cand_t *src = &srcv[i];
+			int comp = src->component_id;
+			int cid;
+			int j, idx;
+			icand_t *dst;
+			icand_t *e;
+
+			if (comp < 1 || comp > 2) {
+				continue;
+			}
+			cid = comp - 1;
+
+			for (j = 0; j < engine->ice_in.cand_idx[cid]; ++j) {
+				e = &engine->ice_in.cands[j][cid];
+				if (e->component_id == comp &&
+				    e->con_addr && !strcmp(e->con_addr, src->ip) &&
+				    e->con_port == (switch_port_t)src->port) {
+					goto next_src;
+				}
+			}
+
+			idx = engine->ice_in.cand_idx[cid];
+			if (idx >= MAX_CAND) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+				                  "Trickle ICE: drop remote cand (foundation=%s %s:%d comp=%d) — capacity full\n",
+				                  src->foundation, src->ip, src->port, comp);
+				goto next_src;
+			}
+
+			dst = &engine->ice_in.cands[idx][cid];
+			dst->foundation   = switch_core_session_strdup(session, src->foundation);
+			dst->component_id = src->component_id;
+			dst->transport    = switch_core_session_strdup(session, src->transport);
+			dst->priority     = (uint32_t)src->priority;
+			dst->con_addr     = switch_core_session_strdup(session, src->ip);
+			dst->con_port     = (switch_port_t)src->port;
+			dst->cand_type    = switch_core_session_strdup(session, src->cand_type);
+			dst->raddr        = zstr(src->rel_addr) ? NULL : switch_core_session_strdup(session, src->rel_addr);
+			dst->rport        = (switch_port_t)src->rel_port;
+			dst->ready        = 1;
+
+			engine->ice_in.cand_idx[cid] = idx + 1;
+			added++;
+
+		next_src:
+			;
+		}
+	}
 
 	if (added) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
@@ -5172,6 +5230,11 @@ static int trickle_merge_rtp_remote_into_engine(switch_media_handle_t *smh, swit
 		                  added,
 		                  type == SWITCH_MEDIA_TYPE_AUDIO ? "audio" :
 		                  type == SWITCH_MEDIA_TYPE_VIDEO ? "video" : "text");
+	}
+
+	/* Free the malloc'd candidate vec from switch_rtp_get_remote_ice_candidates */
+	if (srcv) {
+		free((void *)srcv);
 	}
 
 	return added;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -11776,99 +11776,110 @@ SWITCH_DECLARE(void) switch_rtp_prepare_trickle_ice(switch_rtp_t *rtp_session,  
 	switch_mutex_unlock(rtp_session->ice_mutex);
 }
 
-
-SWITCH_DECLARE(int) switch_rtp_merge_remote_ice_candidates_into_engine(switch_rtp_t *rtp, switch_core_session_t *session, ice_t *ice_in)
+SWITCH_DECLARE(uint32_t) switch_rtp_get_remote_ice_candidates(const switch_rtp_t *rtp, const switch_rtp_ice_cand_t **out_vec)
 {
 	const switch_rtp_ice_t *ices[2] = { NULL, NULL };
 	const int comp_id_for_ice[2] = { 1, 2 };
-	int added = 0;
+	switch_rtp_ice_cand_t *vec = NULL;
+	uint32_t total = 0;
 	int i, cid;
 
-	if (!rtp || !session || !ice_in) {
+	if (!rtp || !out_vec) {
 		return 0;
 	}
 
 	if (!rtp->pool) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "switch_rtp_get_remote_ice_candidates(): NULL pool for RTP %p\n", (void *)rtp);
+		*out_vec = NULL;
 		return 0;
 	}
 
-	switch_mutex_lock(rtp->ice_mutex);
-
-	ices[0] = rtp->ice.ice_params      ? &rtp->ice      : NULL;
-	ices[1] = rtp->rtcp_ice.ice_params ? &rtp->rtcp_ice : NULL;
+	ices[0] = rtp->ice.ice_params      ? &rtp->ice      : NULL;  /* RTP  */
+	ices[1] = rtp->rtcp_ice.ice_params ? &rtp->rtcp_ice : NULL;  /* RTCP */
 
 	if (!ices[0] && !ices[1]) {
-		switch_mutex_unlock(rtp->ice_mutex);
+		*out_vec = NULL;
 		return 0;
 	}
 
 	for (i = 0; i < 2; ++i) {
 		const switch_rtp_ice_t *ice = ices[i];
-		int comp_id = comp_id_for_ice[i];
-		uint32_t n, ii;
-
 		if (!ice || !ice->ice_params) continue;
-
 		cid = (ice->proto >= 0 && ice->proto <= 1) ? ice->proto : 0;
-		n = (uint32_t)ice->ice_params->cand_idx[cid];
+		total += (uint32_t)ice->ice_params->cand_idx[cid];
+	}
 
-		for (ii = 0; ii < n; ++ii) {
-			const char *found = ice->ice_params->cands[ii][cid].foundation;
-			const char *addr  = ice->ice_params->cands[ii][cid].con_addr;
-			switch_port_t port = ice->ice_params->cands[ii][cid].con_port;
-			uint32_t prio      = ice->ice_params->cands[ii][cid].priority;
-			const char *ctype  = ice->ice_params->cands[ii][cid].cand_type;
-			const char *transport = ice->ice_params->cands[ii][cid].transport;
-			const char *raddr  = ice->ice_params->cands[ii][cid].raddr;
-			switch_port_t rport = ice->ice_params->cands[ii][cid].rport;
-			int engine_cid = comp_id - 1;
-			int j, idx;
-			icand_t *dst, *e;
+	if (!total) {
+		*out_vec = NULL;
+		return 0;
+	}
 
-			if (engine_cid < 0 || engine_cid > 1) continue;
+	/* Use malloc: vector is short-lived within caller scope. Pool alloc
+ 	 * isn’t freed and seems to corrupt the pool on repeated trickle rechecks. */
+	vec = (switch_rtp_ice_cand_t *)malloc(total * sizeof(*vec));
+	switch_assert(vec);
+	memset(vec, 0, total * sizeof(*vec));
 
-			/* Dedup: skip if already in engine list */
-			for (j = 0; j < ice_in->cand_idx[engine_cid]; ++j) {
-				e = &ice_in->cands[j][engine_cid];
-				if (e->component_id == comp_id &&
-				    e->con_addr && addr && !strcmp(e->con_addr, addr) &&
-				    e->con_port == port) {
-					goto next_merge_cand;
+	{
+		uint32_t k = 0;
+		for (i = 0; i < 2; ++i) {
+			const switch_rtp_ice_t *ice = ices[i];
+			int comp_id = comp_id_for_ice[i];
+			if (!ice || !ice->ice_params) continue;
+
+			cid = (ice->proto >= 0 && ice->proto <= 1) ? ice->proto : 0;
+			{
+				uint32_t n = (uint32_t)ice->ice_params->cand_idx[cid];
+				uint32_t ii;
+				for (ii = 0; ii < n; ++ii) {
+					const char *found = ice->ice_params->cands[ii][cid].foundation;
+					const char *addr  = ice->ice_params->cands[ii][cid].con_addr;
+					switch_port_t port = ice->ice_params->cands[ii][cid].con_port;
+					uint32_t prio      = ice->ice_params->cands[ii][cid].priority;
+					const char *ctype  = ice->ice_params->cands[ii][cid].cand_type;
+					const char *transport  = ice->ice_params->cands[ii][cid].transport;
+					const char *raddr  = ice->ice_params->cands[ii][cid].raddr;
+					switch_port_t rport = ice->ice_params->cands[ii][cid].rport;
+
+					memset(&vec[k], 0, sizeof(vec[k]));
+
+					vec[k].component_id = comp_id;
+
+					if (found) {
+						switch_copy_string(vec[k].foundation, found, sizeof(vec[k].foundation));
+					}
+
+					switch_copy_string(vec[k].transport, (transport && *transport) ? transport : "udp", sizeof(vec[k].transport));
+
+					vec[k].priority = (unsigned long)prio;
+
+					if (addr) {
+						switch_copy_string(vec[k].ip, addr, sizeof(vec[k].ip));
+					}
+					vec[k].port = (int)port;
+
+					if (ctype) {
+						switch_copy_string(vec[k].cand_type, ctype, sizeof(vec[k].cand_type));
+					}
+
+					if (raddr) {
+						switch_copy_string(vec[k].rel_addr, raddr, sizeof(vec[k].rel_addr));
+					} else {
+						vec[k].rel_addr[0] = '\0';
+					}
+					
+					vec[k].rel_port = (int)rport;
+
+					++k;
 				}
 			}
-
-			idx = ice_in->cand_idx[engine_cid];
-			if (idx >= MAX_CAND) {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
-					"Trickle ICE merge: capacity full (%d/%d), dropping %s:%d comp=%d\n",
-					idx, MAX_CAND, addr ? addr : "?", (int)port, comp_id);
-				goto next_merge_cand;
-			}
-
-			dst = &ice_in->cands[idx][engine_cid];
-			dst->foundation   = found ? switch_core_session_strdup(session, found) : NULL;
-			dst->component_id = comp_id;
-			dst->transport    = transport ? switch_core_session_strdup(session, transport) : NULL;
-			dst->priority     = prio;
-			dst->con_addr     = addr ? switch_core_session_strdup(session, addr) : NULL;
-			dst->con_port     = port;
-			dst->cand_type    = ctype ? switch_core_session_strdup(session, ctype) : NULL;
-			dst->raddr        = raddr ? switch_core_session_strdup(session, raddr) : NULL;
-			dst->rport        = rport;
-			dst->ready        = 1;
-
-			ice_in->cand_idx[engine_cid] = idx + 1;
-			added++;
-
-		next_merge_cand:
-			;
 		}
 	}
 
-	switch_mutex_unlock(rtp->ice_mutex);
-
-	return added;
+	*out_vec = vec;
+	return total;
 }
+
 static inline switch_channel_t *cand_get_channel(const switch_rtp_t *rtp_session)
 {
 	switch_channel_t *ch;

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -258,10 +258,26 @@ switch_bool_t switch_telnyx_sofia_register_handler(
 	return SWITCH_FALSE;
 }
 
-void * switch_telnyx_sofia_find_nua(const char *profile_name)
+void * switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle)
 {
+	if (profile_handle) *profile_handle = NULL;
 	if (_event_dispatch.switch_telnyx_sofia_find_nua) {
-		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name);
+		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name, profile_handle);
 	}
 	return NULL;
+}
+
+void switch_telnyx_sofia_release_profile(void *profile_handle)
+{
+	if (profile_handle && _event_dispatch.switch_telnyx_sofia_release_profile) {
+		_event_dispatch.switch_telnyx_sofia_release_profile(profile_handle);
+	}
+}
+
+switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
+{
+	if (_event_dispatch.switch_telnyx_sofia_find_profile_url) {
+		return _event_dispatch.switch_telnyx_sofia_find_profile_url(profile_name, use_tls, buf, buflen);
+	}
+	return SWITCH_STATUS_FALSE;
 }


### PR DESCRIPTION
NUA bridge API:
- Add switch_telnyx_sofia_find_nua() with ref-counted profile handle to prevent use-after-free when caller holds NUA pointer
- Add switch_telnyx_sofia_release_profile() for callers to release the profile read-lock after NUA use
- Pre-filter NUA events by type before dispatching to external handler; only register/unregister responses are dispatched, call-path events (INVITE, BYE, ACK) bypass for zero overhead

Profile URL for Contact headers:
- Add switch_telnyx_sofia_find_profile_url() exposing profile SIP IP and port for building explicit Contact headers
- Add use_tls parameter to return TLS port instead of SIP port for TLS registrations