### PR TITLE
TELCORE-141: Decouple RTCP ICE activation from rtcp_*_interval_msec

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11721,32 +11721,48 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				}
 			}
 
-			if (a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].ready && a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready &&
-				!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr) && 
-				!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)) {
-				if (a_engine->rtcp_mux > 0 && 
-					!strcmp(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr, a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)
-					&& a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_port == a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_port) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping RTCP ICE (Same as RTP)\n");
-				} else {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating RTCP ICE\n");
+		}
 
-					switch_rtp_activate_ice(a_engine->rtp_session,
-											a_engine->ice_in.ufrag,
-											a_engine->ice_out.ufrag,
-											a_engine->ice_out.pwd,
-											a_engine->ice_in.pwd,
-											IPR_RTCP,
-#ifdef GOOGLE_ICE
-											ICE_GOOGLE_JINGLE,
-											NULL
-#else
-											switch_determine_ice_type(a_engine, session),
-											&a_engine->ice_in
-#endif
-										);
+		/* Activate RTCP ICE independently of rtcp_audio_interval_msec.
+		 * Per RFC 8445, ICE requires connectivity checks on all advertised components.
+		 * The interval variable controls RTCP report send rate, not ICE activation. */
+		if (a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].ready && a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready &&
+			!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr) &&
+			!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)) {
+
+			/* Ensure RTCP context is initialized for ICE even without rtcp_audio_interval_msec */
+			if (!switch_rtp_test_flag(a_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP)) {
+				switch_port_t rtcp_port = a_engine->remote_rtcp_port;
+				if (!rtcp_port) {
+					const char *rp = switch_channel_get_variable(session->channel, "rtp_remote_audio_rtcp_port");
+					if (rp) rtcp_port = (switch_port_t)atoi(rp);
 				}
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+								  "Activating RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
+				switch_rtp_activate_rtcp(a_engine->rtp_session, 0, rtcp_port, a_engine->rtcp_mux > 0);
+			}
 
+			if (a_engine->rtcp_mux > 0 &&
+				!strcmp(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr, a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)
+				&& a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_port == a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_port) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping RTCP ICE (Same as RTP)\n");
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating RTCP ICE\n");
+
+				switch_rtp_activate_ice(a_engine->rtp_session,
+										a_engine->ice_in.ufrag,
+										a_engine->ice_out.ufrag,
+										a_engine->ice_out.pwd,
+										a_engine->ice_in.pwd,
+										IPR_RTCP,
+#ifdef GOOGLE_ICE
+										ICE_GOOGLE_JINGLE,
+										NULL
+#else
+										switch_determine_ice_type(a_engine, session),
+										&a_engine->ice_in
+#endif
+									);
 			}
 		}
 
@@ -11758,7 +11774,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 			//}
 
 			xtype = DTLS_TYPE_RTP;
