### PR TITLE
TEL-6986: generate silence toward A-leg from hold path (supersedes #571)

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8863,6 +8863,20 @@ SWITCH_DECLARE(int) switch_core_media_toggle_hold(switch_core_session_t *session
 				stream = "local_stream://moh";
 			}
 
+			/* TEL-6986: When the bridged peer (A-leg) opts in via
+			 * bridge_generate_silence_on_hold=true, replace the normal hold
+			 * music with a timer-paced infinite silence stream so the held
+			 * peer (B-leg) does not pull existing MOH (e.g. noise.wav) toward
+			 * A. The broadcast still targets b_session (the partner = A-leg)
+			 * and is stopped automatically on unhold via the existing
+			 * switch_channel_stop_broadcast() path below. We never write RTP
+			 * to the held leg here. */
+			if (b_channel && switch_channel_var_true(b_channel, "bridge_generate_silence_on_hold")) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+								  "TEL-6986: bridge_generate_silence_on_hold=true on partner %s; overriding hold music with silence_stream://-1\n",
+								  switch_channel_get_name(b_channel));
+				stream = "silence_stream://-1";
+			}
 
 			if (stream && strcasecmp(stream, "silence") && (!b_channel || !switch_channel_test_flag(b_channel, CF_EVENT_LOCK_PRI))) {
 				if (!strcasecmp(stream, "indicate_hold")) {


### PR DESCRIPTION
## Summary

When the bridged peer (A-leg) opts in via `bridge_generate_silence_on_hold=true`, generate timer-paced silence toward A from the **hold/MOH path** instead of the bridge read/write loop. This supersedes #571.

Jira: TEL-6986

## Why #571 was wrong

When B sends re-INVITE with `sendonly`/`inactive`, mod_sofia drives `switch_core_media_toggle_hold(B, sendonly=1)`, which broadcasts B-channel hold music against the partner session A via `switch_ivr_broadcast(b_session_uuid, stream, SMF_ECHO_ALEG | SMF_LOOP | SMF_PRIORITY)`. That broadcast becomes the producer of audio toward A and effectively suspends bridge-loop frame writes on the same leg.

PCAP evidence (TEL-6986 topic 53803):
- A-leg sets `bridge_generate_silence_on_hold=true` ✓
- B gets `CF_LEG_HOLDING` ✓
- Telnyx→A RTP has a 5.393s gap during hold (only 1 packet in hold-answer→unhold-request window)
- A→Telnyx RTP continues normally (256 packets) — so A is NOT muted upstream
- Only existing hold playback (`/usr/share/sounds/noise.wav`) was reaching A in earlier captures

Conclusion: hooking silence into the bridge read/write loop (PR #571) cannot reach A during hold because the bridge loop is no longer the runtime path producing audio toward A. The fix has to live where the MOH broadcast lives.

## Fix

`src/switch_core_media.c` — `switch_core_media_toggle_hold()` (hold-start branch only):

```c
if (b_channel && switch_channel_var_true(b_channel, "bridge_generate_silence_on_hold")) {
    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
                      "TEL-6986: bridge_generate_silence_on_hold=true on partner %s; overriding hold music with silence_stream://-1\n",
                      switch_channel_get_name(b_channel));
    stream = "silence_stream://-1";
}
```

Then the **existing** `switch_ivr_broadcast(b_session_uuid, stream, SMF_ECHO_ALEG | SMF_LOOP | SMF_PRIORITY)` runs with `silence_stream://-1` instead of the normal MOH file. `silence_stream://` is FreeSWITCH's canonical timer-paced silence file (`mod_tone_stream`); `-1` means infinite. Already used as silent MOH by `mod_valet_parking.c:622` and `mod_fsv.c:761`.

## Required behavior — coverage

| Requirement | How it's met |
|---|---|
| Var on A-leg only | Read from `b_channel` inside `toggle_hold(B,…)`. `b_channel` is the partner = A-leg. No effect when B sets it. |
| Suppress normal hold playback when B holds | `stream` is overridden to `silence_stream://-1` before the broadcast, replacing whatever B-channel `hold_music` resolved to (incl. file MOH or empty/`silence`/`indicate_hold` which would otherwise mute A). |
| Timer-paced silence toward A independent of A-leg inbound RTP | `switch_ivr_broadcast` runs its own playback thread fed by the silence file framework. Bridge loop and A-leg inbound cadence are irrelevant. |
| Stop cleanly on unhold | Existing unhold branch already runs `switch_channel_stop_broadcast(b_channel)` + `switch_channel_wait_for_flag(b_channel, CF_BROADCAST, SWITCH_FALSE, 5000, NULL)`. Same as it already stops MOH today. |
| Never write RTP to held B-leg | Broadcast target is `b_session` = A-leg partner. The held session (B) is the function's `session` argument and is not written to here. |

## Diff

```
 src/switch_core_media.c | 14 ++++++++++++++
 1 file changed, 14 insertions(+)
```

Single hunk, 14 lines added, zero deletions, no other files touched.

## Validation

- `git diff --check` — clean, no whitespace errors.
- C90 syntax sanity-check on the new hunk in isolation: PASS.
- Manual hold-flow trace verified:
  1. B sends re-INVITE `sendonly` → `sofia.c` calls `switch_core_media_toggle_hold(B, 1)`.
  2. `toggle_hold` locates partner via `switch_core_session_get_partner(session, &b_session)` → `b_channel`.
  3. Hunk reads `bridge_generate_silence_on_hold` from `b_channel` (A-leg). If true, override `stream`.
  4. Existing guard `(!b_channel || !switch_channel_test_flag(b_channel, CF_EVENT_LOCK_PRI))` preserved.
  5. Existing `switch_ivr_broadcast(...)` plays `silence_stream://-1` to A.
- Unhold branch verified: `switch_channel_stop_broadcast(b_channel)` is called regardless of the stream content; cleanup is generic.
- Variable name confirmed: `bridge_generate_silence_on_hold` (matches Tuan-corrected naming, not `bridge_generate_hold_silence`).
- `switch_channel_var_true` is a static inline declared in `src/include/switch_channel.h:366` — safe to use, no link risk.
- Build not run locally (Tuan owns build/QA per workflow). Targeted CI build will exercise.

## Coding-rule self-check

- C90: yes, one decl-then-statements pattern, no mid-block decls.
- Lock balance: no new locks introduced; partner session ref obtained via existing `switch_core_session_get_partner` call, unlocked at end of function via existing `switch_core_session_rwunlock(b_session)`.
- Alloc balance: no allocations.
- NULL checks: `b_channel` checked before deref; `b_channel` was already null-checked by the surrounding existing guard.
- Error paths: override is best-effort; if `silence_stream://-1` open fails inside the broadcast, behavior degrades to the existing MOH-failure path (already handled by `switch_ivr_broadcast`).
- Smallest fix: 14 lines, single file, single function, single new code path.
- Logging: one INFO log when the override fires (off by default volume, fires once per hold transition).
- Blast radius: zero when `bridge_generate_silence_on_hold` is unset (default).

## Followups (out of scope for this PR)

- Council of Claws PCAP review on a fresh capture once Tuan rebuilds B2BUA with this branch.
- Optional: extend to video MOH path if needed (current scope: audio only, matching feature spec).

Closes #571 in spirit (replaced).
