### PR TITLE
TELCORE-120: fix mod_xml_rpc build with debian trixie / gcc 14

### DIFF
--- a/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
+++ b/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
@@ -1340,7 +1340,12 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_xml_rpc_runtime)
 	switch_hash_index_t *hi;
 	const void *var;
 	void *val;
-	in_addr_t addr;
+	// The bundled xmlrpc-c's ServerCreate() takes `struct in_addr *` for the
+	// bind-address arg; the original telnyx fork patch (cf68bd0164a, 2019)
+	// declared this as `in_addr_t` (a uint32_t). gcc <= 13 reported it as a
+	// -Wincompatible-pointer-types warning; gcc 14 (Debian Trixie default)
+	// makes it a hard error.
+	struct in_addr addr;
 
 	//
 	// Lock the global mutex.  ssl_init is not threadsafe
@@ -1353,7 +1358,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_xml_rpc_runtime)
 	globals.registryP = xmlrpc_registry_new(&env);
 	
 	if (globals.addr) {
-		addr = inet_addr(globals.addr);
+		addr.s_addr = inet_addr(globals.addr);
 	}
 
 	/* TODO why twice and why add_method for freeswitch.api and add_method2 for freeswitch.management ? */


### PR DESCRIPTION
## Summary
- `src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c`: declare the local bind address as `struct in_addr addr` (was `in_addr_t`); assign through `addr.s_addr = inet_addr(...)` (was `addr = inet_addr(...)`).

## Why
The bundled `libs/xmlrpc-c/include/xmlrpc-c/abyss.h` declares

```c
ServerCreate(... struct in_addr * const addrP, ...)
```

but the 2019 telnyx fork patch [cf68bd0164a](https://github.com/team-telnyx/freeswitch/commit/cf68bd0164a845bd8d67d100edec870fb87ebba6) backing IP-bind support declared the local var as `in_addr_t` (a `uint32_t`) and passed `&addr`. gcc ≤ 13 reported this as a `-Wincompatible-pointer-types` warning; gcc 14 (Debian Trixie default) promotes it to a hard error.

Wire behavior is unchanged — `struct in_addr` is just `{ uint32_t s_addr; }` and the network-order layout is identical. The patch only routes the assignment through `s_addr` so the type checker is happy.

## Test plan
- [ ] Build FS in `freeswitch-docker-base:1.16.0` (Trixie) — mod_xml_rpc compiles
- [ ] `xml_rpc.conf` `http-address` setting still binds the configured interface (smoke: start FS with `http-address` set, `ss -lntp` shows the bind)