-			if (a_engine->rtcp_mux > 0 && smh->mparams->rtcp_audio_interval_msec) xtype |= DTLS_TYPE_RTCP;
+			if (a_engine->rtcp_mux > 0 && (smh->mparams->rtcp_audio_interval_msec ||
+				switch_rtp_test_flag(a_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) xtype |= DTLS_TYPE_RTCP;
 
 			if (switch_channel_var_true(session->channel, "legacyDTLS")) {
 				switch_channel_clear_flag(session->channel, CF_WANT_DTLSv1_2);
@@ -11767,7 +11784,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 			switch_rtp_add_dtls(a_engine->rtp_session, &a_engine->local_dtls_fingerprint, &a_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 
-			if (a_engine->rtcp_mux < 1 && smh->mparams->rtcp_audio_interval_msec) {
+			if (a_engine->rtcp_mux < 1 && (smh->mparams->rtcp_audio_interval_msec ||
+				switch_rtp_test_flag(a_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) {
 				xtype = DTLS_TYPE_RTCP;
 				switch_rtp_add_dtls(a_engine->rtp_session, &a_engine->local_dtls_fingerprint, &a_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 			}
@@ -12089,34 +12107,44 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					}
 
 
-					if (t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].ready && t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].ready &&
-						!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr) && 
-						!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr)) {
-						if (t_engine->rtcp_mux > 0 && !strcmp(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr,
-															  t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr) &&
-							t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_port == t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_port) {
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping TEXT RTCP ICE (Same as TEXT RTP)\n");
-						} else {
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating TEXT RTCP ICE\n");
-							switch_rtp_activate_ice(t_engine->rtp_session,
-													t_engine->ice_in.ufrag,
-													t_engine->ice_out.ufrag,
-													t_engine->ice_out.pwd,
-													t_engine->ice_in.pwd,
-													IPR_RTCP,
-#ifdef GOOGLE_ICE
-													ICE_GOOGLE_JINGLE,
-													NULL
-#else
-													switch_determine_ice_type(t_engine, session),
-													&t_engine->ice_in
-#endif
-													);
+				}
 
+				/* Activate TEXT RTCP ICE independently of rtcp_text_interval_msec */
+				if (t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].ready && t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].ready &&
+					!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr) &&
+					!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr)) {
 
-
+					if (!switch_rtp_test_flag(t_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP)) {
+						switch_port_t rtcp_port = t_engine->remote_rtcp_port;
+						if (!rtcp_port) {
+							const char *rp = switch_channel_get_variable(session->channel, "rtp_remote_text_rtcp_port");
+							if (rp) rtcp_port = (switch_port_t)atoi(rp);
 						}
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+										  "Activating TEXT RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
+						switch_rtp_activate_rtcp(t_engine->rtp_session, 0, rtcp_port, t_engine->rtcp_mux > 0);
+					}
 
+					if (t_engine->rtcp_mux > 0 && !strcmp(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr,
+														  t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr) &&
+						t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_port == t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_port) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping TEXT RTCP ICE (Same as TEXT RTP)\n");
+					} else {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating TEXT RTCP ICE\n");
+						switch_rtp_activate_ice(t_engine->rtp_session,
+												t_engine->ice_in.ufrag,
+												t_engine->ice_out.ufrag,
+												t_engine->ice_out.pwd,
+												t_engine->ice_in.pwd,
+												IPR_RTCP,
+#ifdef GOOGLE_ICE
+												ICE_GOOGLE_JINGLE,
+												NULL
+#else
+												switch_determine_ice_type(t_engine, session),
+												&t_engine->ice_in
+#endif
+												);
 					}
 				}
 
@@ -12124,7 +12152,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					dtls_type_t xtype,
 						dtype = t_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
 					xtype = DTLS_TYPE_RTP;
-					if (t_engine->rtcp_mux > 0 && smh->mparams->rtcp_text_interval_msec) xtype |= DTLS_TYPE_RTCP;
+					if (t_engine->rtcp_mux > 0 && (smh->mparams->rtcp_text_interval_msec ||
+						switch_rtp_test_flag(t_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) xtype |= DTLS_TYPE_RTCP;
 			
 					if (switch_channel_var_true(session->channel, "legacyDTLS")) {
 						switch_channel_clear_flag(session->channel, CF_WANT_DTLSv1_2);
@@ -12133,7 +12162,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 					switch_rtp_add_dtls(t_engine->rtp_session, &t_engine->local_dtls_fingerprint, &t_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 
-					if (t_engine->rtcp_mux < 1 && smh->mparams->rtcp_text_interval_msec) {
+					if (t_engine->rtcp_mux < 1 && (smh->mparams->rtcp_text_interval_msec ||
+						switch_rtp_test_flag(t_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) {
 						xtype = DTLS_TYPE_RTCP;
 						switch_rtp_add_dtls(t_engine->rtp_session, &t_engine->local_dtls_fingerprint, &t_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 					}
@@ -12428,35 +12458,43 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					}
 
 
-					if (v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].ready && v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].ready &&
-						!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr) && 
-						!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)) {
+				}
 
-						if (v_engine->rtcp_mux > 0 && !strcmp(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr, v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)
-							&& v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_port == v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_port) {
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping VIDEO RTCP ICE (Same as VIDEO RTP)\n");
-						} else {
+				/* Activate VIDEO RTCP ICE independently of rtcp_video_interval_msec */
+				if (v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].ready && v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].ready &&
+					!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr) &&
+					!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)) {
 
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating VIDEO RTCP ICE\n");
-							switch_rtp_activate_ice(v_engine->rtp_session,
-													v_engine->ice_in.ufrag,
-													v_engine->ice_out.ufrag,
-													v_engine->ice_out.pwd,
-													v_engine->ice_in.pwd,
-													IPR_RTCP,
-#ifdef GOOGLE_ICE
-													ICE_GOOGLE_JINGLE,
-													NULL
-#else
-													switch_determine_ice_type(v_engine, session),
-													&v_engine->ice_in
-#endif
-													);
-
-
-
+					if (!switch_rtp_test_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP)) {
+						switch_port_t rtcp_port = v_engine->remote_rtcp_port;
+						if (!rtcp_port) {
+							const char *rp = switch_channel_get_variable(session->channel, "rtp_remote_video_rtcp_port");
+							if (rp) rtcp_port = (switch_port_t)atoi(rp);
 						}
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+										  "Activating VIDEO RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
+						switch_rtp_activate_rtcp(v_engine->rtp_session, 0, rtcp_port, v_engine->rtcp_mux > 0);
+					}
 
