### PR TITLE
TEL-6986: Generate silence toward A-leg from hold path

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4324,7 +4324,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_write_frame(switch_core_sessio
 	if (type == SWITCH_MEDIA_TYPE_AUDIO) {
 		switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
 
-		if (audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
+		if (!(flags & SWITCH_IO_FLAG_FORCE) && audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
 			switch_thread_rwlock_unlock(engine->dtls_init_rwlock);
 			return SWITCH_STATUS_SUCCESS;
 		}

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -440,6 +440,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 	const char *silence_var;
 	const char *continuous_silence_var;
 	int silence_val = 0, bypass_media_after_bridge = 0, max_continuous_silence_ms = 0, silence_threshold = 0;
+	int silence_codec_initialized = 0, generate_silence_on_hold = 0, logged_generated_hold_silence = 0;
 	const char *bridge_answer_timeout = NULL;
 	int bridge_filter_dtmf, answer_timeout, sent_update = 0;
 	time_t answer_limit = 0;
@@ -625,6 +626,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 				silence_val = 0;
 			} else {
+				silence_codec_initialized = 1;
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated silence from %s to %s at %d\n", switch_channel_get_name(chan_a),
 								  switch_channel_get_name(chan_b), silence_val);
 				silence_frame.codec = &silence_codec;
@@ -638,6 +640,36 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: NO silence_var %p %p -> %p\n", (void*)session_a, (void*)session_a, (void*)session_b);
 #endif
+	}
+
+	if (switch_channel_var_true(chan_b, "bridge_generate_silence_on_hold")) {
+		generate_silence_on_hold = 1;
+
+		if (!silence_val) {
+			silence_val = 1400;
+
+			if (switch_core_codec_init(&silence_codec,
+									   "L16",
+									   NULL,
+									   NULL,
+									   read_impl.actual_samples_per_second,
+									   read_impl.microseconds_per_packet / 1000,
+									   1,
+									   SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+									   NULL, switch_core_session_get_pool(session_a)) != SWITCH_STATUS_SUCCESS) {
+				silence_val = 0;
+				generate_silence_on_hold = 0;
+			} else {
+				silence_codec_initialized = 1;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+								  "Setup hold-generated silence from %s to %s\n", switch_channel_get_name(chan_a), switch_channel_get_name(chan_b));
+				silence_frame.codec = &silence_codec;
+				silence_frame.data = silence_data;
+				silence_frame.buflen = sizeof(silence_data);
+				silence_frame.datalen = read_impl.decoded_bytes_per_packet;
+				silence_frame.samples = silence_frame.datalen / sizeof(int16_t);
+			}
+		}
 	}
 
 	bridge_filter_dtmf = switch_true(switch_channel_get_variable(chan_a, "bridge_filter_dtmf"));
@@ -1145,6 +1177,20 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 									  "%s ending bridge by request from write function\n", switch_channel_get_name(chan_b));
 					goto end_of_bridge_loop;
 				}
+			} else if (generate_silence_on_hold && switch_channel_test_flag(chan_a, CF_HOLD)) {
+				if (!logged_generated_hold_silence) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+									  "Writing hold-generated silence from %s to %s\n", switch_channel_get_name(chan_a), switch_channel_get_name(chan_b));
+					logged_generated_hold_silence = 1;
+				}
+
+				switch_generate_sln_silence((int16_t *) silence_frame.data, silence_frame.samples,
+												read_impl.number_of_channels, silence_val);
+				if (switch_core_session_write_frame(session_b, &silence_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+									  "%s ending bridge by request from hold-generated silence write function\n", switch_channel_get_name(chan_b));
+					goto end_of_bridge_loop;
+				}
 			}
 		} else {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "%s ending bridge by request from read function\n", switch_channel_get_name(chan_a));
