### PR TITLE
TEL-6981: align record force_channels with stereo bug mode

### DIFF
--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -3504,14 +3504,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		int have_force_channels = 0;
 		int force_channels = 0;
 
-		const char *sv = NULL;
-		const char *sw = NULL;
 		const char *fc = NULL;
 
 		if (vars) {
-			sv = switch_event_get_header(vars, "stereo");
-			sw = switch_event_get_header(vars, "stereo_swap");
-			fc = switch_event_get_header(vars, "force_channels");
+			const char *sv = switch_event_get_header(vars, "stereo");
+			const char *sw = switch_event_get_header(vars, "stereo_swap");
 			if (sv || sw) {
 				/* Per-recording override: resolve both from vars only, no channel fallback */
 				have_override = 1;
@@ -3521,13 +3518,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 			}
 		}
 
+		fc = vars ? switch_event_get_header(vars, "force_channels") : NULL;
+
 		if (file_vars) {
-			if (!sv) {
-				sv = switch_event_get_header(file_vars, "stereo");
-			}
-			if (!sw) {
-				sw = switch_event_get_header(file_vars, "stereo_swap");
-			}
+			const char *sv = switch_event_get_header(file_vars, "stereo");
+			const char *sw = switch_event_get_header(file_vars, "stereo_swap");
+
 			if (!fc) {
 				fc = switch_event_get_header(file_vars, "force_channels");
 			}
@@ -3539,9 +3535,15 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 				if (sw) want_swap = switch_true(sw);
 				if (want_swap) want_stereo = 1;
 			}
+
+			if (sv || sw || fc) {
+				have_recording_channel_override = 1;
+			}
 		}
 
