### PR TITLE
TEL-6976: Add NUA bridge API and TLS profile URL support

### DIFF
--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -28,16 +28,36 @@ typedef switch_bool_t (*switch_telnyx_on_media_timeout_func)(switch_channel_t*, 
 typedef void (*switch_telnyx_channel_event_set_basic_data_func)(switch_channel_t*, switch_event_t*);
 typedef switch_bool_t (*switch_telnyx_on_add_media_bug_func)(switch_media_bug_t**, switch_media_bug_t*, const char*, const char*);
 
-/* Get the NUA handle for a named mod_sofia profile. Returns nua_t* as void*.
- * Returns NULL if the profile is not found or not running.
- * The returned pointer is valid as long as the profile is alive. */
-typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name);
+/* Acquire a ref-counted NUA handle for a named mod_sofia profile.
+ * Returns nua_t* as void*. The caller MUST call switch_telnyx_sofia_release_profile()
+ * when done using the NUA pointer to release the read-lock on the profile.
+ * The profile_handle output parameter receives an opaque handle that must be
+ * passed to the release function. Returns NULL if profile is not found/running. */
+typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name, void **profile_handle);
 
-/* Registration handler callback for external registration engines.
- * When set, mod_sofia dispatches nua_r_register/nua_r_unregister events to this handler
- * before processing them internally. Sofia-SIP types are passed as void* to avoid
- * pulling sofia-sip headers into the core.
- * Returns SWITCH_TRUE if the event was handled, SWITCH_FALSE to fall through to mod_sofia. */
+/* Release the profile read-lock acquired by switch_telnyx_sofia_find_nua().
+ * Must be called once for every successful find_nua call. */
+typedef void (*switch_telnyx_sofia_release_profile_func)(void *profile_handle);
+
+/* Get the SIP URL for a named mod_sofia profile (e.g. "IP:PORT").
+ * When use_tls is true, returns the TLS IP:PORT instead.
+ * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success. */
+typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
+
+/* NUA event handler callback for external modules that own NUA handles.
+ *
+ * When set, mod_sofia dispatches ALL NUA events to this handler before its own
+ * processing. This is necessary because external modules bind their own structs
+ * (not sofia_private_t) to NUA handles — if mod_sofia processed these events,
+ * it would dereference the wrong struct type.
+ *
+ * The handler identifies its own handles via a magic sentinel in hmagic and
+ * returns SWITCH_TRUE to consume the event, SWITCH_FALSE to fall through.
+ *
+ * Performance: mod_sofia pre-filters by event type — only register/unregister
+ * responses and inbound events on handles with non-NULL hmagic are dispatched.
+ * Call-path events (INVITE, BYE, ACK, etc.) on mod_sofia's own handles are
+ * never dispatched to this handler. */
 typedef switch_bool_t (*switch_telnyx_sofia_register_handler_func)(
 	int event, int status, const char *phrase,
 	void *nua, void *nh, void *hmagic,
@@ -64,6 +84,8 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_on_add_media_bug_func switch_telnyx_on_add_media_bug;
 	switch_telnyx_sofia_register_handler_func switch_telnyx_sofia_register_handler;
 	switch_telnyx_sofia_find_nua_func switch_telnyx_sofia_find_nua;
+	switch_telnyx_sofia_release_profile_func switch_telnyx_sofia_release_profile;
+	switch_telnyx_sofia_find_profile_url_func switch_telnyx_sofia_find_profile_url;
 } switch_telnyx_event_dispatch_t;
 
 SWITCH_DECLARE(void) switch_telnyx_init(switch_memory_pool_t *pool);
@@ -96,7 +118,9 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_sip_on_media_timeout(switch_channel_
 SWITCH_DECLARE(void) switch_telnyx_channel_event_set_basic_data(switch_channel_t *channel, switch_event_t *event);
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t **list, switch_media_bug_t *bug, const char* function, const char* target);
 
-SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name);
+SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle);
+SWITCH_DECLARE(void) switch_telnyx_sofia_release_profile(void *profile_handle);
+SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
 	int event, int status, const char *phrase,

--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -45,13 +45,14 @@ typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name, vo
  * Must be called once for every successful find_nua call. */
 typedef void (*switch_telnyx_sofia_release_profile_func)(void *profile_handle);
 