@@ -1175,7 +1221,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #endif
 
 
-	if (silence_val) {
+	if (silence_codec_initialized) {
 		switch_core_codec_destroy(&silence_codec);
 	}
 

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -400,6 +400,15 @@ static switch_bool_t is_silence_frame(switch_frame_t *frame, int silence_thresho
 	return is_silence;
 }
 
+static switch_status_t write_hold_generated_silence(switch_core_session_t *session_b, switch_frame_t *silence_frame,
+										 switch_codec_implementation_t *read_impl, int silence_val, int stream_id)
+{
+	switch_generate_sln_silence((int16_t *) silence_frame->data, silence_frame->samples,
+							 read_impl->number_of_channels, silence_val);
+
+	return switch_core_session_write_frame(session_b, silence_frame, SWITCH_IO_FLAG_NONE, stream_id);
+}
+
 
 SWITCH_DECLARE(void) switch_ivr_bridge_display(switch_core_session_t *session, switch_core_session_t *peer_session)
 {
@@ -440,7 +449,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 	const char *silence_var;
 	const char *continuous_silence_var;
 	int silence_val = 0, bypass_media_after_bridge = 0, max_continuous_silence_ms = 0, silence_threshold = 0;
-	int silence_codec_initialized = 0, generate_silence_on_hold = 0, logged_generated_hold_silence = 0;
+	int silence_codec_initialized = 0, generate_silence_on_hold = 0;
 	const char *bridge_answer_timeout = NULL;
 	int bridge_filter_dtmf, answer_timeout, sent_update = 0;
 	time_t answer_limit = 0;
@@ -839,6 +848,16 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #endif
 				goto end_of_bridge_loop;
 			}
+
+			/* Hold also sets CF_SUSPEND. Use the held read (often SWITCH_STATUS_BREAK)
+			   only as the timer tick for generated silence, and never write toward a held peer. */
+			if (generate_silence_on_hold && switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+									  "%s ending bridge by request from hold-generated silence write function\n", switch_channel_get_name(chan_b));
+					goto end_of_bridge_loop;
+				}
+			}
 			continue;
 		}
 #if DEBUG_RTP
@@ -1177,16 +1196,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 									  "%s ending bridge by request from write function\n", switch_channel_get_name(chan_b));
 					goto end_of_bridge_loop;
 				}