+					if (v_engine->rtcp_mux > 0 && !strcmp(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr, v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)
+						&& v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_port == v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_port) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping VIDEO RTCP ICE (Same as VIDEO RTP)\n");
+					} else {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating VIDEO RTCP ICE\n");
+						switch_rtp_activate_ice(v_engine->rtp_session,
+												v_engine->ice_in.ufrag,
+												v_engine->ice_out.ufrag,
+												v_engine->ice_out.pwd,
+												v_engine->ice_in.pwd,
+												IPR_RTCP,
+#ifdef GOOGLE_ICE
+												ICE_GOOGLE_JINGLE,
+												NULL
+#else
+												switch_determine_ice_type(v_engine, session),
+												&v_engine->ice_in
+#endif
+												);
 					}
 				}
 
@@ -12464,7 +12502,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					dtls_type_t xtype,
 						dtype = v_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
 					xtype = DTLS_TYPE_RTP;
-					if (v_engine->rtcp_mux > 0 && smh->mparams->rtcp_video_interval_msec) xtype |= DTLS_TYPE_RTCP;
+					if (v_engine->rtcp_mux > 0 && (smh->mparams->rtcp_video_interval_msec ||
+						switch_rtp_test_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) xtype |= DTLS_TYPE_RTCP;
 			
 
 					if (switch_channel_var_true(session->channel, "legacyDTLS")) {
@@ -12474,7 +12513,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 					switch_rtp_add_dtls(v_engine->rtp_session, &v_engine->local_dtls_fingerprint, &v_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 
-					if (v_engine->rtcp_mux < 1 && smh->mparams->rtcp_video_interval_msec) {
+					if (v_engine->rtcp_mux < 1 && (smh->mparams->rtcp_video_interval_msec ||
+						switch_rtp_test_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) {
 						xtype = DTLS_TYPE_RTCP;
 						switch_rtp_add_dtls(v_engine->rtp_session, &v_engine->local_dtls_fingerprint, &v_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 					}

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11739,7 +11739,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				}
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
 								  "Activating RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
-				switch_rtp_activate_rtcp(a_engine->rtp_session, 0, rtcp_port, a_engine->rtcp_mux > 0);
+				if (switch_rtp_activate_rtcp(a_engine->rtp_session, 0, rtcp_port, a_engine->rtcp_mux > 0) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+									  "Failed to activate RTCP socket for ICE, skipping RTCP ICE\n");
+					goto skip_audio_rtcp_ice;
+				}
 			}
 
 			if (a_engine->rtcp_mux > 0 &&
@@ -11765,6 +11769,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 									);
 			}
 		}
+
+		skip_audio_rtcp_ice:
 
 		if (!zstr(a_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
 			dtls_type_t xtype, dtype = a_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
@@ -12122,7 +12128,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 						}
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
 										  "Activating TEXT RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
-						switch_rtp_activate_rtcp(t_engine->rtp_session, 0, rtcp_port, t_engine->rtcp_mux > 0);
+						if (switch_rtp_activate_rtcp(t_engine->rtp_session, 0, rtcp_port, t_engine->rtcp_mux > 0) != SWITCH_STATUS_SUCCESS) {
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+										  "Failed to activate TEXT RTCP socket for ICE, skipping TEXT RTCP ICE\n");
+							goto skip_text_rtcp_ice;
+						}
 					}
 
 					if (t_engine->rtcp_mux > 0 && !strcmp(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr,
@@ -12147,6 +12157,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 												);
 					}
 				}