-/* Get the advertised host:port for a named mod_sofia profile.
- * Uses ext-sip-ip/ext-sip-port when configured, otherwise the bound address.
- * When use_tls is true, returns the TLS port (requires PFLAG_TLS on the profile).
- * IPv6 addresses are bracket-wrapped per RFC 3986.
- * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success,
- * SWITCH_STATUS_FALSE on error (profile not found, TLS not configured, truncation). */
-typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
+/* Get the advertised host:port (addr) for a named mod_sofia profile.
+ * Uses ext-sip-ip/ext-sip-port when explicitly configured (not auto-NAT),
+ * otherwise the bound address. When use_tls is true, returns the TLS port
+ * (requires PFLAG_TLS on the profile). IPv6 addresses are bracket-wrapped
+ * per RFC 3986. Writes into buf up to buflen bytes.
+ * Returns SWITCH_STATUS_SUCCESS on success, SWITCH_STATUS_FALSE on error
+ * (profile not found, TLS not configured, truncation). */
+typedef switch_status_t (*switch_telnyx_sofia_find_profile_addr_func)(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 /* NUA event handler callback for external modules that own NUA handles.
  *
@@ -94,7 +95,7 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_sofia_register_handler_func switch_telnyx_sofia_register_handler;
 	switch_telnyx_sofia_find_nua_func switch_telnyx_sofia_find_nua;
 	switch_telnyx_sofia_release_profile_func switch_telnyx_sofia_release_profile;
-	switch_telnyx_sofia_find_profile_url_func switch_telnyx_sofia_find_profile_url;
+	switch_telnyx_sofia_find_profile_addr_func switch_telnyx_sofia_find_profile_addr;
 } switch_telnyx_event_dispatch_t;
 
 SWITCH_DECLARE(void) switch_telnyx_init(switch_memory_pool_t *pool);
@@ -129,7 +130,7 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_on_add_media_bug(switch_media_bug_t 
 
 SWITCH_DECLARE(void *) switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle);
 SWITCH_DECLARE(void) switch_telnyx_sofia_release_profile(void *profile_handle);
-SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
+SWITCH_DECLARE(switch_status_t) switch_telnyx_sofia_find_profile_addr(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
 	int event, int status, const char *phrase,

--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -31,33 +31,42 @@ typedef switch_bool_t (*switch_telnyx_on_add_media_bug_func)(switch_media_bug_t*
 /* Acquire a ref-counted NUA handle for a named mod_sofia profile.
  * Returns nua_t* as void*. The caller MUST call switch_telnyx_sofia_release_profile()
  * when done using the NUA pointer to release the read-lock on the profile.
- * The profile_handle output parameter receives an opaque handle that must be
- * passed to the release function. Returns NULL if profile is not found/running. */
+ * The profile_handle output parameter is required and receives an opaque handle
+ * that must be passed to the release function. Returns NULL if profile is not
+ * found/running or if profile_handle is NULL.
+ *
+ * LIFETIME: hold profile_handle only for the duration of a single NUA operation.
+ * Do NOT cache the NUA pointer or profile_handle across sleeps or blocking calls
+ * -- re-acquire on each use and release before blocking. Holding the read-lock
+ * indefinitely blocks profile restarts and shutdown. */
 typedef void * (*switch_telnyx_sofia_find_nua_func)(const char *profile_name, void **profile_handle);
 
 /* Release the profile read-lock acquired by switch_telnyx_sofia_find_nua().
  * Must be called once for every successful find_nua call. */
 typedef void (*switch_telnyx_sofia_release_profile_func)(void *profile_handle);
 
-/* Get the SIP URL for a named mod_sofia profile (e.g. "IP:PORT").
- * When use_tls is true, returns the TLS IP:PORT instead.
- * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success. */
+/* Get the advertised host:port for a named mod_sofia profile.
+ * Uses ext-sip-ip/ext-sip-port when configured, otherwise the bound address.
+ * When use_tls is true, returns the TLS port (requires PFLAG_TLS on the profile).
+ * IPv6 addresses are bracket-wrapped per RFC 3986.
+ * Writes into buf up to buflen bytes. Returns SWITCH_STATUS_SUCCESS on success,
+ * SWITCH_STATUS_FALSE on error (profile not found, TLS not configured, truncation). */
 typedef switch_status_t (*switch_telnyx_sofia_find_profile_url_func)(const char *profile_name, int use_tls, char *buf, switch_size_t buflen);
 
 /* NUA event handler callback for external modules that own NUA handles.
  *
- * When set, mod_sofia dispatches ALL NUA events to this handler before its own
- * processing. This is necessary because external modules bind their own structs
- * (not sofia_private_t) to NUA handles — if mod_sofia processed these events,
- * it would dereference the wrong struct type.
+ * When set, mod_sofia dispatches registration-related NUA events to this handler
+ * before its own processing. This is necessary because external modules bind their
+ * own structs (not sofia_private_t) to NUA handles -- if mod_sofia processed these
+ * events, it would dereference the wrong struct type.
  *
  * The handler identifies its own handles via a magic sentinel in hmagic and
  * returns SWITCH_TRUE to consume the event, SWITCH_FALSE to fall through.
  *
- * Performance: mod_sofia pre-filters by event type — only register/unregister
- * responses and inbound events on handles with non-NULL hmagic are dispatched.
- * Call-path events (INVITE, BYE, ACK, etc.) on mod_sofia's own handles are
- * never dispatched to this handler. */
+ * Dispatched events: nua_r_register, nua_r_unregister, nua_r_authenticate,
+ * nua_i_outbound. Call-path events (INVITE, BYE, ACK, etc.) are never dispatched.
+ * External modules that bind handles receiving events outside this set must update
+ * the pre-filter in sofia_event_callback(). */
 typedef switch_bool_t (*switch_telnyx_sofia_register_handler_func)(
 	int event, int status, const char *phrase,
 	void *nua, void *nh, void *hmagic,
@@ -130,4 +139,3 @@ SWITCH_DECLARE(switch_bool_t) switch_telnyx_sofia_register_handler(
 SWITCH_END_EXTERN_C
 
 #endif /* SWITCH_TELNYX_H */
-

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7048,22 +7048,24 @@ char *sofia_stir_shaken_as_create_identity_header(switch_core_session_t *session
 
 /* Acquire a ref-counted NUA handle for a named sofia profile.
  * The profile read-lock is held until sofia_release_profile_handle() is called.
- * This prevents the profile (and its NUA) from being destroyed while in use. */
+ * This prevents the profile (and its NUA) from being destroyed while in use.
+ * profile_handle is required — callers MUST release via sofia_release_profile_handle(). */
 static void *sofia_find_nua_by_profile(const char *profile_name, void **profile_handle)
 {
-	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+	sofia_profile_t *profile;
 
-	if (profile_handle) *profile_handle = NULL;
-	if (!profile) return NULL;
-
-	/* Return the profile as an opaque handle — caller must release it */
-	if (profile_handle) {
-		*profile_handle = (void *)profile;
-	} else {
-		/* No handle output — caller can't release, so release now (legacy) */
-		sofia_glue_release_profile(profile);
+	if (!profile_handle) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+			"sofia_find_nua_by_profile called without profile_handle output — "
+			"caller must use the ref-counted API\n");
+		return NULL;
 	}
 
+	*profile_handle = NULL;
+	profile = sofia_glue_find_profile(profile_name);
+	if (!profile) return NULL;
+
+	*profile_handle = (void *)profile;
 	return (void *)profile->nua;
 }
 
@@ -7075,26 +7077,46 @@ static void sofia_release_profile_handle(void *profile_handle)
 	}
 }
 
-/* Return the SIP URL (sip:mod_sofia@IP:PORT) for a named sofia profile */
+/* Return the host:port for a named sofia profile.
+ * When use_tls is true, returns the TLS port instead.
+ * IPv6 addresses are bracket-wrapped per RFC 3986. */
 static switch_status_t sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
 {
-	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+	sofia_profile_t *profile;
 	const char *ip;
+	const char *ob, *cb;
 	int port;
+	int written;
 
+	if (!buf || buflen == 0) return SWITCH_STATUS_FALSE;
+
+	profile = sofia_glue_find_profile(profile_name);
 	if (!profile) return SWITCH_STATUS_FALSE;
 
-	ip = profile->extsipip ? profile->extsipip : profile->sipip;
-
 	if (use_tls) {
+		if (!sofia_test_pflag(profile, PFLAG_TLS)) {
+			sofia_glue_release_profile(profile);
+			return SWITCH_STATUS_FALSE;
+		}
 		port = profile->tls_sip_port;
 	} else {
 		port = profile->extsipip ? profile->extsipport : profile->sip_port;
 	}
 
-	snprintf(buf, buflen, "%s:%d", ip, port);
+	/* extsipport can be 0 if not explicitly configured */
+	if (!port) port = profile->sip_port;
+
+	ip = profile->extsipip ? profile->extsipip : profile->sipip;
+
+	/* Bracket-wrap IPv6 addresses */
+	ob = strchr(ip, ':') ? "[" : "";
+	cb = strchr(ip, ':') ? "]" : "";
+
+	written = switch_snprintf(buf, buflen, "%s%s%s:%d", ob, ip, cb, port);
 
 	sofia_glue_release_profile(profile);
+
+	if (written < 0 || written >= (int)buflen) return SWITCH_STATUS_FALSE;
 
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7061,9 +7061,15 @@ static void *sofia_find_nua_by_profile(const char *profile_name, void **profile_
 		return NULL;
 	}
 
+	/* Clear before dispatch so caller never sees stale data on error */
 	*profile_handle = NULL;
 	profile = sofia_glue_find_profile(profile_name);
 	if (!profile) return NULL;
+
+	if (!profile->nua) {
+		sofia_glue_release_profile(profile);
+		return NULL;
+	}
 
 	*profile_handle = (void *)profile;
 	return (void *)profile->nua;
@@ -7077,10 +7083,14 @@ static void sofia_release_profile_handle(void *profile_handle)
 	}
 }
 
