### PR TITLE
TEL-6986: opt-in bridge_generate_silence_on_hold

### DIFF
--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -440,6 +440,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 	const char *silence_var;
 	const char *continuous_silence_var;
 	switch_bool_t bridge_generate_silence_on_hold = SWITCH_FALSE;
+	switch_bool_t bridge_generate_silence_on_hold_codec = SWITCH_FALSE;
 	int silence_val = 0, bypass_media_after_bridge = 0, max_continuous_silence_ms = 0, silence_threshold = 0;
 	const char *bridge_answer_timeout = NULL;
 	int bridge_filter_dtmf, answer_timeout, sent_update = 0;
@@ -595,13 +596,6 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		}
 	}
 
-	bridge_generate_silence_on_hold = switch_channel_var_true(chan_a, "bridge_generate_silence_on_hold");
-
-	if (bridge_generate_silence_on_hold && !switch_channel_media_up(chan_a)) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_ERROR, "Channel has no media!\n");
-		goto end_of_bridge_loop;
-	}
-
 	if ((silence_var = switch_channel_get_variable(chan_a, "bridge_generate_comfort_noise"))) {
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: silence_var - %s %p\n", silence_var, (void*)session_a);
@@ -619,14 +613,45 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				silence_val = 0;
 			}
 		}
+
+		if (silence_val) {
+			if (switch_core_codec_init(&silence_codec,
+									   "L16",
+									   NULL,
+									   NULL,
+									   read_impl.actual_samples_per_second,
+									   read_impl.microseconds_per_packet / 1000,
+									   1,
+									   SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+									   NULL, switch_core_session_get_pool(session_a)) != SWITCH_STATUS_SUCCESS) {
+
+				silence_val = 0;
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated silence from %s to %s at %d\n", switch_channel_get_name(chan_a),
+								  switch_channel_get_name(chan_b), silence_val);
+				silence_frame.codec = &silence_codec;
+				silence_frame.data = silence_data;
+				silence_frame.buflen = sizeof(silence_data);
+				silence_frame.datalen = read_impl.decoded_bytes_per_packet;
+				silence_frame.samples = silence_frame.datalen / sizeof(int16_t);
+			}
+		}
 	} else {
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: NO silence_var %p %p -> %p\n", (void*)session_a, (void*)session_a, (void*)session_b);
 #endif
 	}
 
-	if (silence_val || bridge_generate_silence_on_hold) {
-		if (switch_core_codec_init(&silence_codec,
+	bridge_generate_silence_on_hold = switch_channel_var_true(chan_a, "bridge_generate_silence_on_hold");
+
+	if (bridge_generate_silence_on_hold) {
+		if (!switch_channel_media_up(chan_a)) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_ERROR, "Channel has no media!\n");
+			goto end_of_bridge_loop;
+		}
+
+		if (!silence_frame.codec) {
+			if (switch_core_codec_init(&silence_codec,
 								   "L16",
 								   NULL,
 								   NULL,
@@ -636,22 +661,20 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 								   SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
 								   NULL, switch_core_session_get_pool(session_a)) != SWITCH_STATUS_SUCCESS) {
 
-			silence_val = 0;
-			bridge_generate_silence_on_hold = SWITCH_FALSE;
-		} else {
-			if (silence_val) {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated silence from %s to %s at %d\n", switch_channel_get_name(chan_a),
-								  switch_channel_get_name(chan_b), silence_val);
+				bridge_generate_silence_on_hold = SWITCH_FALSE;
+			} else {
+				bridge_generate_silence_on_hold_codec = SWITCH_TRUE;
+				silence_frame.codec = &silence_codec;
+				silence_frame.data = silence_data;
+				silence_frame.buflen = sizeof(silence_data);
+				silence_frame.datalen = read_impl.decoded_bytes_per_packet;
+				silence_frame.samples = silence_frame.datalen / sizeof(int16_t);
 			}
-			if (bridge_generate_silence_on_hold) {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated hold silence to %s while %s is held\n",
-								  switch_channel_get_name(chan_a), switch_channel_get_name(chan_b));
-			}
-			silence_frame.codec = &silence_codec;
-			silence_frame.data = silence_data;
-			silence_frame.buflen = sizeof(silence_data);
-			silence_frame.datalen = read_impl.decoded_bytes_per_packet;
-			silence_frame.samples = silence_frame.datalen / sizeof(int16_t);
+		}
+
+		if (bridge_generate_silence_on_hold) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated hold silence to %s while %s is held\n",
+							  switch_channel_get_name(chan_a), switch_channel_get_name(chan_b));
 		}
 	}
 
