### PR TITLE
TELCORE-138: fix ICE role for non-DTLS inbound calls with ICE

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -511,7 +511,6 @@ SWITCH_DECLARE(int) switch_core_media_trickle_accept(switch_core_session_t *sess
 
 SWITCH_DECLARE(switch_bool_t) switch_rtp_trickle_is_registered(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_trickle_emit_local_candidate(switch_rtp_t *rtp_session, const switch_rtp_ice_cand_t *cand, const char *mid, int mline_index, int end_of_candidates);
-SWITCH_DECLARE(void) switch_rtp_set_ice_role(switch_rtp_t *rtp_session, switch_bool_t controlling);
 SWITCH_DECLARE(void) switch_rtp_dtls_init_once(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_status_t) switch_rtp_extmap_register(switch_rtp_t *rtp_session, uint8_t id, const char *uri);
 SWITCH_DECLARE(void) switch_rtp_mark_ice_connectivity_failed(switch_rtp_t *rtp_session, const char *reason);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4994,7 +4994,10 @@ static switch_call_direction_t switch_ice_direction(switch_rtp_engine_t *engine,
 		r = (r == SWITCH_CALL_DIRECTION_INBOUND) ? SWITCH_CALL_DIRECTION_OUTBOUND : SWITCH_CALL_DIRECTION_INBOUND;
 	}
 
-	if (switch_rtp_has_dtls() && dtls_ok(smh->session)) {
+	/* Gate DTLS controller-role on CF_DTLS (set when a=fingerprint is parsed);
+	 * CF_DTLS_OK alone is always-on and misleading for non-DTLS sessions. */
+	if (switch_rtp_has_dtls() && dtls_ok(smh->session)
+	    && switch_channel_test_flag(session->channel, CF_DTLS)) {
 		if (switch_channel_test_flag(session->channel, CF_OBSERVE_INITIATOR)) {
 			r = engine->ice_remote_initiator ? SWITCH_CALL_DIRECTION_INBOUND : SWITCH_CALL_DIRECTION_OUTBOUND;
 		} else {
@@ -5012,6 +5015,7 @@ static switch_call_direction_t switch_ice_direction(switch_rtp_engine_t *engine,
 
 static switch_core_media_ice_type_t switch_determine_ice_type(switch_rtp_engine_t *engine, switch_core_session_t *session) {
 	switch_core_media_ice_type_t ice_type = ICE_VANILLA;
+	const char *role_override = NULL;
 
 	if (switch_channel_var_true(session->channel, "ice_lite")) {
 		ice_type |= ICE_CONTROLLED;
@@ -5023,6 +5027,25 @@ static switch_core_media_ice_type_t switch_determine_ice_type(switch_rtp_engine_
 		if (direction == SWITCH_CALL_DIRECTION_INBOUND) {
 			ice_type |= ICE_CONTROLLED;
 		}
+	}
+
+	/* Dialplan override (rtp_ice_role=controlling|controlled). Skipped for ICE-lite
+	 * peers: a lite peer cannot run checks or nominate, FS must stay controlling. */
+	role_override = switch_channel_get_variable(session->channel, "rtp_ice_role");
+	if (!zstr(role_override) && !(ice_type & (ICE_LITE | ICE_LITE_INBOUND))) {
+		if (!strcasecmp(role_override, "controlled")) {
+			ice_type |= ICE_CONTROLLED;
+		} else if (!strcasecmp(role_override, "controlling")) {
+			ice_type &= ~ICE_CONTROLLED;
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+			                  "Ignoring invalid rtp_ice_role=%s (expected 'controlling' or 'controlled')\n",
+			                  role_override);
+		}
+	} else if (!zstr(role_override)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+		                  "Ignoring rtp_ice_role=%s: ICE-lite forces FS to remain controlling\n",
+		                  role_override);
 	}
 
 	return ice_type;
@@ -11132,16 +11155,6 @@ static void gen_ice(switch_core_session_t *session, switch_media_type_t type, co
 	engine->ice_out.cands[0][0].generation = "0";
 
 	engine->ice_out.cands[0][0].ready = 1;
-
-	/* Dynamic ICE role: offerer is controlling unless remote is ice-lite; allow override via var "rtp_ice_role" */
-	{
-		const char *role_override = switch_channel_get_variable(session->channel, "rtp_ice_role");
-		switch_bool_t controlling = SWITCH_TRUE;
-		if (role_override) {
-			controlling = !strcasecmp(role_override, "controlling") ? SWITCH_TRUE : SWITCH_FALSE;
-		}
-		switch_rtp_set_ice_role(engine->rtp_session, controlling);
-	}
 
 	if (engine->rtp_session && switch_core_media_trickle_enabled(session) && switch_rtp_trickle_is_registered(engine->rtp_session)) {
 		switch_rtp_ice_cand_t cand;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -11651,21 +11651,6 @@ SWITCH_DECLARE(void) switch_rtp_trickle_emit_local_candidate(switch_rtp_t *rtp_s
 	}
 }
 
-SWITCH_DECLARE(void) switch_rtp_set_ice_role(switch_rtp_t *rtp_session, switch_bool_t controlling)
-{
-#ifdef SWITCH_HAVE_ICE
-	if (!rtp_session || !rtp_session->ice.ice_params) return;
-	rtp_session->ice.ice_params->controlling = controlling ? 1 : 0;
-	if (!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && rtp_session->rtcp_ice.ice_params) {
-		rtp_session->rtcp_ice.ice_params->controlling = controlling ? 1 : 0;
-	}
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
-	                  "ICE role set to %s\n", controlling ? "controlling" : "controlled");
-#else
-	(void)rtp_session; (void)controlling;
-#endif
-}
-
 SWITCH_DECLARE(switch_status_t) switch_rtp_extmap_register(switch_rtp_t *rtp_session, uint8_t id, const char *uri)
 {
 #ifdef SWITCH_HAVE_RTP


### PR DESCRIPTION
## Summary

`switch_ice_direction()` gated DTLS controller-role logic on `CF_DTLS_OK`, but that flag is set unconditionally for every media session in `switch_media_handle_create()`. For non-DTLS inbound calls (e.g. Cisco RTP/SAVP+ICE), `dtls_ok()` returned true while `engine->dtls_controller` stayed 0 — so the function returned `OUTBOUND` and `switch_determine_ice_type()` omitted `ICE_CONTROLLED`. On the wire, FS sent `ICE-CONTROLLING` + `USE-CANDIDATE` on the answerer leg, conflicting with compliant ICE peers and breaking candidate nomination → zero inbound RTP, one-way audio.

## Linear

https://linear.app/telnyx/issue/TELCORE-138

## Root cause

The Linear ticket initially pointed at `gen_ice()`'s `switch_rtp_set_ice_role()` call. That call is a no-op for the wire — it only writes `ice_params->controlling`, which isn't read anywhere in `src/`. The on-wire ICE role is decided by `ice->type & ICE_CONTROLLED` in `ice_out()` (`src/switch_rtp.c:1138`), and `ice->type` is set by `switch_determine_ice_type()` at `switch_rtp_activate_ice()` time. The real bug is that `switch_ice_direction()` returned `OUTBOUND` for non-DTLS inbound ICE calls.

## Fix

1. **`switch_ice_direction()`** — add `CF_DTLS` to the DTLS gate. `CF_DTLS` is set when the remote `a=fingerprint` is parsed, which is the correct "DTLS negotiated" signal.

2. **`switch_determine_ice_type()`** — honour the `rtp_ice_role` dialplan override directly on `ice_type`, so it actually affects the STUN wire. Skipped for ICE-lite peers (lite peer cannot run checks or nominate, FS must stay controlling); warns on invalid values.

3. **`gen_ice()`** — drop the vestigial `switch_rtp_set_ice_role()` call.

4. **`switch_rtp_set_ice_role()` removed entirely** — declaration in `switch_core_media.h` and definition in `switch_rtp.c` deleted. It was added in #449 (TEL-6622) but was never wired correctly: it only wrote `ice_params->controlling`, a field that has no readers. With no callers left in `src/` and no plausible external users (function is ~6 weeks old and broken), safe to remove.