-/* Return the host:port for a named sofia profile.
- * When use_tls is true, returns the TLS port instead.
- * IPv6 addresses are bracket-wrapped per RFC 3986. */
-static switch_status_t sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
+/* Return the advertised host:port (addr) for a named sofia profile.
+ * Uses ext-sip-ip/ext-sip-port when explicitly configured (not auto-NAT),
+ * otherwise the bound address. When use_tls is true, returns the TLS port
+ * (requires PFLAG_TLS on the profile). IPv6 addresses are bracket-wrapped
+ * per RFC 3986. Writes into buf up to buflen bytes.
+ * Returns SWITCH_STATUS_SUCCESS on success, SWITCH_STATUS_FALSE on error
+ * (profile not found, TLS not configured, truncation). */
+static switch_status_t sofia_find_profile_addr(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
 {
 	sofia_profile_t *profile;
 	const char *ip;
@@ -7098,15 +7108,33 @@ static switch_status_t sofia_find_profile_url(const char *profile_name, int use_
 			sofia_glue_release_profile(profile);
 			return SWITCH_STATUS_FALSE;
 		}
-		port = profile->tls_sip_port;
+		/* Mirror config_sofia_profile_urls(): use extsipip only when
+		 * explicitly configured (not auto-NAT). */
+		if (profile->extsipip && !sofia_test_pflag(profile, PFLAG_AUTO_NAT)) {
+			ip = profile->extsipip;
+			port = profile->tls_sip_port;
+		} else {
+			ip = profile->sipip;
+			port = profile->tls_sip_port;
+		}
+	} else if (profile->extsipip && !sofia_test_pflag(profile, PFLAG_AUTO_NAT)) {
+		ip = profile->extsipip;
+		port = profile->extsipport;
 	} else {
-		port = profile->extsipip ? profile->extsipport : profile->sip_port;
+		ip = profile->sipip;
+		port = profile->sip_port;
 	}
 
-	/* extsipport can be 0 if not explicitly configured */
-	if (!port) port = profile->sip_port;
-
-	ip = profile->extsipip ? profile->extsipip : profile->sipip;
+	/* Guard against zero port — for non-TLS, extsipport may be 0 if
+	 * not explicitly configured. For TLS, a zero port means TLS is
+	 * misconfigured — fail rather than return the wrong port. */
+	if (!port) {
+		if (use_tls) {
+			sofia_glue_release_profile(profile);
+			return SWITCH_STATUS_FALSE;
+		}
+		port = profile->sip_port;
+	}
 
 	/* Bracket-wrap IPv6 addresses */
 	ob = strchr(ip, ':') ? "[" : "";
@@ -7377,7 +7405,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	switch_telnyx_event_dispatch()->switch_telnyx_call_recover = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_nua = sofia_find_nua_by_profile;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_release_profile = sofia_release_profile_handle;
-	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_profile_url = sofia_find_profile_url;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_profile_addr = sofia_find_profile_addr;
 
 	management_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_MANAGEMENT_INTERFACE);
 	management_interface->relative_oid = "1001";

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -7046,18 +7046,57 @@ char *sofia_stir_shaken_as_create_identity_header(switch_core_session_t *session
 }
 
 
