### PR TITLE
TEL-6982: Emit /channels in AMR-WB rtpmap for strict IMS peers

### DIFF
--- a/src/include/switch_module_interfaces.h
+++ b/src/include/switch_module_interfaces.h
@@ -771,6 +771,8 @@ struct switch_codec_implementation {
 	uint32_t impl_id;
 	char *modname;
 	struct switch_codec_implementation *next;
+	/*! always write /channels in rtpmap even when channels == 1 (strict IMS peers) */
+	switch_bool_t always_emit_channels_in_rtpmap;
 };
 
 /*! \brief Top level module interface to implement a series of codec implementations */

--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -2820,6 +2820,8 @@ typedef struct payload_map_s {
 
 	struct payload_map_s *next;
 
+	switch_bool_t always_emit_channels_in_rtpmap;
+
 } payload_map_t;
 
 typedef enum {

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -932,6 +932,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_amrwb_load)
 										 SWITCH_CODEC_TYPE_AUDIO, 100, "AMR-WB", default_fmtp_oa,
 										 16000, 16000, 23850, 20000, 320, 640, 0, 1, 1,
 										 switch_amrwb_init, switch_amrwb_encode, switch_amrwb_decode, switch_amrwb_destroy);
+	codec_interface->implementations->always_emit_channels_in_rtpmap = SWITCH_TRUE;
 #ifndef AMRWB_PASSTHROUGH
 	codec_interface->implementations->codec_control = switch_amrwb_control;
 	codec_interface->implementations->matches_fmtp = matches_fmtp;
@@ -946,6 +947,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_amrwb_load)
 										 SWITCH_CODEC_TYPE_AUDIO, 110, "AMR-WB", default_fmtp_be,
 										 16000, 16000, 23850, 20000, 320, 640, 0, 1, 1,
 										 switch_amrwb_init, switch_amrwb_encode, switch_amrwb_decode, switch_amrwb_destroy);
+	codec_interface->implementations->always_emit_channels_in_rtpmap = SWITCH_TRUE;
 #ifndef AMRWB_PASSTHROUGH
 	codec_interface->implementations->codec_control = switch_amrwb_control;
 	codec_interface->implementations->matches_fmtp = matches_fmtp;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -7985,6 +7985,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					pmap->codec_ms = mimp->microseconds_per_packet / 1000;
 					pmap->bitrate = mimp->bits_per_second;
 					pmap->channels = mimp->number_of_channels;
+					pmap->always_emit_channels_in_rtpmap = mimp->always_emit_channels_in_rtpmap;
 
 					if (!strcasecmp((char *) mmap->rm_encoding, "opus")) {
 						// Set adv_channels to what remote advertised, not based on our internal channels
@@ -12773,7 +12774,7 @@ static void generate_m(switch_core_session_t *session, char *buf, size_t buflen,
 		if (smh->ianacodes[i] > 95 || switch_channel_test_flag(session->channel, CF_VERBOSE_SDP)) {
 			int channels = get_channels(imp->iananame, imp->number_of_channels);
 
-			if (channels > 1) {
+			if (channels > 1 || imp->always_emit_channels_in_rtpmap) {
 				switch_snprintf(buf + strlen(buf), buflen - strlen(buf), "a=rtpmap:%d %s/%d/%d\r\n", smh->ianacodes[i], imp->iananame, rate, channels);
 
 			} else {
@@ -13661,7 +13662,7 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 			a_engine->cur_payload_map->adv_channels = get_channels(a_engine->cur_payload_map->rm_encoding, 1);
 		}
 
-		if (a_engine->cur_payload_map->adv_channels > 1) {
+		if (a_engine->cur_payload_map->adv_channels > 1 || a_engine->cur_payload_map->always_emit_channels_in_rtpmap) {
 			switch_snprintf(buf + strlen(buf), SDPBUFLEN - strlen(buf), "a=rtpmap:%d %s/%d/%d\r\n",
 							a_engine->cur_payload_map->pt, a_engine->cur_payload_map->rm_encoding, rate, a_engine->cur_payload_map->adv_channels);
 		} else {
@@ -14187,7 +14188,7 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 						//		red = ianacode;
 						//}
 
-						if (channels > 1) {
+						if (channels > 1 || imp->always_emit_channels_in_rtpmap) {
 							switch_snprintf(buf + strlen(buf), SDPBUFLEN - strlen(buf), "a=rtpmap:%d %s/%d/%d\r\n", ianacode, imp->iananame,
 											imp->samples_per_second, channels);
 						} else {


### PR DESCRIPTION
FreeSWITCH has never emitted the channels suffix in rtpmap for mono codecs (since commit 05dd02d0a6 in 2013), relying on RFC 4566's implicit default of 1. Some IMS/VoLTE peers (e.g. Mavenir) reject such answers with "no audio payload can be selected" and immediately BYE the call, requiring the explicit "/1".

Add a per-codec-impl flag always_emit_channels_in_rtpmap, plumbed into payload_map_t during SDP negotiation, and consulted at all three rtpmap emission sites in switch_core_media.c. Set the flag on both AMR-WB implementations (octet-aligned and bandwidth-efficient).

Both new struct fields are added at the end of their respective structs to preserve binary layout of existing fields.