-			} else if (generate_silence_on_hold && switch_channel_test_flag(chan_a, CF_HOLD)) {
-				if (!logged_generated_hold_silence) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
-									  "Writing hold-generated silence from %s to %s\n", switch_channel_get_name(chan_a), switch_channel_get_name(chan_b));
-					logged_generated_hold_silence = 1;
-				}
-
-				switch_generate_sln_silence((int16_t *) silence_frame.data, silence_frame.samples,
-												read_impl.number_of_channels, silence_val);
-				if (switch_core_session_write_frame(session_b, &silence_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
+			} else if (generate_silence_on_hold && switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+				/* Held reads can return SWITCH_STATUS_BREAK; treat BREAK as pacing for generated silence only. */
+				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from hold-generated silence write function\n", switch_channel_get_name(chan_b));
 					goto end_of_bridge_loop;

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -686,6 +686,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 	for (;;) {
 		int sanity = 1000;
+		int source_held = 0, target_held = 0;
 		switch_channel_state_t b_state;
 		switch_status_t status;
 		switch_event_t *event;
@@ -833,6 +834,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 		switch_ivr_parse_all_messages(session_a);
 
+		source_held = switch_channel_test_flag(chan_a, CF_HOLD) || switch_channel_test_flag(chan_a, CF_LEG_HOLDING);
+		target_held = switch_channel_test_flag(chan_b, CF_HOLD) || switch_channel_test_flag(chan_b, CF_LEG_HOLDING);
+
 		if (!inner_bridge && (switch_channel_test_flag(chan_a, CF_SUSPEND) || switch_channel_test_flag(chan_b, CF_SUSPEND))) {
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #21 %p -> %p\n", (void*)session_a, (void*)session_b);
@@ -849,9 +853,10 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				goto end_of_bridge_loop;
 			}
 
-			/* Hold also sets CF_SUSPEND. Use the held read (often SWITCH_STATUS_BREAK)
-			   only as the timer tick for generated silence, and never write toward a held peer. */
-			if (generate_silence_on_hold && switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+			/* Hold may set CF_SUSPEND; protocol hold may only set CF_LEG_HOLDING.
+			   Use the held read (often SWITCH_STATUS_BREAK) only as the timer tick
+			   for generated silence, and never write toward a held peer. */
+			if (generate_silence_on_hold && source_held && !target_held) {
 				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from hold-generated silence write function\n", switch_channel_get_name(chan_b));
@@ -1187,7 +1192,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				continue;
 			}
 
-			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+			if (status != SWITCH_STATUS_BREAK && !source_held && !target_held) {
 #if DEBUG_RTP
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write frame %p -> %p\n", (void*)session_a, (void*)session_b);
 #endif
@@ -1196,7 +1201,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 									  "%s ending bridge by request from write function\n", switch_channel_get_name(chan_b));
 					goto end_of_bridge_loop;
 				}
-			} else if (generate_silence_on_hold && switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+			} else if (generate_silence_on_hold && source_held && !target_held) {
 				/* Held reads can return SWITCH_STATUS_BREAK; treat BREAK as pacing for generated silence only. */
 				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -400,13 +400,23 @@ static switch_bool_t is_silence_frame(switch_frame_t *frame, int silence_thresho
 	return is_silence;
 }
 
-static switch_status_t write_hold_generated_silence(switch_core_session_t *session_b, switch_frame_t *silence_frame,
-										 switch_codec_implementation_t *read_impl, int silence_val, int stream_id)
+static switch_status_t write_hold_generated_silence(switch_core_session_t *session_a, switch_core_session_t *session_b, switch_frame_t *silence_frame,
+										 switch_codec_implementation_t *read_impl, int silence_val, int stream_id, int source_held,
+										 int target_held, int *logged_generated_hold_silence)
 {
+	switch_media_flow_t target_audio_flow = switch_core_session_media_flow(session_b, SWITCH_MEDIA_TYPE_AUDIO);
+
+	if (logged_generated_hold_silence && !*logged_generated_hold_silence) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
+						  "Writing hold-generated silence from %s to %s source_held=%d target_held=%d target_audio_flow=%d force_write=1\n",
+						  switch_core_session_get_name(session_a), switch_core_session_get_name(session_b), source_held, target_held, target_audio_flow);
+		*logged_generated_hold_silence = 1;
+	}
+
 	switch_generate_sln_silence((int16_t *) silence_frame->data, silence_frame->samples,
 							 read_impl->number_of_channels, silence_val);
 
-	return switch_core_session_write_frame(session_b, silence_frame, SWITCH_IO_FLAG_NONE, stream_id);
+	return switch_core_session_write_frame(session_b, silence_frame, SWITCH_IO_FLAG_FORCE, stream_id);
 }
 
 
@@ -449,7 +459,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 	const char *silence_var;
 	const char *continuous_silence_var;
 	int silence_val = 0, bypass_media_after_bridge = 0, max_continuous_silence_ms = 0, silence_threshold = 0;
-	int silence_codec_initialized = 0, generate_silence_on_hold = 0;
+	int silence_codec_initialized = 0, generate_silence_on_hold = 0, logged_generated_hold_silence = 0;
 	const char *bridge_answer_timeout = NULL;
 	int bridge_filter_dtmf, answer_timeout, sent_update = 0;
 	time_t answer_limit = 0;
@@ -857,7 +867,8 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 			   Use the held read (often SWITCH_STATUS_BREAK) only as the timer tick
 			   for generated silence, and never write toward a held peer. */
 			if (generate_silence_on_hold && source_held && !target_held) {
-				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
+				if (write_hold_generated_silence(session_a, session_b, &silence_frame, &read_impl, silence_val, stream_id,
+										 source_held, target_held, &logged_generated_hold_silence) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from hold-generated silence write function\n", switch_channel_get_name(chan_b));
 					goto end_of_bridge_loop;
@@ -1203,7 +1214,8 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				}
 			} else if (generate_silence_on_hold && source_held && !target_held) {
 				/* Held reads can return SWITCH_STATUS_BREAK; treat BREAK as pacing for generated silence only. */
-				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
+				if (write_hold_generated_silence(session_a, session_b, &silence_frame, &read_impl, silence_val, stream_id,
+										 source_held, target_held, &logged_generated_hold_silence) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from hold-generated silence write function\n", switch_channel_get_name(chan_b));
 					goto end_of_bridge_loop;


### PR DESCRIPTION
## Summary

Fixes the TEL-6986 hold-media gap where the B2BUA stopped sending RTP toward the non-held A-leg while the B-leg SIP client was on protocol hold (`a=inactive`).

The change is opt-in via `bridge_generate_silence_on_hold=true` and is intentionally scoped to the bridge direction where the source leg is held and the target leg is not held.

## Problem

When the B-leg sends a re-INVITE with SDP `a=inactive`, FreeSWITCH marks the B-leg as held/holding and the normal bridge write path stops forwarding media.

That is correct for the held B-leg, but it also means the non-held A-leg can stop receiving RTP. Some upstream carriers use media inactivity timers, so no RTP toward A during B hold can cause the call to be dropped.

Earlier attempts using hold music / broadcast / `silence_stream://-1` were not enough: logs could show playback execution, while the PCAP still showed no sustained RTP toward the non-held leg.

## How this PR works

### 1. Initialize an opt-in generated-silence frame in the bridge loop

`audio_bridge_thread()` now checks the target leg for:

```text
bridge_generate_silence_on_hold=true
```

When enabled, the bridge thread initializes an L16 silence codec/frame that can be used as timer-paced RTP when the source side is held.

Codec cleanup is guarded by an explicit `silence_codec_initialized` flag so cleanup only destroys a codec that was actually initialized.

### 2. Track held state directionally

Each bridge loop iteration computes directional hold state:

```c
source_held = switch_channel_test_flag(chan_a, CF_HOLD) ||
              switch_channel_test_flag(chan_a, CF_LEG_HOLDING);

target_held = switch_channel_test_flag(chan_b, CF_HOLD) ||
              switch_channel_test_flag(chan_b, CF_LEG_HOLDING);
```

This matters because SIP/SDP protocol hold can set `CF_LEG_HOLDING` / `CF_PROTO_HOLD` without using the local/API hold path represented by only `CF_HOLD`.

The generated-silence path only fires for:

```text
bridge_generate_silence_on_hold=true && source_held && !target_held
```

So it writes only from the held source side toward the non-held peer. It does not generate RTP toward the held/inactive leg.

### 3. Handle the suspend/hold bridge path

Hold can put the bridge into a suspended path before the normal write branch. The PR adds the same guarded generated-silence write in the suspend handling path so the held source leg can still provide a timer tick for silence generation.

### 4. Avoid normal writes while either side is held

The normal bridge write condition is tightened from a partial hold check to:

```text
!source_held && !target_held
```

That avoids leaking normal RTP toward a held peer while still allowing the explicit opt-in generated-silence path toward the non-held target.

### 5. Force only the opt-in generated-silence write through the media-flow gate

The final issue found during retest was that the non-held A-leg can have target audio flow set to inactive while B is on hold:

```text
Updating partner media mode to 3
```

`3` is `SWITCH_MEDIA_FLOW_INACTIVE`.

`switch_core_media_write_frame()` normally returns `SWITCH_STATUS_SUCCESS` without sending RTP when target audio flow is not `SENDRECV` or `SENDONLY`. That meant generated silence could be attempted but silently suppressed before reaching the wire.

This PR now sends the explicit hold-generated-silence frame with:

```c
SWITCH_IO_FLAG_FORCE
```

and updates the audio media-flow gate so only forced writes bypass that gate:

```c
if (!(flags & SWITCH_IO_FLAG_FORCE) &&
    audio_flow != SWITCH_MEDIA_FLOW_SENDRECV &&
    audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
    return SWITCH_STATUS_SUCCESS;
}
```

Normal audio writes keep the existing media-flow behavior. Only this narrowly guarded opt-in generated-silence path uses FORCE.

### 6. One-time debug log for verification

The generated-silence write logs once per bridge thread:

```text
Writing hold-generated silence from <source> to <target> source_held=<0/1> target_held=<0/1> target_audio_flow=<n> force_write=1
```

This proves which bridge direction fired, whether the source/target hold predicates were correct, and whether the target was in an inactive media-flow state.

## Safety / behavior scope

- Disabled by default.
- Only active when `bridge_generate_silence_on_hold=true` is exported/set.
- Generates RTP only toward the non-held target leg.
- Does not send RTP toward the held/inactive leg after the inactive answer.
- Uses negotiated active audio payload for the A-leg keepalive media; in the validating capture this was PCMU/PT0.
- Keeps the normal media-flow gate for all non-forced writes.

## Pre-fix evidence

Previous TEL-6986 capture showed B-leg hold with no sustained FS -> A RTP:

- B-leg hold: SDP `a=inactive`.
- During hold:
  - A -> FS: `268-269` packets depending on window.
  - B -> FS: `269` packets.
  - FS -> held B: `0` packets, correct.
  - FS -> non-held A: only `6-7` transition packets, not sustained.

That confirmed the bug: the held leg did not receive RTP, but the non-held A-leg also stopped receiving sustained RTP.

## Post-fix validation

Validated with new PCAP/log from the patched build.

### Input artifacts

- PCAP: `TEL-6986.pcap`
  - SHA256: `300038bd2258b43417d2bbf6deb711a112c3227d654daf217053202062d910af`
  - Packets: `2883`
  - Duration: `18.264759s`
  - Time span: `2026-04-30 14:44:46.681560` -> `2026-04-30 14:45:04.946319`
- Log: `TEL-6986.log`
  - SHA256: `463a4e3edcc3bf91d7cefa42a01fe79436829fc5ead1f14a45f2c5551ae8da79`

### Log evidence

The patched path executed in the expected direction:

```text
Writing hold-generated silence from sofia/outbound/4258000142@192.34.58.13:50062 to sofia/inbound/tuan19422@sipdev.telnyx.com source_held=1 target_held=0 target_audio_flow=3 force_write=1
```

Relevant log markers:

- `bridge_generate_silence_on_hold=true` exported.
- `Setup hold-generated silence ...` logged for both bridge directions.
- B-leg SDP hold: `a=inactive`.
- B-leg state: `ACTIVE -> HELD`.
- Partner media mode changed to `3` / inactive.
- Forced hold-generated-silence write fired toward A.
- On unhold, partner media mode returned to `0` / sendrecv.

### SIP / SDP window

From the validating PCAP:

- B-leg hold offer: frame `1009`, `t=7.133911`, SDP `a=inactive`.
- FS hold answer: frame `1045`, `t=7.399897`, SDP `a=inactive`.
- B-leg unhold offer: frame `1807`, `t=12.510067`, SDP `a=sendrecv`.
- FS unhold answer: frame `1838`, `t=12.782254`, SDP `a=sendrecv`.

### RTP counts during confirmed hold

Using the strict confirmed-hold window after FS answered inactive:

```text
7.399897 <= t < 12.510067
```

RTP counts:

```text
A -> FS: 250
B -> FS: 255
FS -> A: 254
FS -> B: 0
```

This is the desired behavior: continuous RTP toward the non-held A-leg and zero RTP toward the held B-leg.

### FS -> A continuity

Direction:

```text
50.114.144.37:19674 -> 171.240.253.53:4012
```

During confirmed hold:

- Count: `254` packets.
- Payload: PT0 / PCMU.
- First packet: frame `1048`, `t=7.419876`, seq `2961`, RTP timestamp `43040`.
- Last packet: frame `1806`, `t=12.507468`, seq `3214`, RTP timestamp `83680`.
- Delta min/mean/max: `20.063ms / 20.109ms / 20.857ms`.
- Gaps >100ms: `0`.

### FS -> held B check

Direction:

```text
50.114.144.37:25802 -> 192.34.58.13:30010
```

During confirmed hold after inactive answer:

```text
FS -> B: 0 packets
```

So the fix does not leak RTP to the held/inactive B-leg.

## Test plan / verification commands

Code hygiene:

```bash
git diff --check origin/telnyx/telephony/deploy-development...HEAD
```

PCAP metadata:

```bash
capinfos TEL-6986.pcap
shasum -a 256 TEL-6986.pcap TEL-6986.log
```

SIP/SDP window extraction:

```bash
tshark -r TEL-6986.pcap -Y 'sip || sdp' -T fields \
  -e frame.number -e frame.time_relative -e ip.src -e ip.dst \
  -e sip.Method -e sip.Status-Code -e sip.CSeq.method -e sip.Call-ID \
  -e sdp.media -e sdp.connection_info -e sdp.media_attr
```

RTP stream summary:

```bash
tshark -r TEL-6986.pcap -q -z rtp,streams
```

RTP window counting used `tshark -Y rtp` fields split by the hold/unhold frame times above.

## Result

The post-fix PCAP and log validate the intended behavior:

- The forced hold-generated-silence path fires only from held source to non-held target.
- FS sends continuous ~20ms PCMU RTP toward A during B hold.
- FS sends zero RTP toward held B after the inactive answer.
- Normal media resumes after unhold.