-/* Return the NUA handle for a named sofia profile */
-static void *sofia_find_nua_by_profile(const char *profile_name)
+/* Acquire a ref-counted NUA handle for a named sofia profile.
+ * The profile read-lock is held until sofia_release_profile_handle() is called.
+ * This prevents the profile (and its NUA) from being destroyed while in use. */
+static void *sofia_find_nua_by_profile(const char *profile_name, void **profile_handle)
 {
 	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
-	void *nua;
 
+	if (profile_handle) *profile_handle = NULL;
 	if (!profile) return NULL;
 
-	nua = (void *)profile->nua;
+	/* Return the profile as an opaque handle — caller must release it */
+	if (profile_handle) {
+		*profile_handle = (void *)profile;
+	} else {
+		/* No handle output — caller can't release, so release now (legacy) */
+		sofia_glue_release_profile(profile);
+	}
+
+	return (void *)profile->nua;
+}
+
+/* Release the profile read-lock acquired by sofia_find_nua_by_profile() */
+static void sofia_release_profile_handle(void *profile_handle)
+{
+	if (profile_handle) {
+		sofia_glue_release_profile((sofia_profile_t *)profile_handle);
+	}
+}
+
+/* Return the SIP URL (sip:mod_sofia@IP:PORT) for a named sofia profile */
+static switch_status_t sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
+{
+	sofia_profile_t *profile = sofia_glue_find_profile(profile_name);
+	const char *ip;
+	int port;
+
+	if (!profile) return SWITCH_STATUS_FALSE;
+
+	ip = profile->extsipip ? profile->extsipip : profile->sipip;
+
+	if (use_tls) {
+		port = profile->tls_sip_port;
+	} else {
+		port = profile->extsipip ? profile->extsipport : profile->sip_port;
+	}
+
+	snprintf(buf, buflen, "%s:%d", ip, port);
+
 	sofia_glue_release_profile(profile);
 
-	return nua;
+	return SWITCH_STATUS_SUCCESS;
 }
 
 SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
