### PR TITLE
TEL-6986: Generate silence toward A-leg from hold path

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4324,7 +4324,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_write_frame(switch_core_sessio
 	if (type == SWITCH_MEDIA_TYPE_AUDIO) {
 		switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
 
-		if (audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
+		if (!(flags & SWITCH_IO_FLAG_FORCE) && audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
 			switch_thread_rwlock_unlock(engine->dtls_init_rwlock);
 			return SWITCH_STATUS_SUCCESS;
 		}

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -400,6 +400,15 @@ static switch_bool_t is_silence_frame(switch_frame_t *frame, int silence_thresho
 	return is_silence;
 }
 
+static switch_status_t write_hold_generated_silence(switch_core_session_t *session_b, switch_frame_t *silence_frame,
+										 switch_codec_implementation_t *read_impl, int silence_val, int stream_id)
+{
+	switch_generate_sln_silence((int16_t *) silence_frame->data, silence_frame->samples,
+							 read_impl->number_of_channels, silence_val);
+
+	return switch_core_session_write_frame(session_b, silence_frame, SWITCH_IO_FLAG_FORCE, stream_id);
+}
+
 
 SWITCH_DECLARE(void) switch_ivr_bridge_display(switch_core_session_t *session, switch_core_session_t *peer_session)
 {
@@ -440,6 +449,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 	const char *silence_var;
 	const char *continuous_silence_var;
 	int silence_val = 0, bypass_media_after_bridge = 0, max_continuous_silence_ms = 0, silence_threshold = 0;
+	int silence_codec_initialized = 0;
 	const char *bridge_answer_timeout = NULL;
 	int bridge_filter_dtmf, answer_timeout, sent_update = 0;
 	time_t answer_limit = 0;
@@ -625,6 +635,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 				silence_val = 0;
 			} else {
+				silence_codec_initialized = 1;
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Setup generated silence from %s to %s at %d\n", switch_channel_get_name(chan_a),
 								  switch_channel_get_name(chan_b), silence_val);
 				silence_frame.codec = &silence_codec;
@@ -645,6 +656,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 	for (;;) {
 		int sanity = 1000;
+		int source_held = 0, target_held = 0;
 		switch_channel_state_t b_state;
 		switch_status_t status;
 		switch_event_t *event;
@@ -792,6 +804,9 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 		switch_ivr_parse_all_messages(session_a);
 
+		source_held = switch_channel_test_flag(chan_a, CF_HOLD) || switch_channel_test_flag(chan_a, CF_LEG_HOLDING);
+		target_held = switch_channel_test_flag(chan_b, CF_HOLD) || switch_channel_test_flag(chan_b, CF_LEG_HOLDING);
+
 		if (!inner_bridge && (switch_channel_test_flag(chan_a, CF_SUSPEND) || switch_channel_test_flag(chan_b, CF_SUSPEND))) {
 #if DEBUG_RTP
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #21 %p -> %p\n", (void*)session_a, (void*)session_b);
@@ -806,6 +821,15 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: #23 %p -> %p\n", (void*)session_a, (void*)session_b);
 #endif
 				goto end_of_bridge_loop;
+			}
+
+			/* Hold may set CF_SUSPEND; protocol hold may only set CF_LEG_HOLDING.
+			   Use the held read (often SWITCH_STATUS_BREAK) only as the timer tick
+			   for generated silence, and never write toward a held peer. */
+			if (silence_val && source_held && !target_held) {
+				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
+					goto end_of_bridge_loop;
+				}
 			}
 			continue;
 		}
@@ -1136,13 +1160,18 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				continue;
 			}
 
-			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
+			if (status != SWITCH_STATUS_BREAK && !source_held && !target_held) {
 #if DEBUG_RTP
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_NOTICE, "Audio bridge thread: write frame %p -> %p\n", (void*)session_a, (void*)session_b);
 #endif
 				if (switch_core_session_write_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,
 									  "%s ending bridge by request from write function\n", switch_channel_get_name(chan_b));
+					goto end_of_bridge_loop;
+				}
+			} else if (silence_val && source_held && !target_held) {
+				/* Held reads can return SWITCH_STATUS_BREAK; treat BREAK as pacing for generated silence only. */
+				if (write_hold_generated_silence(session_b, &silence_frame, &read_impl, silence_val, stream_id) != SWITCH_STATUS_SUCCESS) {
 					goto end_of_bridge_loop;
 				}
 			}