-		have_recording_channel_override = (sv || sw || fc) ? 1 : 0;
+		if (fc) {
+			have_recording_channel_override = 1;
+		}
 
 		if (!zstr(fc)) {
 			force_channels = atoi(fc);
@@ -3888,9 +3890,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	rh->stereo_swap = (flags & SMBF_STEREO_SWAP) ? 1 : 0;
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
-		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s\n",
+		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s
+",
 		file, channels, rh->stereo, rh->stereo_swap,
-		have_recording_channel_override ? " (per-recording channel override)" : "");
+		(vars && (switch_event_get_header(vars, "stereo") || switch_event_get_header(vars, "stereo_swap")))
+			? " (per-recording override)"
+			: (have_recording_channel_override ? " (per-recording channel override)" : ""));
 
 	if ((status = switch_core_media_bug_add(session, "session_record", file,
 											record_callback, rh, to, flags, &bug)) != SWITCH_STATUS_SUCCESS) {

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -99,7 +99,6 @@ struct switch_ivr_dmachine {
 
 static const char *get_recording_var(switch_channel_t *channel, switch_event_t *vars, const char *name);
 static int recording_var_true(switch_channel_t *channel, switch_event_t *vars, const char *name);
-static const char *get_recording_file_var(switch_event_t *vars, switch_event_t *file_vars, const char *name);
 static switch_status_t parse_recording_file_vars(switch_core_session_t *session, const char *file, switch_event_t **file_vars);
 static switch_status_t speech_on_dtmf(switch_core_session_t *session, const switch_dtmf_t *dtmf, switch_dtmf_direction_t direction);
 
@@ -3363,21 +3362,6 @@ static int recording_var_true(switch_channel_t *channel, switch_event_t *vars, c
 	return switch_true(get_recording_var(channel, vars, name));
 }
 
-static const char *get_recording_file_var(switch_event_t *vars, switch_event_t *file_vars, const char *name)
-{
-	const char *val = NULL;
-
-	if (vars) {
-		val = switch_event_get_header(vars, name);
-	}
-
-	if (!val && file_vars) {
-		val = switch_event_get_header(file_vars, name);
-	}
-
-	return val;
-}
-
 static switch_status_t parse_recording_file_vars(switch_core_session_t *session, const char *file, switch_event_t **file_vars)
 {
 	char *file_vars_data = NULL;
@@ -3520,19 +3504,44 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		int have_force_channels = 0;
 		int force_channels = 0;
 
-		const char *sv = get_recording_file_var(vars, file_vars, "stereo");
-		const char *sw = get_recording_file_var(vars, file_vars, "stereo_swap");
-		const char *fc = get_recording_file_var(vars, file_vars, "force_channels");
+		const char *sv = NULL;
+		const char *sw = NULL;
+		const char *fc = NULL;
+
+		if (vars) {
+			sv = switch_event_get_header(vars, "stereo");
+			sw = switch_event_get_header(vars, "stereo_swap");
+			fc = switch_event_get_header(vars, "force_channels");
+			if (sv || sw) {
+				/* Per-recording override: resolve both from vars only, no channel fallback */
+				have_override = 1;
+				if (sv) want_stereo = switch_true(sv);
+				if (sw) want_swap = switch_true(sw);
+				if (want_swap) want_stereo = 1;
+			}
+		}
+
+		if (file_vars) {
+			if (!sv) {
+				sv = switch_event_get_header(file_vars, "stereo");
+			}
+			if (!sw) {
+				sw = switch_event_get_header(file_vars, "stereo_swap");
+			}
+			if (!fc) {
+				fc = switch_event_get_header(file_vars, "force_channels");
+			}
+
+			if (!have_override && (sv || sw)) {
+				/* Per-recording override: resolve both from file vars only, no channel fallback */
+				have_override = 1;
+				if (sv) want_stereo = switch_true(sv);
+				if (sw) want_swap = switch_true(sw);
+				if (want_swap) want_stereo = 1;
+			}
+		}
 
 		have_recording_channel_override = (sv || sw || fc) ? 1 : 0;
-
-		if (sv || sw) {
-			/* Per-recording override: resolve both from recording-specific vars only, no channel fallback */
-			have_override = 1;
-			if (sv) want_stereo = switch_true(sv);
-			if (sw) want_swap = switch_true(sw);
-			if (want_swap) want_stereo = 1;
-		}
 
 		if (!zstr(fc)) {
 			force_channels = atoi(fc);

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -99,6 +99,8 @@ struct switch_ivr_dmachine {
 
 static const char *get_recording_var(switch_channel_t *channel, switch_event_t *vars, const char *name);
 static int recording_var_true(switch_channel_t *channel, switch_event_t *vars, const char *name);
+static const char *get_recording_file_var(switch_event_t *vars, switch_event_t *file_vars, const char *name);
+static switch_status_t parse_recording_file_vars(switch_core_session_t *session, const char *file, switch_event_t **file_vars);
 static switch_status_t speech_on_dtmf(switch_core_session_t *session, const switch_dtmf_t *dtmf, switch_dtmf_direction_t direction);
 
 SWITCH_DECLARE(switch_status_t) switch_ivr_dmachine_last_ping(switch_ivr_dmachine_t *dmachine)
@@ -3361,6 +3363,41 @@ static int recording_var_true(switch_channel_t *channel, switch_event_t *vars, c
 	return switch_true(get_recording_var(channel, vars, name));
 }
 
+static const char *get_recording_file_var(switch_event_t *vars, switch_event_t *file_vars, const char *name)
+{
+	const char *val = NULL;
+
+	if (vars) {
+		val = switch_event_get_header(vars, name);
+	}
+
+	if (!val && file_vars) {
+		val = switch_event_get_header(file_vars, name);
+	}
+
+	return val;
+}
+
+static switch_status_t parse_recording_file_vars(switch_core_session_t *session, const char *file, switch_event_t **file_vars)
+{
+	char *file_vars_data = NULL;
+	char *file_vars_path = NULL;
+
+	if (zstr(file) || *file != '{') {
+		return SWITCH_STATUS_SUCCESS;
+	}
+
+	if (!(file_vars_data = switch_core_session_strdup(session, file))) {
+		return SWITCH_STATUS_MEMERR;
+	}
+
+	if (switch_event_create_brackets(file_vars_data, '{', '}', ',', file_vars, &file_vars_path, SWITCH_FALSE) != SWITCH_STATUS_SUCCESS) {
+		switch_event_safe_destroy(*file_vars);
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
 SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_session_t *session, const char *file, uint32_t limit, switch_file_handle_t *fh, switch_event_t *vars)
 {
 	switch_channel_t *channel = switch_core_session_get_channel(session);
@@ -3379,8 +3416,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	char *ext;
 	char *in_file = NULL, *out_file = NULL;
 	switch_event_t *file_vars = NULL;
-	char *file_vars_data = NULL;
-	char *file_vars_path = NULL;
+	int have_recording_channel_override = 0;
 
 	if ((p = get_recording_var(channel, vars, "RECORD_HANGUP_ON_ERROR"))) {
 		hangup_on_error = switch_true(p);
@@ -3449,12 +3485,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		}
 	}
 
-	if (!(file_vars_data = switch_core_session_strdup(session, file))) {
-		switch_goto_status(SWITCH_STATUS_MEMERR, err);
-	}
-
-	if (*file_vars_data == '{') {
-		switch_event_create_brackets(file_vars_data, '{', '}', ',', &file_vars, &file_vars_path, SWITCH_FALSE);
+	if ((status = parse_recording_file_vars(session, file, &file_vars)) != SWITCH_STATUS_SUCCESS) {
+		switch_goto_status(status, err);
 	}
 	
 	if (recording_var_true(channel, vars, "RECORD_WRITE_ONLY")) {
@@ -3488,19 +3520,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		int have_force_channels = 0;
 		int force_channels = 0;
 
-		const char *sv = vars ? switch_event_get_header(vars, "stereo") : NULL;
-		const char *sw = vars ? switch_event_get_header(vars, "stereo_swap") : NULL;
-		const char *fc = vars ? switch_event_get_header(vars, "force_channels") : NULL;
+		const char *sv = get_recording_file_var(vars, file_vars, "stereo");
+		const char *sw = get_recording_file_var(vars, file_vars, "stereo_swap");
+		const char *fc = get_recording_file_var(vars, file_vars, "force_channels");
 
-		if (!sv && file_vars) {
-			sv = switch_event_get_header(file_vars, "stereo");
-		}
-		if (!sw && file_vars) {
-			sw = switch_event_get_header(file_vars, "stereo_swap");
-		}
-		if (!fc && file_vars) {
-			fc = switch_event_get_header(file_vars, "force_channels");
-		}
+		have_recording_channel_override = (sv || sw || fc) ? 1 : 0;
 
 		if (sv || sw) {
 			/* Per-recording override: resolve both from recording-specific vars only, no channel fallback */
@@ -3857,9 +3881,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
 		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s\n",
 		file, channels, rh->stereo, rh->stereo_swap,
-		((vars && (switch_event_get_header(vars, "stereo") || switch_event_get_header(vars, "stereo_swap") || switch_event_get_header(vars, "force_channels"))) ||
-		 (file_vars && (switch_event_get_header(file_vars, "stereo") || switch_event_get_header(file_vars, "stereo_swap") || switch_event_get_header(file_vars, "force_channels"))))
-			? " (per-recording channel override)" : "");
+		have_recording_channel_override ? " (per-recording channel override)" : "");
 
 	if ((status = switch_core_media_bug_add(session, "session_record", file,
 											record_callback, rh, to, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
@@ -3892,16 +3914,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		switch_core_session_receive_message(session, &msg);
 	}
 
-	if (file_vars) {
-		switch_event_destroy(&file_vars);
-	}
+	switch_event_safe_destroy(file_vars);
 
 	return SWITCH_STATUS_SUCCESS;
 
 err:
-	if (file_vars) {
-		switch_event_destroy(&file_vars);
-	}
+	switch_event_safe_destroy(file_vars);
 	if (!zstr(rh->completion_cause)) {
 		switch_channel_set_variable_printf(channel, "record_completion_cause", "%s", rh->completion_cause);
 	}

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1194,6 +1194,8 @@ struct record_helper {
 	switch_mutex_t *cond_mutex;
 	switch_thread_cond_t *cond;
 	char *record_label;
+	uint8_t stereo;
+	uint8_t stereo_swap;
 };
 
 static switch_status_t record_helper_destroy(struct record_helper **rh, switch_core_session_t *session);
@@ -3464,31 +3466,49 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		flags |= SMBF_LAST;
 	}
 
-	if (channels == 1) { /* if leg is already stereo this feature is not available */
-		if (recording_var_true(channel, vars, "RECORD_STEREO")) {
-			flags |= SMBF_STEREO;
-			flags &= ~SMBF_STEREO_SWAP;
-			channels = 2;
+	/* Per-recording 'stereo'/'stereo_swap' vars take precedence over channel-level
+	 * RECORD_STEREO, preventing cross-contamination between concurrent recordings. */
+	{
+		int want_stereo = 0, want_swap = 0;
+		int have_override = 0;
+
+		if (vars) {
+			const char *sv = switch_event_get_header(vars, "stereo");
+			const char *sw = switch_event_get_header(vars, "stereo_swap");
+			if (sv || sw) {
+				/* Per-recording override: resolve both from vars only, no channel fallback */
+				have_override = 1;
+				if (sv) want_stereo = switch_true(sv);
+				if (sw) want_swap = switch_true(sw);
+				if (want_swap) want_stereo = 1;
+			}
 		}
 
-		if (recording_var_true(channel, vars, "RECORD_STEREO_SWAP")) {
-			flags |= SMBF_STEREO;
-			flags |= SMBF_STEREO_SWAP;
-			channels = 2;
-		}
-	} else if (channels == 2) {
-		flags |= SMBF_REAL_STEREO;
-		if (recording_var_true(channel, vars, "RECORD_STEREO")) {
-			flags |= SMBF_STEREO;
-			flags &= ~SMBF_STEREO_SWAP;
+		if (!have_override) {
+			want_stereo = recording_var_true(channel, vars, "RECORD_STEREO");
+			want_swap = recording_var_true(channel, vars, "RECORD_STEREO_SWAP");
 		}
 
-		if (recording_var_true(channel, vars, "RECORD_STEREO_SWAP")) {
-			flags |= SMBF_STEREO;
-			flags |= SMBF_STEREO_SWAP;
-		}
-		if (!(flags & SMBF_STEREO)) {
-			channels = 1;
+		if (channels == 1) {
+			if (want_swap == 1) {
+				flags |= SMBF_STEREO | SMBF_STEREO_SWAP;
+				channels = 2;
+			} else if (want_stereo == 1) {
+				flags |= SMBF_STEREO;
+				flags &= ~SMBF_STEREO_SWAP;
+				channels = 2;
+			}
+		} else if (channels == 2) {
+			flags |= SMBF_REAL_STEREO;
+			if (want_swap == 1) {
+				flags |= SMBF_STEREO | SMBF_STEREO_SWAP;
+			} else if (want_stereo == 1) {
+				flags |= SMBF_STEREO;
+				flags &= ~SMBF_STEREO_SWAP;
+			}
+			if (!(flags & SMBF_STEREO)) {
+				channels = 1;
+			}
 		}
 	}
 
@@ -3791,6 +3811,14 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	}
 
 	rh->hangup_on_error = hangup_on_error;
+	rh->stereo = (flags & SMBF_STEREO) ? 1 : 0;
+	rh->stereo_swap = (flags & SMBF_STEREO_SWAP) ? 1 : 0;
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s\n",
+		file, channels, rh->stereo, rh->stereo_swap,
+		(vars && (switch_event_get_header(vars, "stereo") || switch_event_get_header(vars, "stereo_swap")))
+			? " (per-recording override)" : "");
 
 	if ((status = switch_core_media_bug_add(session, "session_record", file,
 											record_callback, rh, to, flags, &bug)) != SWITCH_STATUS_SUCCESS) {

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -3378,6 +3378,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	char *file_path = NULL;
 	char *ext;
 	char *in_file = NULL, *out_file = NULL;
+	switch_event_t *file_vars = NULL;
+	char *file_vars_data = NULL;
+	char *file_vars_path = NULL;
 
 	if ((p = get_recording_var(channel, vars, "RECORD_HANGUP_ON_ERROR"))) {
 		hangup_on_error = switch_true(p);
@@ -3445,6 +3448,14 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 			switch_goto_status(SWITCH_STATUS_MEMERR, err);
 		}
 	}
+
+	if (!(file_vars_data = switch_core_session_strdup(session, file))) {
+		switch_goto_status(SWITCH_STATUS_MEMERR, err);
+	}
+
+	if (*file_vars_data == '{') {
+		switch_event_create_brackets(file_vars_data, '{', '}', ',', &file_vars, &file_vars_path, SWITCH_FALSE);
+	}
 	
 	if (recording_var_true(channel, vars, "RECORD_WRITE_ONLY")) {
 		flags &= ~SMBF_READ_STREAM;
@@ -3467,21 +3478,50 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	}
 
 	/* Per-recording 'stereo'/'stereo_swap' vars take precedence over channel-level
-	 * RECORD_STEREO, preventing cross-contamination between concurrent recordings. */
+	 * RECORD_STEREO, preventing cross-contamination between concurrent recordings.
+	 * A per-recording force_channels value must also keep the media bug channel mode
+	 * aligned with the file handle channel count; otherwise encoders such as MP3 can
+	 * open a 2-channel target while receiving mono/default bug frames. */
 	{
 		int want_stereo = 0, want_swap = 0;
 		int have_override = 0;
+		int have_force_channels = 0;
+		int force_channels = 0;
 
-		if (vars) {
-			const char *sv = switch_event_get_header(vars, "stereo");
-			const char *sw = switch_event_get_header(vars, "stereo_swap");
-			if (sv || sw) {
-				/* Per-recording override: resolve both from vars only, no channel fallback */
-				have_override = 1;
-				if (sv) want_stereo = switch_true(sv);
-				if (sw) want_swap = switch_true(sw);
-				if (want_swap) want_stereo = 1;
+		const char *sv = vars ? switch_event_get_header(vars, "stereo") : NULL;
+		const char *sw = vars ? switch_event_get_header(vars, "stereo_swap") : NULL;
+		const char *fc = vars ? switch_event_get_header(vars, "force_channels") : NULL;
+
+		if (!sv && file_vars) {
+			sv = switch_event_get_header(file_vars, "stereo");
+		}
+		if (!sw && file_vars) {
+			sw = switch_event_get_header(file_vars, "stereo_swap");
+		}
+		if (!fc && file_vars) {
+			fc = switch_event_get_header(file_vars, "force_channels");
+		}
+
+		if (sv || sw) {
+			/* Per-recording override: resolve both from recording-specific vars only, no channel fallback */
+			have_override = 1;
+			if (sv) want_stereo = switch_true(sv);
+			if (sw) want_swap = switch_true(sw);
+			if (want_swap) want_stereo = 1;
+		}
+
+		if (!zstr(fc)) {
+			force_channels = atoi(fc);
+			if (force_channels > 0 && force_channels < 3) {
+				have_force_channels = 1;
 			}
+		}
+
+		if (!have_override && have_force_channels) {
+			/* Match the media bug frame layout to the requested file channel count. */
+			have_override = 1;
+			want_stereo = (force_channels == 2) ? 1 : 0;
+			want_swap = 0;
 		}
 
 		if (!have_override) {
@@ -3817,8 +3857,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
 		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s\n",
 		file, channels, rh->stereo, rh->stereo_swap,
-		(vars && (switch_event_get_header(vars, "stereo") || switch_event_get_header(vars, "stereo_swap")))
-			? " (per-recording override)" : "");
+		((vars && (switch_event_get_header(vars, "stereo") || switch_event_get_header(vars, "stereo_swap") || switch_event_get_header(vars, "force_channels"))) ||
+		 (file_vars && (switch_event_get_header(file_vars, "stereo") || switch_event_get_header(file_vars, "stereo_swap") || switch_event_get_header(file_vars, "force_channels"))))
+			? " (per-recording channel override)" : "");
 
 	if ((status = switch_core_media_bug_add(session, "session_record", file,
 											record_callback, rh, to, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
@@ -3851,9 +3892,16 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		switch_core_session_receive_message(session, &msg);
 	}
 
+	if (file_vars) {
+		switch_event_destroy(&file_vars);
+	}
+
 	return SWITCH_STATUS_SUCCESS;
 
 err:
+	if (file_vars) {
+		switch_event_destroy(&file_vars);
+	}
 	if (!zstr(rh->completion_cause)) {
 		switch_channel_set_variable_printf(channel, "record_completion_cause", "%s", rh->completion_cause);
 	}

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -3890,8 +3890,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	rh->stereo_swap = (flags & SMBF_STEREO_SWAP) ? 1 : 0;
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
-		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s
-",
+		"Recording %s: channels=%d stereo=%d stereo_swap=%d%s\n",
 		file, channels, rh->stereo, rh->stereo_swap,
 		(vars && (switch_event_get_header(vars, "stereo") || switch_event_get_header(vars, "stereo_swap")))
 			? " (per-recording override)"


### PR DESCRIPTION
## Summary
- Treat per-recording `force_channels=1|2` as an explicit recording channel-layout request when creating the `record_session` media bug.
- `force_channels=2` now enables the stereo media-bug path for that recording, so MP3/libmp3lame does not open a 2-channel target while receiving mono/default bug frames.
- Also reads `force_channels`, `stereo`, and `stereo_swap` from leading `{...}` file params, which is the actual TEL-6981 execute-on-answer syntax: `record_session {force_channels=2,...}/recordings/file.mp3`.
- `force_channels=1` keeps that recording mono even if channel-level `RECORD_STEREO=true` exists, preventing TELCORE-2-style channel-variable contamination.

## Behavior / precedence
This is stacked on PR #579's per-recording `stereo` / `stereo_swap` support.

Resolution order is now:
1. Explicit per-recording `{stereo=...}` / `{stereo_swap=...}` from app vars or leading file params
2. Per-recording `{force_channels=1|2}` from app vars or leading file params
3. Legacy channel-level `RECORD_STEREO` / `RECORD_STEREO_SWAP`

So the TEL-6981 exact old command now gets a scoped stereo bug automatically from `force_channels=2`:

```text
uuid_setvar_multi <uuid> execute_on_answer_record=record_session {local_recording=true,recording_id=<recording_id>,samplerate=11025,force_channels=2,av_audio_codec=libmp3lame,av_record_audio_only=true}/recordings/<file>.mp3
```

## Evidence from B2BUA test before v2
Tuan tested the first version of this PR and logs showed the patch was loaded but only saw `force_channels` when it was in `vars`, not when it was in the leading file params:

```text
record_session({local_recording=true,...,force_channels=2,...}/recordings/...mp3)
Recording {...force_channels=2...}/recordings/...mp3: channels=1 stereo=0 stereo_swap=0
```

The control variants with channel-level `RECORD_STEREO=true` logged:

```text
Recording {...force_channels=2...}/recordings/...mp3: channels=2 stereo=1 stereo_swap=0
```

This update fixes that by parsing the leading `{...}` prefix for the stereo decision while leaving the original file string intact for `switch_core_file_open()` / mod_shout params.

## Expected matrix
- `force_channels=1`, `RECORD_STEREO=true` => mono media bug, MP3 should be valid
- `force_channels=1`, `RECORD_STEREO=false` => mono media bug, MP3 should be valid
- `force_channels=1`, no `RECORD_STEREO` => mono media bug, MP3 should be valid
- `force_channels=2`, `RECORD_STEREO=true` => stereo media bug, MP3 should be valid
- `force_channels=2`, `RECORD_STEREO=false` => stereo media bug, MP3 should be valid
- `force_channels=2`, no `RECORD_STEREO` => stereo media bug, MP3 should be valid
- no `force_channels`, `RECORD_STEREO=true` => legacy stereo behavior
- no `force_channels`, `RECORD_STEREO=false` / unset => legacy mono/default behavior

## Test plan
- [x] `git diff --check pr-579...HEAD`
- [x] B2BUA log analysis from failed v1 proved `force_channels=2` lived in leading file params and the v1 logic did not read it.
- [ ] Rebuild B2BUA with this latest PR head.
- [ ] Re-run TEL-6981 MP3 execute-on-answer harness. The previously-failing `minimal`, `rw_undef`, `bug_bottom_only`, and `stop_write_only` variants should now log `channels=2 stereo=1 stereo_swap=0 (per-recording channel override)` and produce non-tiny valid MP3 output.

## Notes
This avoids using channel-level `RECORD_STEREO=true` as the TEL-6981 workaround, because TELCORE-2 showed that channel-level stereo contaminates concurrent mono recordings.

— 🪽 Hermes War Room on behalf of @minhtuan1407-telnyx
