### PR TITLE
TEL-6981: stabilize local MP3 record_session tags

### DIFF
--- a/src/mod/formats/mod_shout/mod_shout.c
+++ b/src/mod/formats/mod_shout/mod_shout.c
@@ -229,6 +229,7 @@ static inline void free_context(shout_context_t *context)
 				fwrite(mp3buffer, 1, len, context->fp);
 			}
 
+			fflush(context->fp);
 			lame_mp3_tags_fid(context->gfp, context->fp);
 		}
 
@@ -839,6 +840,8 @@ static switch_status_t shout_file_open(switch_file_handle_t *handle, const char 
 			id3tag_init(context->gfp);
 			id3tag_v2_only(context->gfp);
 			id3tag_pad_v2(context->gfp);
+			lame_set_bWriteVbrTag(context->gfp, 0);
+			lame_mp3_tags_fid(context->gfp, NULL);
 
 		}
 		context->channels = handle->channels;


### PR DESCRIPTION
## Summary
- Disable LAME VBR/Xing tag writing for local `mod_shout` MP3 file recordings, matching the existing stream/handler path behavior.
- Flush pending stdio writes before the close-time MP3 tag finalization call.

## Source evidence
- `record_session` opens local recording files through `switch_core_file_open()` in `switch_ivr_async.c`.
- local bare `.mp3` paths route by extension to `mod_shout` via `switch_core_file.c` and `mod_shout`'s registered `mp3` file interface.
- stream/handler MP3 writes already disable VBR tag writing; local file writes did not.

## Test Plan
- [x] `git diff --check -- src/mod/formats/mod_shout/mod_shout.c`
- [ ] Reproduce TEL-6981 on an FS test host with short first local `.mp3` `record_session` calls.
- [ ] Verify before/after generated files with `stat`, `file`, and `ffprobe`.
- [ ] Validate normal longer MP3 recordings and first-vs-second recording on the same channel.

## Notes
Hermes prepared the local repro checklist here:
`/Users/tuan/.hermes/agent-workspaces/orchestrator/reports/TEL-6981-mp3-repro-and-fix-prep.md`