+
+				skip_text_rtcp_ice:
 
 				if (!zstr(t_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
 					dtls_type_t xtype,
@@ -12473,7 +12485,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 						}
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
 										  "Activating VIDEO RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
-						switch_rtp_activate_rtcp(v_engine->rtp_session, 0, rtcp_port, v_engine->rtcp_mux > 0);
+						if (switch_rtp_activate_rtcp(v_engine->rtp_session, 0, rtcp_port, v_engine->rtcp_mux > 0) != SWITCH_STATUS_SUCCESS) {
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+										  "Failed to activate VIDEO RTCP socket for ICE, skipping VIDEO RTCP ICE\n");
+							goto skip_video_rtcp_ice;
+						}
 					}
 
 					if (v_engine->rtcp_mux > 0 && !strcmp(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr, v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)
@@ -12497,6 +12513,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 												);
 					}
 				}
+
+				skip_video_rtcp_ice:
 
 				if (!zstr(v_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
 					dtls_type_t xtype,

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -2624,7 +2624,8 @@ static int check_rtcp_and_ice(switch_rtp_t *rtp_session)
 
 	//switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "WTF %d %d %d %d\n", rate, rtp_session->rtcp_sent_packets, rtcp_ok, nack_ttl);
 
-	if (rtp_session->rtcp_sock_output && rtp_session->flags[SWITCH_RTP_FLAG_ENABLE_RTCP] && !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_PASSTHRU] && rtcp_ok) {
+	/* Skip RTCP report sending when rtcp_interval is 0 (ICE-only activation) */
+	if (rtp_session->rtcp_sock_output && rtp_session->flags[SWITCH_RTP_FLAG_ENABLE_RTCP] && !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_PASSTHRU] && rtp_session->rtcp_interval && rtcp_ok) {
 		switch_rtcp_numbers_t * stats = &rtp_session->stats.rtcp;
 		struct switch_rtcp_receiver_report *rr;
 		struct switch_rtcp_sender_report *sr;


### PR DESCRIPTION
## Summary

Decouple RTCP ICE activation from the `rtcp_audio/video/text_interval_msec` channel variable. The interval variable now only controls RTCP report send rate — ICE connectivity checks on the RTCP socket (component-2) are activated independently when ICE is in use.

## Problem

FreeSWITCH advertises component-2 ICE candidates in the SDP but gates RTCP ICE activation behind `rtcp_*_interval_msec`. When that variable is not set, STUN Binding Requests on the RTCP port are silently dropped — breaking strict ICE implementations (e.g. Cisco Webex/BroadWorks) that perform connectivity checks on all advertised components per RFC 8445.

## Changes

- **switch_core_media.c**: Move RTCP ICE activation blocks (audio, text, video) outside the `rtcp_*_interval_msec` gate. Add fallback: when RTCP context was not initialized by the interval path, activate with `send_rate=0` to set up the socket for ICE only. Update DTLS blocks to include RTCP type when RTCP was activated for ICE.
- **switch_rtp.c**: Guard RTCP report sending on `rtcp_interval > 0` in `check_rtcp_and_ice()` to prevent report flooding when activated for ICE only.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `rtcp_*_interval_msec` set + ICE | RTCP reports + ICE ✅ | Same ✅ |
| `rtcp_*_interval_msec` not set + ICE | No RTCP, no ICE on RTCP port ❌ | No reports, but RTCP ICE works ✅ |
| `rtcp_*_interval_msec` not set, no ICE | No change | No change |
| `rtcp-mux` active | RTCP ICE skipped (same as RTP) | Same |

## Linear

https://linear.app/telnyx/issue/TELCORE-141