@@ -1153,27 +1176,26 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				continue;
 			}
 
-			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD)) {
-				if (!switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
 #if DEBUG_RTP
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write frame %p -> %p\n", (void*)session_a, (void*)session_b);
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write frame %p -> %p\n", (void*)session_a, (void*)session_b);
 #endif
-					if (switch_core_session_write_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+				if (switch_core_session_write_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from write function\n", switch_channel_get_name(chan_b));
-						goto end_of_bridge_loop;
-					}
-				} else if (bridge_generate_silence_on_hold) {
+					goto end_of_bridge_loop;
+				}
+			} else if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) &&
+					   bridge_generate_silence_on_hold && switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
 #if DEBUG_RTP
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write generated hold silence %p -> %p\n", (void*)session_a, (void*)session_a);
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write generated hold silence %p -> %p\n", (void*)session_a, (void*)session_a);
 #endif
-					switch_generate_sln_silence((int16_t *) silence_frame.data, silence_frame.samples,
-									read_impl.number_of_channels, 1400);
-					if (switch_core_session_write_frame(session_a, &silence_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+				switch_generate_sln_silence((int16_t *) silence_frame.data, silence_frame.samples,
+									 read_impl.number_of_channels, 1400);
+				if (switch_core_session_write_frame(session_a, &silence_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from hold silence write function\n", switch_channel_get_name(chan_a));
-						goto end_of_bridge_loop;
-					}
+					goto end_of_bridge_loop;
 				}
 			}
 		} else {
@@ -1205,7 +1227,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #endif
 
 
-	if (silence_frame.codec) {
+	if (silence_val) {
+		switch_core_codec_destroy(&silence_codec);
+	} else if (bridge_generate_silence_on_hold_codec) {
 		switch_core_codec_destroy(&silence_codec);
 	}
 

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -439,6 +439,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 	int16_t silence_data[SWITCH_RECOMMENDED_BUFFER_SIZE / 2] = { 0 };
 	const char *silence_var;
 	const char *continuous_silence_var;
+	switch_bool_t bridge_generate_silence_on_hold = SWITCH_FALSE;
 	int silence_val = 0, bypass_media_after_bridge = 0, max_continuous_silence_ms = 0, silence_threshold = 0;
 	const char *bridge_answer_timeout = NULL;
 	int bridge_filter_dtmf, answer_timeout, sent_update = 0;
@@ -594,6 +595,13 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		}
 	}
 
+	bridge_generate_silence_on_hold = switch_channel_var_true(chan_a, "bridge_generate_silence_on_hold");
+
+	if (bridge_generate_silence_on_hold && !switch_channel_media_up(chan_a)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_ERROR, "Channel has no media!\n");
+		goto end_of_bridge_loop;
+	}
+
 	if ((silence_var = switch_channel_get_variable(chan_a, "bridge_generate_comfort_noise"))) {
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: silence_var - %s %p\n", silence_var, (void*)session_a);
@@ -611,33 +619,40 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				silence_val = 0;
 			}
 		}
