### PR TITLE
TELCORE-67: Defensively sanitize SIP display-names before quoted-string embed

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -383,6 +383,8 @@ char *generate_pai_str(private_object_t *tech_pvt)
 
 	if (!zstr(callee_name) && strcmp(callee_name, "_undef_") && !zstr(callee_number)) {
 		check_decode(callee_name, tech_pvt->session);
+		/* Sanitize display-name before quoted-string embed. */
+		callee_name = sofia_glue_sanitize_display_name((char *)callee_name);
 
 		if (switch_stristr("update_display", tech_pvt->x_freeswitch_support_remote)) {
 			pai = switch_core_session_sprintf(tech_pvt->session, "%s: \"%s\" <%s>%s\n"
@@ -2386,6 +2388,10 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 				const char *session_id_header = sofia_glue_session_id_header(tech_pvt->session, tech_pvt->profile);
 
 				check_decode(name, tech_pvt->session);
+				/* Sanitize before quoted-string embed (nua_info/nua_update). */
+				if (!zstr(name)) {
+					name = sofia_glue_sanitize_display_name(switch_core_session_strdup(tech_pvt->session, name));
+				}
 
 				if (allow) {
 					update_allowed = !!switch_stristr("UPDATE", allow);
@@ -2523,16 +2529,18 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 					char message[256] = "";
 					const char *ua = switch_channel_get_variable(tech_pvt->channel, "sip_user_agent");
 					const char *session_id_header = sofia_glue_session_id_header(tech_pvt->session, tech_pvt->profile);
+					/* Sanitize display-name before quoted-string embed. */
+					char *hold_display = sofia_glue_sanitize_display_name(switch_core_session_strdup(tech_pvt->session, msg->string_arg));
 
 					if (ua && switch_stristr("snom", ua)) {
-						snprintf(message, sizeof(message), "From:\r\nTo: \"%s\" %s\r\n", msg->string_arg, tech_pvt->caller_profile->destination_number);
+						snprintf(message, sizeof(message), "From:\r\nTo: \"%s\" %s\r\n", hold_display, tech_pvt->caller_profile->destination_number);
 						nua_info(tech_pvt->nh, SIPTAG_CONTENT_TYPE_STR("message/sipfrag"),
 								 TAG_IF(!zstr(tech_pvt->user_via), SIPTAG_VIA_STR(tech_pvt->user_via)),
 								 SIPTAG_PAYLOAD_STR(message),
 								 TAG_IF(!zstr(session_id_header), SIPTAG_HEADER_STR(session_id_header)),
 								 TAG_END());
 					} else if (ua && switch_stristr("polycom", ua)) {
-						snprintf(message, sizeof(message), "P-Asserted-Identity: \"%s\" <%s>", msg->string_arg, tech_pvt->caller_profile->destination_number);
+						snprintf(message, sizeof(message), "P-Asserted-Identity: \"%s\" <%s>", hold_display, tech_pvt->caller_profile->destination_number);
 						nua_update(tech_pvt->nh,
 								   NUTAG_SESSION_TIMER(tech_pvt->session_timeout),
 								   NUTAG_SESSION_REFRESHER(tech_pvt->session_refresher),

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -1145,6 +1145,11 @@ void sofia_reg_unregister(sofia_profile_t *profile);
 
 void sofia_glue_pass_sdp(private_object_t *tech_pvt, char *sdp);
 switch_call_cause_t sofia_glue_sip_cause_to_freeswitch(int status);
+
+/* Sanitize a SIP display-name in place so it is safe to embed in a
+ * quoted-string. Only touches the display-name buffer; URI/identity untouched.
+ * See implementation in sofia_glue.c for the full rules. */
+char *sofia_glue_sanitize_display_name(char *name);
 void sofia_glue_do_xfer_invite(switch_core_session_t *session);
 uint8_t sofia_reg_handle_register_token(nua_t *nua, sofia_profile_t *profile, nua_handle_t *nh, sip_t const *sip,
 								  sofia_dispatch_event_t *de,

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -12519,6 +12519,10 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 
 
 	check_decode(displayname, session);
+	/* Sanitize inbound display-name to protect outbound nua_handle(). */
+	if (!zstr(displayname)) {
+		displayname = sofia_glue_sanitize_display_name(switch_core_session_strdup(session, displayname));
+	}
 
 	profile_dup_clean(from_user, tech_pvt->caller_profile->username, tech_pvt->caller_profile->pool);
 	profile_dup_clean(dialplan, tech_pvt->caller_profile->dialplan, tech_pvt->caller_profile->pool);

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -41,6 +41,59 @@ switch_cache_db_handle_t *_sofia_glue_get_db_handle(sofia_profile_t *profile, co
 #define sofia_glue_get_db_handle(_p) _sofia_glue_get_db_handle(_p, __FILE__, __SWITCH_FUNC__, __LINE__)
 #define SWITCH_RECOVERY_GRACE_PERIOD_SEC 30
 
+/* Sanitize a SIP display-name in place for sofia-sip's strict parser.
+ * Strips a dangling trailing '\\', keeps "\\"/"\"" quoted-pairs, replaces any
+ * stray '\\X' or raw '"' with a space. URI/identity is never touched. */
+char *sofia_glue_sanitize_display_name(char *name)
+{
+	char *p;
+	size_t len;
+	switch_bool_t changed = SWITCH_FALSE;
+
+	if (zstr(name)) {
+		return name;
+	}
+
+	len = strlen(name);
+
+	/* Strip a trailing unescaped backslash (odd-length run of trailing '\\'). */
+	if (len > 0 && name[len - 1] == '\\') {
+		size_t bs_run = 0;
+		size_t i = len;
+		while (i > 0 && name[i - 1] == '\\') {
+			bs_run++;
+			i--;
+		}
+		if ((bs_run % 2) != 0) {
+			name[--len] = '\0';
+			changed = SWITCH_TRUE;
+		}
+	}
+
+	/* Walk: keep "\\"/"\"" pairs, neutralize stray '\\X' and raw '"'. */
+	for (p = name; *p; p++) {
+		if (*p == '\\') {
+			char next = *(p + 1);
+			if (next == '\\' || next == '"') {
+				p++;
+				continue;
+			}
+			*p = ' ';
+			changed = SWITCH_TRUE;
+		} else if (*p == '"') {
+			*p = ' ';
+			changed = SWITCH_TRUE;
+		}
+	}
+
+	if (changed) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+						  "sofia: sanitized malformed SIP display-name -> [%s]\n", name);
+	}
+
+	return name;
+}
+
 int sofia_glue_check_nat(sofia_profile_t *profile, const char *network_ip)
 {
 	switch_assert(network_ip);
@@ -1381,7 +1434,11 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 
 		url_str = sofia_overcome_sip_uri_weakness(session, url, tech_pvt->transport, SWITCH_TRUE, invite_params, invite_tel_params);
 		if (switch_channel_var_true(tech_pvt->channel, "sip_caller_id_name_in_contact")) {
-			invite_contact = switch_core_session_sprintf(session, "\"%s\" %s", tech_pvt->caller_profile->caller_id_name, sofia_overcome_sip_uri_weakness(session, tech_pvt->invite_contact, tech_pvt->transport, SWITCH_FALSE, invite_contact_params, NULL));
+			/* Sanitize Contact display-name. */
+			char *contact_name = !zstr(tech_pvt->caller_profile->caller_id_name) ?
+				sofia_glue_sanitize_display_name(switch_core_session_strdup(session, tech_pvt->caller_profile->caller_id_name)) :
+				(char *)tech_pvt->caller_profile->caller_id_name;
+			invite_contact = switch_core_session_sprintf(session, "\"%s\" %s", contact_name, sofia_overcome_sip_uri_weakness(session, tech_pvt->invite_contact, tech_pvt->transport, SWITCH_FALSE, invite_contact_params, NULL));
 		} else {
 			invite_contact = sofia_overcome_sip_uri_weakness(session, tech_pvt->invite_contact, tech_pvt->transport, SWITCH_FALSE, invite_contact_params, NULL);
 		}
@@ -1405,6 +1462,8 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		} else {
 			char *name = switch_core_session_strdup(session, from_display ? from_display : tech_pvt->caller_profile->caller_id_name);
 			check_decode(name, session);
+			/* Sanitize From display-name. */
+			name = sofia_glue_sanitize_display_name(name);
 			from_str = switch_core_session_sprintf(session, "\"%s\" <%s>", name, use_from_str);
 		}
 
@@ -1536,6 +1595,10 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		}
 
 		check_decode(use_name, session);
+		/* Sanitize PAID/RPID/PPID display-name (dup first; may alias chanvar). */
+		if (!zstr(use_name)) {
+			use_name = sofia_glue_sanitize_display_name(switch_core_session_strdup(session, use_name));
+		}
 
 		switch (cid_type) {
 		case CID_TYPE_PID:
@@ -1552,15 +1615,16 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 																		invite_pid_params ? invite_pid_params : "");
 				}
 			} else {
-				if (zstr(tech_pvt->caller_profile->caller_id_name) || !strcasecmp(tech_pvt->caller_profile->caller_id_name, "_undef_")) {
+				/* Use sanitized use_name/use_number for P-Preferred-Identity. */
+				if (zstr(use_name) || !strcasecmp(use_name, "_undef_")) {
 					tech_pvt->preferred_id = switch_core_session_sprintf(tech_pvt->session, "<sip:%s@%s%s%s>",
-																		 tech_pvt->caller_profile->caller_id_number, rpid_domain,
+																		 use_number, rpid_domain,
 																		 invite_pid_params ? ";" : "",
 																		 invite_pid_params ? invite_pid_params : "");
 				} else {
 					tech_pvt->preferred_id = switch_core_session_sprintf(tech_pvt->session, "\"%s\" <sip:%s@%s%s%s>",
-																		 tech_pvt->caller_profile->caller_id_name,
-																		 tech_pvt->caller_profile->caller_id_number, rpid_domain,
+																		 use_name,
+																		 use_number, rpid_domain,
 																		 invite_pid_params ? ";" : "",
 																		 invite_pid_params ? invite_pid_params : "");
 				}
@@ -1892,24 +1956,31 @@ void sofia_glue_do_xfer_invite(switch_core_session_t *session)
 
 	format = strchr(sipip, ':') ? "\"%s\" <sip:%s@[%s]>" : "\"%s\" <sip:%s@%s>";
 
-	if ((tech_pvt->from_str = switch_core_session_sprintf(session, format, caller_profile->caller_id_name, caller_profile->caller_id_number, sipip))) {
+	/* Sanitize xfer From display-name. */
+	{
+		char *xfer_name = !zstr(caller_profile->caller_id_name)
+			? sofia_glue_sanitize_display_name(switch_core_session_strdup(session, caller_profile->caller_id_name))
+			: (char *) caller_profile->caller_id_name;
 
-		const char *rep = switch_channel_get_variable(channel, SOFIA_REPLACES_HEADER);
+		if ((tech_pvt->from_str = switch_core_session_sprintf(session, format, xfer_name, caller_profile->caller_id_number, sipip))) {
 
-		tech_pvt->nh2 = nua_handle(tech_pvt->profile->nua, NULL,
-								   SIPTAG_TO_STR(tech_pvt->dest), SIPTAG_FROM_STR(tech_pvt->from_str), SIPTAG_CONTACT_STR(contact_url), TAG_END());
+			const char *rep = switch_channel_get_variable(channel, SOFIA_REPLACES_HEADER);
 
-		nua_handle_bind(tech_pvt->nh2, tech_pvt->sofia_private);
+			tech_pvt->nh2 = nua_handle(tech_pvt->profile->nua, NULL,
+									   SIPTAG_TO_STR(tech_pvt->dest), SIPTAG_FROM_STR(tech_pvt->from_str), SIPTAG_CONTACT_STR(contact_url), TAG_END());
 
-		nua_invite(tech_pvt->nh2,
-				   SIPTAG_CONTACT_STR(contact_url),
-				   TAG_IF(!zstr(tech_pvt->user_via), SIPTAG_VIA_STR(tech_pvt->user_via)),
-				   SOATAG_ADDRESS(tech_pvt->mparams.adv_sdp_audio_ip),
-				   SOATAG_USER_SDP_STR(tech_pvt->mparams.local_sdp_str),
-				   SOATAG_REUSE_REJECTED(1),
-				   SOATAG_RTP_SORT(SOA_RTP_SORT_REMOTE), SOATAG_RTP_SELECT(SOA_RTP_SELECT_ALL), TAG_IF(rep, SIPTAG_REPLACES_STR(rep)), TAG_END());
-	} else {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(tech_pvt->session), SWITCH_LOG_ERROR, "Memory Error!\n");
+			nua_handle_bind(tech_pvt->nh2, tech_pvt->sofia_private);
+
+			nua_invite(tech_pvt->nh2,
+					   SIPTAG_CONTACT_STR(contact_url),
+					   TAG_IF(!zstr(tech_pvt->user_via), SIPTAG_VIA_STR(tech_pvt->user_via)),
+					   SOATAG_ADDRESS(tech_pvt->mparams.adv_sdp_audio_ip),
+					   SOATAG_USER_SDP_STR(tech_pvt->mparams.local_sdp_str),
+					   SOATAG_REUSE_REJECTED(1),
+					   SOATAG_RTP_SORT(SOA_RTP_SORT_REMOTE), SOATAG_RTP_SELECT(SOA_RTP_SELECT_ALL), TAG_IF(rep, SIPTAG_REPLACES_STR(rep)), TAG_END());
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(tech_pvt->session), SWITCH_LOG_ERROR, "Memory Error!\n");
+		}
 	}
 	switch_mutex_unlock(tech_pvt->sofia_mutex);
 }

--- a/src/mod/endpoints/mod_sofia/test/test_sofia_funcs.c
+++ b/src/mod/endpoints/mod_sofia/test/test_sofia_funcs.c
@@ -33,6 +33,7 @@
 #include <test/switch_test.h>
 
 int protect_dest_uri(switch_caller_profile_t *cp);
+char *sofia_glue_sanitize_display_name(char *name);
 
 static int timeout_sec = 10;
 static switch_interval_time_t delay_start_ms = 5000;
@@ -55,6 +56,64 @@ FST_TEARDOWN_BEGIN()
 {
 }
 FST_TEARDOWN_END()
+
+FST_TEST_BEGIN(test_sanitize_display_name)
+{
+	char buf[128];
+	char *result;
+
+	/* Clean input passes through unchanged. */
+	switch_copy_string(buf, "Alice", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Alice");
+
+	/* Trailing backslash runs of length 1/2/3 (odd strips, even keeps). */
+	switch_copy_string(buf, "Sami\\", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Sami");
+
+	switch_copy_string(buf, "Sami\\\\", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Sami\\\\");
+
+	switch_copy_string(buf, "Sami\\\\\\", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Sami\\\\");
+
+	/* Customer-reported wire shape "Sami\ ": lone '\<space>' neutralized. */
+	switch_copy_string(buf, "Sami\\ ", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Sami  ");
+
+	/* Raw '"' neutralized; valid '\"' / '\\' quoted-pairs left intact. */
+	switch_copy_string(buf, "Bob\"Smith", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Bob Smith");
+
+	switch_copy_string(buf, "foo\\\"bar", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "foo\\\"bar");
+
+	switch_copy_string(buf, "foo\\\\bar", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "foo\\\\bar");
+
+	/* Stray '\X' is neutralized (sofia-strict, stricter than RFC 3261). */
+	switch_copy_string(buf, "Joe\\,Bloggs", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "Joe ,Bloggs");
+
+	switch_copy_string(buf, "a\"b\"c", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "a b c");
+
+	/* NULL / empty are no-ops. */
+	fst_check(sofia_glue_sanitize_display_name(NULL) == NULL);
+	switch_copy_string(buf, "", sizeof(buf));
+	result = sofia_glue_sanitize_display_name(buf);
+	fst_check_string_equals(result, "");
+}
+FST_TEST_END()
 
 FST_TEST_BEGIN(test_protect_url)
 {


### PR DESCRIPTION
## Problem

B2BUA silently fails to create outbound legs when inbound identity headers contain malformed display-name quoting. Customer-reported wire shape:

```
From: "Sami\ " <sip:+16469142552@34.74.99.53>;tag=eX4NvUFDaH30c
Remote-Party-ID: "Sami\ " <sip:+16469142552@34.74.99.53>;party=calling;screen=yes;privacy=off
```

The unescaped trailing backslash quotes the closing `"`, leaving an unterminated quoted-string. sofia-sip's strict parser rejects the rebuilt outbound header, `nua_handle()` returns NULL, and the call hangs up with `DESTINATION_OUT_OF_ORDER` at `sofia_on_init` (`mod_sofia.c:135`). No clear SIP error is surfaced.

## Fix

Add `sofia_glue_sanitize_display_name()` — a narrow defensive helper that normalizes a display-name in place. Deliberately stricter than RFC 3261 to match sofia-sip's actual parser behavior:

- Strips a dangling trailing unescaped backslash.
- Preserves the `\\` and `\"` quoted-pair sequences.
- Replaces any other `\X` or raw `"` with a space.
- **Never touches the SIP URI or asserted identity.**
- No-op when the display-name is already clean.


## Linear

https://linear.app/telnyx/issue/TELCORE-67