@@ -7315,6 +7354,8 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 	//sofia_endpoint_interface->recover_callback = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_call_recover = sofia_recover_callback;
 	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_nua = sofia_find_nua_by_profile;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_release_profile = sofia_release_profile_handle;
+	switch_telnyx_event_dispatch()->switch_telnyx_sofia_find_profile_url = sofia_find_profile_url;
 
 	management_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_MANAGEMENT_INTERFACE);
 	management_interface->relative_oid = "1001";

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2527,15 +2527,27 @@ void sofia_event_callback(nua_event_t event,
 	uint32_t sess_max = switch_core_session_limit(0);
 	
 	/* External handle dispatch: if an external module (e.g. mod_dynamic_gateway)
-	 * owns this handle, dispatch ALL events to it — not just register/unregister.
-	 * The handler identifies its own handles via a magic sentinel and returns
-	 * SWITCH_TRUE to consume the event, preventing mod_sofia from misinterpreting
-	 * the handle's magic pointer as a sofia_private_t. */
-	if (switch_telnyx_sofia_register_handler(
-			(int)event, status, phrase,
-			(void *)nua, (void *)nh, (void *)sofia_private,
-			(const void *)sip, (void *)tags) == SWITCH_TRUE) {
-		return;
+	 * owns this handle, dispatch the event to it. The handler identifies its own
+	 * handles via a magic sentinel in sofia_private and returns SWITCH_TRUE to
+	 * consume the event, preventing mod_sofia from misinterpreting the handle's
+	 * magic pointer as a sofia_private_t.
+	 *
+	 * Pre-filter: only dispatch events that could belong to external handles.
+	 * Register/unregister responses are the primary use case. We also dispatch
+	 * inbound events (nua_i_*) on handles with non-NULL sofia_private, as
+	 * Sofia-SIP may generate outbound-related events (e.g. nua_i_outbound).
+	 * Call-path events (INVITE, BYE, ACK) on mod_sofia's own handles bypass
+	 * this entirely for zero overhead on the hot path. */
+	if (sofia_private &&
+		(event == nua_r_register || event == nua_r_unregister ||
+		 event == nua_r_authenticate ||
+		 event == nua_i_outbound || event == nua_i_register)) {
+		if (switch_telnyx_sofia_register_handler(
+				(int)event, status, phrase,
+				(void *)nua, (void *)nh, (void *)sofia_private,
+				(const void *)sip, (void *)tags) == SWITCH_TRUE) {
+			return;
+		}
 	}
 
 	switch(event) {

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2532,16 +2532,15 @@ void sofia_event_callback(nua_event_t event,
 	 * consume the event, preventing mod_sofia from misinterpreting the handle's
 	 * magic pointer as a sofia_private_t.
 	 *
-	 * Pre-filter: only dispatch events that could belong to external handles.
-	 * Register/unregister responses are the primary use case. We also dispatch
-	 * inbound events (nua_i_*) on handles with non-NULL sofia_private, as
-	 * Sofia-SIP may generate outbound-related events (e.g. nua_i_outbound).
-	 * Call-path events (INVITE, BYE, ACK) on mod_sofia's own handles bypass
-	 * this entirely for zero overhead on the hot path. */
+	 * Pre-filter: only dispatch registration-related events that external handles
+	 * receive. Call-path events (INVITE, BYE, ACK) on mod_sofia's own handles
+	 * bypass this entirely for zero overhead on the hot path.
+	 *
+	 * NOTE: external modules that bind NUA handles receiving events outside this
+	 * set must add their event types here, or risk sofia_private misinterpretation. */
 	if (sofia_private &&
 		(event == nua_r_register || event == nua_r_unregister ||
-		 event == nua_r_authenticate ||
-		 event == nua_i_outbound || event == nua_i_register)) {
+		 event == nua_r_authenticate || event == nua_i_outbound)) {
 		if (switch_telnyx_sofia_register_handler(
 				(int)event, status, phrase,
 				(void *)nua, (void *)nh, (void *)sofia_private,

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -274,10 +274,10 @@ void switch_telnyx_sofia_release_profile(void *profile_handle)
 	}
 }
 
-switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
+switch_status_t switch_telnyx_sofia_find_profile_addr(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
 {
-	if (_event_dispatch.switch_telnyx_sofia_find_profile_url) {
-		return _event_dispatch.switch_telnyx_sofia_find_profile_url(profile_name, use_tls, buf, buflen);
+	if (_event_dispatch.switch_telnyx_sofia_find_profile_addr) {
+		return _event_dispatch.switch_telnyx_sofia_find_profile_addr(profile_name, use_tls, buf, buflen);
 	}
 	return SWITCH_STATUS_FALSE;
 }

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -258,10 +258,26 @@ switch_bool_t switch_telnyx_sofia_register_handler(
 	return SWITCH_FALSE;
 }
 
-void * switch_telnyx_sofia_find_nua(const char *profile_name)
+void * switch_telnyx_sofia_find_nua(const char *profile_name, void **profile_handle)
 {
+	if (profile_handle) *profile_handle = NULL;
 	if (_event_dispatch.switch_telnyx_sofia_find_nua) {
-		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name);
+		return _event_dispatch.switch_telnyx_sofia_find_nua(profile_name, profile_handle);
 	}
 	return NULL;
+}
+
+void switch_telnyx_sofia_release_profile(void *profile_handle)
+{
+	if (profile_handle && _event_dispatch.switch_telnyx_sofia_release_profile) {
+		_event_dispatch.switch_telnyx_sofia_release_profile(profile_handle);
+	}
+}
+
+switch_status_t switch_telnyx_sofia_find_profile_url(const char *profile_name, int use_tls, char *buf, switch_size_t buflen)
+{
+	if (_event_dispatch.switch_telnyx_sofia_find_profile_url) {
+		return _event_dispatch.switch_telnyx_sofia_find_profile_url(profile_name, use_tls, buf, buflen);
+	}
+	return SWITCH_STATUS_FALSE;
 }


### PR DESCRIPTION
NUA bridge API:
- Add switch_telnyx_sofia_find_nua() with ref-counted profile handle to prevent use-after-free when caller holds NUA pointer
- Add switch_telnyx_sofia_release_profile() for callers to release the profile read-lock after NUA use
- Pre-filter NUA events by type before dispatching to external handler; only register/unregister responses are dispatched, call-path events (INVITE, BYE, ACK) bypass for zero overhead

Profile URL for Contact headers:
- Add switch_telnyx_sofia_find_profile_url() exposing profile SIP IP and port for building explicit Contact headers
- Add use_tls parameter to return TLS port instead of SIP port for TLS registrations