-
-		if (silence_val) {
-			if (switch_core_codec_init(&silence_codec,
-									   "L16",
-									   NULL,
-									   NULL,
-									   read_impl.actual_samples_per_second,
-									   read_impl.microseconds_per_packet / 1000,
-									   1,
-									   SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
-									   NULL, switch_core_session_get_pool(session_a)) != SWITCH_STATUS_SUCCESS) {
-
-				silence_val = 0;
-			} else {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated silence from %s to %s at %d\n", switch_channel_get_name(chan_a),
-								  switch_channel_get_name(chan_b), silence_val);
-				silence_frame.codec = &silence_codec;
-				silence_frame.data = silence_data;
-				silence_frame.buflen = sizeof(silence_data);
-				silence_frame.datalen = read_impl.decoded_bytes_per_packet;
-				silence_frame.samples = silence_frame.datalen / sizeof(int16_t);
-			}
-		}
 	} else {
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: NO silence_var %p %p -> %p\n", (void*)session_a, (void*)session_a, (void*)session_b);
 #endif
+	}
+
+	if (silence_val || bridge_generate_silence_on_hold) {
+		if (switch_core_codec_init(&silence_codec,
+								   "L16",
+								   NULL,
+								   NULL,
+								   read_impl.actual_samples_per_second,
+								   read_impl.microseconds_per_packet / 1000,
+								   1,
+								   SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+								   NULL, switch_core_session_get_pool(session_a)) != SWITCH_STATUS_SUCCESS) {
+
+			silence_val = 0;
+			bridge_generate_silence_on_hold = SWITCH_FALSE;
+		} else {
+			if (silence_val) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated silence from %s to %s at %d\n", switch_channel_get_name(chan_a),
+								  switch_channel_get_name(chan_b), silence_val);
+			}
+			if (bridge_generate_silence_on_hold) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated hold silence to %s while %s is held\n",
+								  switch_channel_get_name(chan_a), switch_channel_get_name(chan_b));
+			}
+			silence_frame.codec = &silence_codec;
+			silence_frame.data = silence_data;
+			silence_frame.buflen = sizeof(silence_data);
+			silence_frame.datalen = read_impl.decoded_bytes_per_packet;
+			silence_frame.samples = silence_frame.datalen / sizeof(int16_t);
+		}
 	}
 
 	bridge_filter_dtmf = switch_true(switch_channel_get_variable(chan_a, "bridge_filter_dtmf"));
