### PR TITLE
TEL-6985: harden scm_should_use_m_port against trickle ICE placeholder overwrite

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -414,6 +414,18 @@ static switch_bool_t scm_should_use_m_port(switch_core_session_t *session, switc
 
 	if (trickle_accept_enabled(session)) {
 		if (engine->ice_in.is_chosen[0]) {
+			/* Never let trickle placeholder 0.0.0.0:9 or :::9 overwrite */
+			/* a valid ICE-selected remote address. */
+			if (engine->cur_payload_map &&
+				engine->cur_payload_map->remote_sdp_port == 9 &&
+				engine->cur_payload_map->remote_sdp_ip &&
+				(!strcmp(engine->cur_payload_map->remote_sdp_ip, "0.0.0.0") ||
+				 !strcmp(engine->cur_payload_map->remote_sdp_ip, "::"))) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+					"Refusing to overwrite ICE-selected address with trickle placeholder %s:%d\n",
+					engine->cur_payload_map->remote_sdp_ip, engine->cur_payload_map->remote_sdp_port);
+				return SWITCH_FALSE;
+			}
 			return SWITCH_TRUE;
 		}
 		return SWITCH_FALSE;


### PR DESCRIPTION
## Problem

When trickle ICE has already chosen a candidate (`is_chosen[0]` set), `scm_should_use_m_port()` returns TRUE unconditionally, allowing `switch_rtp_set_remote_address()` to overwrite the working ICE-selected address with whatever is in the m= line — including the trickle placeholder `0.0.0.0:9`.

This is the root cause of TEL-6985 one-way audio when a duplicate `telnyx_rtc.answer` arrives.

## Fix

Defense-in-depth: in `scm_should_use_m_port()`, when `is_chosen[0]` is set, check if the m= line address is the trickle placeholder (`0.0.0.0:9` or `:::9`). If so, return FALSE — refuse to overwrite the valid ICE-selected address.

`0.0.0.0:9` is never a valid RTP destination:
- Port 9 is the discard port (RFC 4566)
- `0.0.0.0` means "this host"
- Legitimate hold uses `0.0.0.0` with the **real** port, or `a=inactive`/`a=sendonly`
- Media rejection uses port **0** (`m=audio 0`)
