### PR TITLE
TELCORE-135: Make originate bracket parser double-quote-aware

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -2893,7 +2893,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 						dq = 0;
 					}
 
-					if (end && p < end && *p == '"' && !q && (p == pipe_names[r] || *(p-1) != '\\')) {
+					if (end && p < end && *p == '"' && !q && (dq || memchr(p + 1, '"', end - p - 1)) && (p == pipe_names[r] || *(p-1) != '\\')) {
 						dq = !dq;
 					}
 

--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -2832,7 +2832,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 		
 		for (r = 0; r < or_argc && (!cancel_cause || *cancel_cause == 0); r++) {
 			char *p, *end = NULL;
-			int q = 0, alt = 0;
+			int q = 0, dq = 0, alt = 0;
 
 			check_reject = 1;
 
@@ -2890,15 +2890,20 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 							alt = 0;
 						}
 						q = 0;
+						dq = 0;
 					}
 
-					if (*p == '\'') {
+					if (end && p < end && *p == '"' && !q && (p == pipe_names[r] || *(p-1) != '\\')) {
+						dq = !dq;
+					}
+
+					if (*p == '\'' && !dq) {
 						q = !q;
 					}
 
 					if (end && p < end && *p == ',' && *(p-1) != '\\') {
 
-						if (q || alt) {
+						if (q || dq || alt) {
 							*p = QUOTED_ESC_COMMA;
 						} else {
 							*p = UNQUOTED_ESC_COMMA;

--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -2689,6 +2689,7 @@ static char *cleanup_separated_string(char *str, char delim)
 	char *start;
 	char *end = NULL;
 	int inside_quotes = 0;
+	int inside_dquotes = 0;
 
 	/* Skip initial whitespace */
 	for (ptr = str; *ptr == ' '; ++ptr) {
@@ -2708,7 +2709,13 @@ static char *cleanup_separated_string(char *str, char delim)
 			}
 		}
 		if (!esc) {
-			if (*ptr == '\'' && (inside_quotes || strchr(ptr+1, '\''))) {
+			if (*ptr == '"' && !inside_quotes) {
+				inside_dquotes = (1 - inside_dquotes);
+				*dest++ = *ptr;
+				if (*ptr != ' ') {
+					end = dest;
+				}
+			} else if (*ptr == '\'' && !inside_dquotes && (inside_quotes || strchr(ptr+1, '\''))) {
 				if ((inside_quotes = (1 - inside_quotes))) {
 					end = dest;
 				}
@@ -2758,6 +2765,7 @@ static unsigned int separate_string_char_delim(char *buf, char delim, char **arr
 	unsigned int count = 0;
 	char *ptr = buf;
 	int inside_quotes = 0;
+	int inside_dquotes = 0;
 	unsigned int i;
 
 	while (*ptr && count < arraylen) {
@@ -2771,9 +2779,11 @@ static unsigned int separate_string_char_delim(char *buf, char delim, char **arr
 			/* escaped characters are copied verbatim to the destination string */
 			if (*ptr == ESCAPE_META) {
 				++ptr;
-			} else if (*ptr == '\'' && (inside_quotes || strchr(ptr+1, '\''))) {
+			} else if (*ptr == '"' && !inside_quotes) {
+				inside_dquotes = (1 - inside_dquotes);
+			} else if (*ptr == '\'' && !inside_dquotes && (inside_quotes || strchr(ptr+1, '\''))) {
 				inside_quotes = (1 - inside_quotes);
-			} else if (*ptr == delim && !inside_quotes) {
+			} else if (*ptr == delim && !inside_quotes && !inside_dquotes) {
 				*ptr = '\0';
 				state = START;
 			}

--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -2709,7 +2709,7 @@ static char *cleanup_separated_string(char *str, char delim)
 			}
 		}
 		if (!esc) {
-			if (*ptr == '"' && !inside_quotes) {
+			if (*ptr == '"' && !inside_quotes && (inside_dquotes || strchr(ptr + 1, '"'))) {
 				inside_dquotes = (1 - inside_dquotes);
 				*dest++ = *ptr;
 				if (*ptr != ' ') {
@@ -2779,7 +2779,7 @@ static unsigned int separate_string_char_delim(char *buf, char delim, char **arr
 			/* escaped characters are copied verbatim to the destination string */
 			if (*ptr == ESCAPE_META) {
 				++ptr;
-			} else if (*ptr == '"' && !inside_quotes) {
+			} else if (*ptr == '"' && !inside_quotes && (inside_dquotes || strchr(ptr + 1, '"'))) {
 				inside_dquotes = (1 - inside_dquotes);
 			} else if (*ptr == '\'' && !inside_dquotes && (inside_quotes || strchr(ptr+1, '\''))) {
 				inside_quotes = (1 - inside_quotes);


### PR DESCRIPTION
## Problem

The `[...]` local-var parser in `switch_ivr_originate.c` toggles single-quote state (`q`) on every raw `'`, including apostrophes inside SIP double-quoted display names like `"Wood's Homes"`. This corrupts comma classification — subsequent vars like `sip_h_X-USE-TLS=1` and `rtp_secure_media=true` get swallowed into the previous variable's value, breaking TLS/SRTP on call-forward legs.

## Root Cause

Dialplan returns a bridge string with:
```
[...,sip_h_Diversion="Wood's Homes"<sip:...>,sip_execute_on_image='t38_gateway self nocng',fax_enable_t38=true,sip_h_X-USE-TLS=1,rtp_secure_media=true,...]
```

The apostrophe in `Wood's` flips the parser's quote state. The `sip_execute_on_image` quoting then interacts with this corrupted state, and everything after it (including the TLS/SRTP vars) is treated as part of one big quoted value.

## Fix

Add a parallel double-quote state tracker (`dq`/`inside_dquotes`) with mutual exclusion:
- `'` is ignored inside `"..."` (no quote toggle)
- `"` is ignored inside `'...'` (no quote toggle)
- Commas inside `"..."` are protected from delimiter splitting

Three locations patched:
1. **`switch_ivr_originate.c`** — pre-scan loop that classifies commas as `QUOTED_ESC_COMMA` vs `UNQUOTED_ESC_COMMA` inside `[...]` blocks
2. **`switch_utils.c` `separate_string_char_delim`** — delimiter splitting used by `switch_event_create_brackets()`
3. **`switch_utils.c` `cleanup_separated_string`** — quote stripping/cleanup (preserves `"` in output since they're part of SIP header values)

Linear: https://linear.app/telnyx/issue/TELCORE-135