@@ -1112,10 +1127,12 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 												read_impl.number_of_channels, silence_val);
 					read_frame = &silence_frame;
 				} else if (!switch_channel_test_flag(chan_b, CF_ACCEPT_CNG)) {
+					if (!(bridge_generate_silence_on_hold && switch_channel_test_flag(chan_b, CF_LEG_HOLDING))) {
 #if DEBUG_RTP
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: skip write frame, reason: CF_ACCEPT_CNG %p %p -> %p\n", (void*)session_b, (void*)session_a, (void*)session_b);
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: skip write frame, reason: CF_ACCEPT_CNG %p %p -> %p\n", (void*)session_b, (void*)session_a, (void*)session_b);
 #endif
-					continue;
+						continue;
+					}
 				}
 			} else {
 				if (silence_threshold && is_silence_frame(read_frame, silence_threshold, &read_impl)) {
@@ -1136,14 +1153,27 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				continue;
 			}
 
-			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD)) {
+				if (!switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
 #if DEBUG_RTP
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write frame %p -> %p\n", (void*)session_a, (void*)session_b);
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write frame %p -> %p\n", (void*)session_a, (void*)session_b);
 #endif
-				if (switch_core_session_write_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+					if (switch_core_session_write_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from write function\n", switch_channel_get_name(chan_b));
-					goto end_of_bridge_loop;
+						goto end_of_bridge_loop;
+					}
+				} else if (bridge_generate_silence_on_hold) {
+#if DEBUG_RTP
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write generated hold silence %p -> %p\n", (void*)session_a, (void*)session_a);
+#endif
+					switch_generate_sln_silence((int16_t *) silence_frame.data, silence_frame.samples,
+									read_impl.number_of_channels, 1400);
+					if (switch_core_session_write_frame(session_a, &silence_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+									  "%s ending bridge by request from hold silence write function\n", switch_channel_get_name(chan_a));
+						goto end_of_bridge_loop;
+					}
 				}
 			}
 		} else {
@@ -1175,7 +1205,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #endif
 
 
-	if (silence_val) {
+	if (silence_frame.codec) {
 		switch_core_codec_destroy(&silence_codec);
 	}
 


### PR DESCRIPTION
## TEL-6986 — `bridge_generate_silence_on_hold`

Add an opt-in channel variable `bridge_generate_silence_on_hold` to the bridge audio loop in `src/switch_ivr_bridge.c`. When set on a non-held leg and its peer enters SIP hold (`CF_LEG_HOLDING`, sendonly/inactive), the bridge generates codec-compatible silence toward the non-held leg only and writes nothing toward the held leg. Default (absent/false) preserves the existing behavior exactly.

### Why

For TEL-6986, B-leg goes on hold (`a=inactive` re-INVITE) and the B2BUA stops bridging media to A-leg while A-leg remains `sendrecv`. After ~10s of no RTP, the upstream carrier kills the call. We need a bridge-local way to keep RTP flowing toward the non-held leg without weakening hold semantics or sending CN payloads we did not negotiate.

### What

* New channel variable `bridge_generate_silence_on_hold` (boolean, opt-in, set on the **non-held** leg).
* Reuses the existing L16 silence-codec pattern shared with `bridge_generate_comfort_noise` — no new codec, no allocations, no separate timer thread.
* Silence cadence follows the bridge read loop (`read_impl.microseconds_per_packet`, typically ~20ms) — same scheduler as normal bridged frames.
* Silence is generated via `switch_generate_sln_silence(...)` and written through `switch_core_session_write_frame(session_a, ...)`, which transcodes to the negotiated active codec on the non-held leg (e.g. PCMU PT=0). We do **not** emit RFC 3389 CN.
* Codec destroy is now gated on `silence_frame.codec` so both `bridge_generate_comfort_noise` and `bridge_generate_silence_on_hold` paths clean up on every exit.

### What it does NOT do

* Does **not** touch `SWITCH_RTP_FLAG_PAUSE`, `CF_HOLD`, or `CF_LEG_HOLDING`.
* Does **not** write toward the held leg under any circumstance: the held side is still gated by `CF_LEG_HOLDING`. The new branch writes only to `session_a` (self / non-held side).
* Does **not** alter the default code path. With the variable unset/false, the produced binary is byte-equivalent to today’s behavior.
* Does **not** generate RFC 3389 CN unless already negotiated.

### Behavior matrix

| `bridge_generate_silence_on_hold` (chan_a) | chan_b state | Result |
|---|---|---|
| unset / false | any | unchanged from today |
| true | chan_b not held | codec opened, no silence frames written |
| true | chan_b `CF_LEG_HOLDING` | silence written to `session_a` only; nothing to held `session_b` |
| true | chan_a also `CF_HOLD` | `switch_core_session_write_frame()` short-circuits on `CF_HOLD`; effective no-op |

### Files changed
* `src/switch_ivr_bridge.c` — bridge audio loop only (1 file, +59 / −29).

### Risks

* Low. Strictly opt-in and bridge-local. The hot path with the variable unset matches the prior diff exactly aside from a refactor of the codec init / cleanup gate (`silence_frame.codec` instead of `silence_val`), which is functionally equivalent for the comfort-noise path.
* Codec init failure resets both `silence_val` and `bridge_generate_silence_on_hold`, so a failed init does not leave a dangling silence frame.

### Validation performed

* Variable name verified everywhere (no remaining `bridge_generate_hold_silence`).
* Brace balance check on `audio_bridge_thread()` — balanced.
* C90 compliance: declaration kept in the existing declaration block at the top of `audio_bridge_thread()`; no mid-block declarations added.
* Diff visually re-read three times before and after edit per Telnyx FS dev rules.
* Build / on-call tests will be done by Tuan per Rule 11. SIPp scenario (`uas-tel-6986.xml`) and PCAP-based verification will exercise the path before / after enabling the variable.

### Roll-out

1. Merge to `deploy-development`.
2. Set `bridge_generate_silence_on_hold=true` only on the inbound A-leg of the affected route (export / `bridge_export`).
3. Validate via SIPp UAS scenario and PCAP capture (steady ~20ms PCMU PT=0 stream during hold window, no leakage toward held leg, normal resume after un-hold).
4. Roll out wider once the carrier no-RTP timer is no longer firing.

Refs: TEL-6986