@@ -1175,7 +1204,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 #endif
 
 
-	if (silence_val) {
+	if (silence_codec_initialized) {
 		switch_core_codec_destroy(&silence_codec);
 	}
 


### PR DESCRIPTION
## Summary

Fixes TEL-6986 using the existing bridge variable:

```text
bridge_generate_comfort_noise
```

When `bridge_generate_comfort_noise` is enabled and the bridge source leg is held, FreeSWITCH now generates silence RTP toward the non-held target leg. It still sends zero RTP toward the held/inactive leg.

This keeps the PR minimal by reusing FreeSWITCH's existing bridge-generated-comfort-noise knob instead of adding a new channel variable.

## Existing variable reused

FreeSWITCH already has bridge-level generated silence/comfort-noise support:

```c
bridge_generate_comfort_noise
```

Existing source behavior in `src/switch_ivr_bridge.c`:

- reads `bridge_generate_comfort_noise` from `chan_a`,
- parses `true` as default generated silence divisor `1400`,
- accepts numeric values,
- initializes an L16 generated-silence frame,
- uses that frame when bridge input is CNG / no-audio style media.

Existing `docs/ChangeLog` describes it as:

```text
bridge_generate_comfort_noise option for bridge to generate comfort noise to the A leg when there is no audio on the B leg
```

TEL-6986 is the same class of problem, but the no-audio condition comes from SIP protocol hold / `a=inactive` rather than a normal CNG frame.

## Problem

During B-leg protocol hold, FreeSWITCH correctly suppresses media toward the held/inactive B-leg. However, the bridge path can also stop sending RTP toward the non-held A-leg.

Failure mode before this fix:

```text
B-leg sends a=inactive
FS -> held B: 0 RTP      # correct
FS -> non-held A: ~0 RTP # wrong; only transition packets
```

Prior log-based attempts using hold music / broadcast / `silence_stream://-1` were insufficient because playback could execute while the PCAP still showed no sustained FS -> A RTP.

## Final implementation

### 1. Reuse existing generated-silence frame setup

The PR keeps the existing `bridge_generate_comfort_noise` setup path and only tracks codec ownership with:

```c
silence_codec_initialized
```

Cleanup now destroys the codec only if it was actually initialized.

### 2. Add a small helper for forced hold-generated silence writes

```c
write_hold_generated_silence(...)
```

This helper:

1. fills the prepared silence frame with `switch_generate_sln_silence()`, and
2. writes it to the bridge target using `SWITCH_IO_FLAG_FORCE`.

### 3. Use directional hold predicates

Each bridge loop computes:

```c
source_held = CF_HOLD(chan_a) || CF_LEG_HOLDING(chan_a)
target_held = CF_HOLD(chan_b) || CF_LEG_HOLDING(chan_b)
```

This is required because SIP/SDP protocol hold can set `CF_LEG_HOLDING` without using only the local/API `CF_HOLD` path.

### 4. Generate only from held source to non-held target

Generated silence is written only when:

```text
silence_val && source_held && !target_held
```

That means:

- B held, A not held: generate RTP toward A.
- Target held: do not write RTP toward the held leg.

The same guard is present in both the suspend/hold path and the normal post-read bridge path, because hold can enter the suspended branch before the normal write branch.

### 5. Do not use normal writes while either side is held

The normal bridge write path is guarded by:

```text
!source_held && !target_held
```

This avoids forwarding normal media into held endpoints. Hold-generated media is handled by the explicit generated-silence path above.

### 6. Force only the guarded generated-silence write through the media-flow gate

The retest showed the target A-leg can have target audio flow set to inactive while B is on hold (`SWITCH_MEDIA_FLOW_INACTIVE`, enum value `3`). `switch_core_media_write_frame()` normally returns success without sending RTP when target audio flow is not `SENDRECV` or `SENDONLY`.

To avoid generated silence being silently dropped, the hold-generated-silence helper writes with:

```c
SWITCH_IO_FLAG_FORCE
```

and the audio media-flow gate now preserves normal behavior except when FORCE is explicitly set:

```c
if (!(flags & SWITCH_IO_FLAG_FORCE) &&
    audio_flow != SWITCH_MEDIA_FLOW_SENDRECV &&
    audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
    return SWITCH_STATUS_SUCCESS;
}
```

Normal writes still respect media-flow direction. Only the guarded generated-silence write can bypass this gate.

## Why not `send_silence_when_idle`?

HWR checked the existing variables thoroughly.

`send_silence_when_idle` is an IVR/session idle-loop variable used by sleep, park, digit collection, and SRTP idle-gap handling. It writes silence to the current idle session and does not implement bridge-direction hold behavior.

TEL-6986 requires bridge-specific asymmetric behavior:

```text
source held + target not held => generated RTP to target
held target => zero RTP
```

So `send_silence_when_idle` is not the right knob.

## Safety / scope

- Reuses existing `bridge_generate_comfort_noise`; no new channel variable.
- Only active when generated bridge comfort noise is already enabled.
- Only writes when the source leg is held and the target leg is not held.
- Does not send RTP toward the held/inactive leg after the inactive answer.
- Normal media-flow behavior remains unchanged for non-forced writes.
- No new logging was added.

## Validation evidence

The TEL-6986 behavior was validated on the prior patch iteration with the same bridge hold write mechanics using an explicit temporary opt-in variable. HWR then re-reviewed the source and switched the opt-in to the existing `bridge_generate_comfort_noise` variable to minimize the PR surface.

The exact current head should be retested with:

```text
bridge_generate_comfort_noise=true
```

Expected behavior is unchanged because the current source uses the same prepared generated-silence frame and the same guarded forced write path:

```text
silence_val && source_held && !target_held
```

### Latest validation artifacts from prior equivalent patch iteration

- PCAP: `TEL-6986.pcap`
  - SHA256: `24a0c79225916f62ea1f11a0ee721ef26ebe258a0748c49d06f35df6f281672a`
  - Packets: `2900`
  - Duration: `18.283666s`
- Log: `TEL-6986.log`
  - SHA256: `15758cf0336c742cc9e3eb462c3e3c4a30db110a14f211f25326ef2406b00e15`

SIP / SDP window:

- B-leg hold offer: frame `1015`, `t=7.156475`, SDP `a=inactive`.
- FS hold answer: frame `1051`, `t=7.423097`, SDP `a=inactive`.
- B-leg unhold offer: frame `1817`, `t=12.533111`, SDP `a=sendrecv`.
- FS unhold answer: frame `1846`, `t=12.801459`, SDP `a=sendrecv`.

Strict confirmed-hold window:

```text
7.423097 <= t < 12.533111
```

RTP counts from that prior equivalent patch iteration:

```text
A -> FS: 255
B -> FS: 256
FS -> A: 252
FS -> B: 0
```

FS -> A continuity:

- Direction: `50.114.144.37:29014 -> 171.240.253.53:4022`
- Count: `252` packets.
- Payload: PT0 / PCMU.
- First packet: frame `1053`, `t=7.443045`, seq `5424`, RTP timestamp `43040`.
- Last packet: frame `1814`, `t=12.519906`, seq `5675`, RTP timestamp `83680`.
- Delta min/mean/max: `20.076ms / 20.227ms / 40.183ms`.
- Gaps >100ms: `0`.

## Result

The implementation keeps the required TEL-6986 behavior while using FreeSWITCH's existing bridge-generated comfort-noise variable:

- no new channel variable,
- generated silence while source leg is held,
- explicit guard to keep RTP away from held targets,
- FORCE only for generated silence so inactive target media flow does not silently suppress it,
- normal media behavior preserved for all non-forced writes.
