### PR TITLE
Merge telnyx/telephony/deploy-development into telnyx/telephony/master

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -511,7 +511,6 @@ SWITCH_DECLARE(int) switch_core_media_trickle_accept(switch_core_session_t *sess
 
 SWITCH_DECLARE(switch_bool_t) switch_rtp_trickle_is_registered(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_trickle_emit_local_candidate(switch_rtp_t *rtp_session, const switch_rtp_ice_cand_t *cand, const char *mid, int mline_index, int end_of_candidates);
-SWITCH_DECLARE(void) switch_rtp_set_ice_role(switch_rtp_t *rtp_session, switch_bool_t controlling);
 SWITCH_DECLARE(void) switch_rtp_dtls_init_once(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_status_t) switch_rtp_extmap_register(switch_rtp_t *rtp_session, uint8_t id, const char *uri);
 SWITCH_DECLARE(void) switch_rtp_mark_ice_connectivity_failed(switch_rtp_t *rtp_session, const char *reason);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4994,7 +4994,10 @@ static switch_call_direction_t switch_ice_direction(switch_rtp_engine_t *engine,
 		r = (r == SWITCH_CALL_DIRECTION_INBOUND) ? SWITCH_CALL_DIRECTION_OUTBOUND : SWITCH_CALL_DIRECTION_INBOUND;
 	}
 
-	if (switch_rtp_has_dtls() && dtls_ok(smh->session)) {
+	/* Gate DTLS controller-role on CF_DTLS (set when a=fingerprint is parsed);
+	 * CF_DTLS_OK alone is always-on and misleading for non-DTLS sessions. */
+	if (switch_rtp_has_dtls() && dtls_ok(smh->session)
+	    && switch_channel_test_flag(session->channel, CF_DTLS)) {
 		if (switch_channel_test_flag(session->channel, CF_OBSERVE_INITIATOR)) {
 			r = engine->ice_remote_initiator ? SWITCH_CALL_DIRECTION_INBOUND : SWITCH_CALL_DIRECTION_OUTBOUND;
 		} else {
@@ -5012,6 +5015,7 @@ static switch_call_direction_t switch_ice_direction(switch_rtp_engine_t *engine,
 
 static switch_core_media_ice_type_t switch_determine_ice_type(switch_rtp_engine_t *engine, switch_core_session_t *session) {
 	switch_core_media_ice_type_t ice_type = ICE_VANILLA;
+	const char *role_override = NULL;
 
 	if (switch_channel_var_true(session->channel, "ice_lite")) {
 		ice_type |= ICE_CONTROLLED;
@@ -5023,6 +5027,25 @@ static switch_core_media_ice_type_t switch_determine_ice_type(switch_rtp_engine_
 		if (direction == SWITCH_CALL_DIRECTION_INBOUND) {
 			ice_type |= ICE_CONTROLLED;
 		}
+	}
+
+	/* Dialplan override (rtp_ice_role=controlling|controlled). Skipped for ICE-lite
+	 * peers: a lite peer cannot run checks or nominate, FS must stay controlling. */
+	role_override = switch_channel_get_variable(session->channel, "rtp_ice_role");
+	if (!zstr(role_override) && !(ice_type & (ICE_LITE | ICE_LITE_INBOUND))) {
+		if (!strcasecmp(role_override, "controlled")) {
+			ice_type |= ICE_CONTROLLED;
+		} else if (!strcasecmp(role_override, "controlling")) {
+			ice_type &= ~ICE_CONTROLLED;
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+			                  "Ignoring invalid rtp_ice_role=%s (expected 'controlling' or 'controlled')\n",
+			                  role_override);
+		}
+	} else if (!zstr(role_override)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+		                  "Ignoring rtp_ice_role=%s: ICE-lite forces FS to remain controlling\n",
+		                  role_override);
 	}
 
 	return ice_type;
@@ -11132,16 +11155,6 @@ static void gen_ice(switch_core_session_t *session, switch_media_type_t type, co
 	engine->ice_out.cands[0][0].generation = "0";
 
 	engine->ice_out.cands[0][0].ready = 1;
-
-	/* Dynamic ICE role: offerer is controlling unless remote is ice-lite; allow override via var "rtp_ice_role" */
-	{
-		const char *role_override = switch_channel_get_variable(session->channel, "rtp_ice_role");
-		switch_bool_t controlling = SWITCH_TRUE;
-		if (role_override) {
-			controlling = !strcasecmp(role_override, "controlling") ? SWITCH_TRUE : SWITCH_FALSE;
-		}
-		switch_rtp_set_ice_role(engine->rtp_session, controlling);
-	}
 
 	if (engine->rtp_session && switch_core_media_trickle_enabled(session) && switch_rtp_trickle_is_registered(engine->rtp_session)) {
 		switch_rtp_ice_cand_t cand;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11721,34 +11721,56 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				}
 			}
 
-			if (a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].ready && a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready &&
-				!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr) && 
-				!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)) {
-				if (a_engine->rtcp_mux > 0 && 
-					!strcmp(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr, a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)
-					&& a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_port == a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_port) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping RTCP ICE (Same as RTP)\n");
-				} else {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating RTCP ICE\n");
+		}
 
-					switch_rtp_activate_ice(a_engine->rtp_session,
-											a_engine->ice_in.ufrag,
-											a_engine->ice_out.ufrag,
-											a_engine->ice_out.pwd,
-											a_engine->ice_in.pwd,
-											IPR_RTCP,
-#ifdef GOOGLE_ICE
-											ICE_GOOGLE_JINGLE,
-											NULL
-#else
-											switch_determine_ice_type(a_engine, session),
-											&a_engine->ice_in
-#endif
-										);
+		/* Activate RTCP ICE independently of rtcp_audio_interval_msec.
+		 * Per RFC 8445, ICE requires connectivity checks on all advertised components.
+		 * The interval variable controls RTCP report send rate, not ICE activation. */
+		if (a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].ready && a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready &&
+			!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr) &&
+			!zstr(a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)) {
+
+			/* Ensure RTCP context is initialized for ICE even without rtcp_audio_interval_msec */
+			if (!switch_rtp_test_flag(a_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP)) {
+				switch_port_t rtcp_port = a_engine->remote_rtcp_port;
+				if (!rtcp_port) {
+					const char *rp = switch_channel_get_variable(session->channel, "rtp_remote_audio_rtcp_port");
+					if (rp) rtcp_port = (switch_port_t)atoi(rp);
 				}
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+								  "Activating RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
+				if (switch_rtp_activate_rtcp(a_engine->rtp_session, 0, rtcp_port, a_engine->rtcp_mux > 0) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+									  "Failed to activate RTCP socket for ICE, skipping RTCP ICE\n");
+					goto skip_audio_rtcp_ice;
+				}
+			}
 
+			if (a_engine->rtcp_mux > 0 &&
+				!strcmp(a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_addr, a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_addr)
+				&& a_engine->ice_in.cands[a_engine->ice_in.chosen[1]][1].con_port == a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].con_port) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping RTCP ICE (Same as RTP)\n");
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating RTCP ICE\n");
+
+				switch_rtp_activate_ice(a_engine->rtp_session,
+										a_engine->ice_in.ufrag,
+										a_engine->ice_out.ufrag,
+										a_engine->ice_out.pwd,
+										a_engine->ice_in.pwd,
+										IPR_RTCP,
+#ifdef GOOGLE_ICE
+										ICE_GOOGLE_JINGLE,
+										NULL
+#else
+										switch_determine_ice_type(a_engine, session),
+										&a_engine->ice_in
+#endif
+									);
 			}
 		}
+
+		skip_audio_rtcp_ice:
 
 		if (!zstr(a_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
 			dtls_type_t xtype, dtype = a_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
@@ -11758,7 +11780,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 			//}
 
 			xtype = DTLS_TYPE_RTP;
-			if (a_engine->rtcp_mux > 0 && smh->mparams->rtcp_audio_interval_msec) xtype |= DTLS_TYPE_RTCP;
+			if (a_engine->rtcp_mux > 0 && (smh->mparams->rtcp_audio_interval_msec ||
+				switch_rtp_test_flag(a_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) xtype |= DTLS_TYPE_RTCP;
 
 			if (switch_channel_var_true(session->channel, "legacyDTLS")) {
 				switch_channel_clear_flag(session->channel, CF_WANT_DTLSv1_2);
@@ -11767,7 +11790,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 			switch_rtp_add_dtls(a_engine->rtp_session, &a_engine->local_dtls_fingerprint, &a_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 
-			if (a_engine->rtcp_mux < 1 && smh->mparams->rtcp_audio_interval_msec) {
+			if (a_engine->rtcp_mux < 1 && (smh->mparams->rtcp_audio_interval_msec ||
+				switch_rtp_test_flag(a_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) {
 				xtype = DTLS_TYPE_RTCP;
 				switch_rtp_add_dtls(a_engine->rtp_session, &a_engine->local_dtls_fingerprint, &a_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 			}
@@ -12089,42 +12113,59 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					}
 
 
-					if (t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].ready && t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].ready &&
-						!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr) && 
-						!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr)) {
-						if (t_engine->rtcp_mux > 0 && !strcmp(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr,
-															  t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr) &&
-							t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_port == t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_port) {
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping TEXT RTCP ICE (Same as TEXT RTP)\n");
-						} else {
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating TEXT RTCP ICE\n");
-							switch_rtp_activate_ice(t_engine->rtp_session,
-													t_engine->ice_in.ufrag,
-													t_engine->ice_out.ufrag,
-													t_engine->ice_out.pwd,
-													t_engine->ice_in.pwd,
-													IPR_RTCP,
-#ifdef GOOGLE_ICE
-													ICE_GOOGLE_JINGLE,
-													NULL
-#else
-													switch_determine_ice_type(t_engine, session),
-													&t_engine->ice_in
-#endif
-													);
+				}
 
+				/* Activate TEXT RTCP ICE independently of rtcp_text_interval_msec */
+				if (t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].ready && t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].ready &&
+					!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr) &&
+					!zstr(t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr)) {
 
-
+					if (!switch_rtp_test_flag(t_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP)) {
+						switch_port_t rtcp_port = t_engine->remote_rtcp_port;
+						if (!rtcp_port) {
+							const char *rp = switch_channel_get_variable(session->channel, "rtp_remote_text_rtcp_port");
+							if (rp) rtcp_port = (switch_port_t)atoi(rp);
 						}
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+										  "Activating TEXT RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
+						if (switch_rtp_activate_rtcp(t_engine->rtp_session, 0, rtcp_port, t_engine->rtcp_mux > 0) != SWITCH_STATUS_SUCCESS) {
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+										  "Failed to activate TEXT RTCP socket for ICE, skipping TEXT RTCP ICE\n");
+							goto skip_text_rtcp_ice;
+						}
+					}
 
+					if (t_engine->rtcp_mux > 0 && !strcmp(t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_addr,
+														  t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_addr) &&
+						t_engine->ice_in.cands[t_engine->ice_in.chosen[1]][1].con_port == t_engine->ice_in.cands[t_engine->ice_in.chosen[0]][0].con_port) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping TEXT RTCP ICE (Same as TEXT RTP)\n");
+					} else {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating TEXT RTCP ICE\n");
+						switch_rtp_activate_ice(t_engine->rtp_session,
+												t_engine->ice_in.ufrag,
+												t_engine->ice_out.ufrag,
+												t_engine->ice_out.pwd,
+												t_engine->ice_in.pwd,
+												IPR_RTCP,
+#ifdef GOOGLE_ICE
+												ICE_GOOGLE_JINGLE,
+												NULL
+#else
+												switch_determine_ice_type(t_engine, session),
+												&t_engine->ice_in
+#endif
+												);
 					}
 				}
+
+				skip_text_rtcp_ice:
 
 				if (!zstr(t_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
 					dtls_type_t xtype,
 						dtype = t_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
 					xtype = DTLS_TYPE_RTP;
-					if (t_engine->rtcp_mux > 0 && smh->mparams->rtcp_text_interval_msec) xtype |= DTLS_TYPE_RTCP;
+					if (t_engine->rtcp_mux > 0 && (smh->mparams->rtcp_text_interval_msec ||
+						switch_rtp_test_flag(t_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) xtype |= DTLS_TYPE_RTCP;
 			
 					if (switch_channel_var_true(session->channel, "legacyDTLS")) {
 						switch_channel_clear_flag(session->channel, CF_WANT_DTLSv1_2);
@@ -12133,7 +12174,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 					switch_rtp_add_dtls(t_engine->rtp_session, &t_engine->local_dtls_fingerprint, &t_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 
-					if (t_engine->rtcp_mux < 1 && smh->mparams->rtcp_text_interval_msec) {
+					if (t_engine->rtcp_mux < 1 && (smh->mparams->rtcp_text_interval_msec ||
+						switch_rtp_test_flag(t_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) {
 						xtype = DTLS_TYPE_RTCP;
 						switch_rtp_add_dtls(t_engine->rtp_session, &t_engine->local_dtls_fingerprint, &t_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 					}
@@ -12428,43 +12470,58 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					}
 
 
-					if (v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].ready && v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].ready &&
-						!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr) && 
-						!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)) {
+				}
 
-						if (v_engine->rtcp_mux > 0 && !strcmp(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr, v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)
-							&& v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_port == v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_port) {
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping VIDEO RTCP ICE (Same as VIDEO RTP)\n");
-						} else {
+				/* Activate VIDEO RTCP ICE independently of rtcp_video_interval_msec */
+				if (v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].ready && v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].ready &&
+					!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr) &&
+					!zstr(v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)) {
 
-							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating VIDEO RTCP ICE\n");
-							switch_rtp_activate_ice(v_engine->rtp_session,
-													v_engine->ice_in.ufrag,
-													v_engine->ice_out.ufrag,
-													v_engine->ice_out.pwd,
-													v_engine->ice_in.pwd,
-													IPR_RTCP,
-#ifdef GOOGLE_ICE
-													ICE_GOOGLE_JINGLE,
-													NULL
-#else
-													switch_determine_ice_type(v_engine, session),
-													&v_engine->ice_in
-#endif
-													);
-
-
-
+					if (!switch_rtp_test_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP)) {
+						switch_port_t rtcp_port = v_engine->remote_rtcp_port;
+						if (!rtcp_port) {
+							const char *rp = switch_channel_get_variable(session->channel, "rtp_remote_video_rtcp_port");
+							if (rp) rtcp_port = (switch_port_t)atoi(rp);
 						}
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+										  "Activating VIDEO RTCP for ICE (no send interval) PORT %d\n", rtcp_port);
+						if (switch_rtp_activate_rtcp(v_engine->rtp_session, 0, rtcp_port, v_engine->rtcp_mux > 0) != SWITCH_STATUS_SUCCESS) {
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+										  "Failed to activate VIDEO RTCP socket for ICE, skipping VIDEO RTCP ICE\n");
+							goto skip_video_rtcp_ice;
+						}
+					}
 
+					if (v_engine->rtcp_mux > 0 && !strcmp(v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_addr, v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_addr)
+						&& v_engine->ice_in.cands[v_engine->ice_in.chosen[1]][1].con_port == v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].con_port) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Skipping VIDEO RTCP ICE (Same as VIDEO RTP)\n");
+					} else {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating VIDEO RTCP ICE\n");
+						switch_rtp_activate_ice(v_engine->rtp_session,
+												v_engine->ice_in.ufrag,
+												v_engine->ice_out.ufrag,
+												v_engine->ice_out.pwd,
+												v_engine->ice_in.pwd,
+												IPR_RTCP,
+#ifdef GOOGLE_ICE
+												ICE_GOOGLE_JINGLE,
+												NULL
+#else
+												switch_determine_ice_type(v_engine, session),
+												&v_engine->ice_in
+#endif
+												);
 					}
 				}
+
+				skip_video_rtcp_ice:
 
 				if (!zstr(v_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
 					dtls_type_t xtype,
 						dtype = v_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
 					xtype = DTLS_TYPE_RTP;
-					if (v_engine->rtcp_mux > 0 && smh->mparams->rtcp_video_interval_msec) xtype |= DTLS_TYPE_RTCP;
+					if (v_engine->rtcp_mux > 0 && (smh->mparams->rtcp_video_interval_msec ||
+						switch_rtp_test_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) xtype |= DTLS_TYPE_RTCP;
 			
 
 					if (switch_channel_var_true(session->channel, "legacyDTLS")) {
@@ -12474,7 +12531,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 					switch_rtp_add_dtls(v_engine->rtp_session, &v_engine->local_dtls_fingerprint, &v_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 
-					if (v_engine->rtcp_mux < 1 && smh->mparams->rtcp_video_interval_msec) {
+					if (v_engine->rtcp_mux < 1 && (smh->mparams->rtcp_video_interval_msec ||
+						switch_rtp_test_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP))) {
 						xtype = DTLS_TYPE_RTCP;
 						switch_rtp_add_dtls(v_engine->rtp_session, &v_engine->local_dtls_fingerprint, &v_engine->remote_dtls_fingerprint, dtype | xtype, want_DTLSv1_2);
 					}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -2624,7 +2624,8 @@ static int check_rtcp_and_ice(switch_rtp_t *rtp_session)
 
 	//switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "WTF %d %d %d %d\n", rate, rtp_session->rtcp_sent_packets, rtcp_ok, nack_ttl);
 
-	if (rtp_session->rtcp_sock_output && rtp_session->flags[SWITCH_RTP_FLAG_ENABLE_RTCP] && !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_PASSTHRU] && rtcp_ok) {
+	/* Skip RTCP report sending when rtcp_interval is 0 (ICE-only activation) */
+	if (rtp_session->rtcp_sock_output && rtp_session->flags[SWITCH_RTP_FLAG_ENABLE_RTCP] && !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_PASSTHRU] && rtp_session->rtcp_interval && rtcp_ok) {
 		switch_rtcp_numbers_t * stats = &rtp_session->stats.rtcp;
 		struct switch_rtcp_receiver_report *rr;
 		struct switch_rtcp_sender_report *sr;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -11652,21 +11652,6 @@ SWITCH_DECLARE(void) switch_rtp_trickle_emit_local_candidate(switch_rtp_t *rtp_s
 	}
 }
 
-SWITCH_DECLARE(void) switch_rtp_set_ice_role(switch_rtp_t *rtp_session, switch_bool_t controlling)
-{
-#ifdef SWITCH_HAVE_ICE
-	if (!rtp_session || !rtp_session->ice.ice_params) return;
-	rtp_session->ice.ice_params->controlling = controlling ? 1 : 0;
-	if (!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && rtp_session->rtcp_ice.ice_params) {
-		rtp_session->rtcp_ice.ice_params->controlling = controlling ? 1 : 0;
-	}
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
-	                  "ICE role set to %s\n", controlling ? "controlling" : "controlled");
-#else
-	(void)rtp_session; (void)controlling;
-#endif
-}
-
 SWITCH_DECLARE(switch_status_t) switch_rtp_extmap_register(switch_rtp_t *rtp_session, uint8_t id, const char *uri)
 {
 #ifdef SWITCH_HAVE_RTP

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -752,22 +752,47 @@ static void trickle_eoc_cleanup(const void *rtp)
 	}
 }
 
+static switch_bool_t ice_candidate_matches_addr(const icand_t *cand, const char *host, switch_port_t port)
+{
+	return cand && cand->con_addr && host && !strcmp(cand->con_addr, host) && cand->con_port == port;
+}
+
+static switch_bool_t ice_candidate_matches_host(const icand_t *cand, const char *host)
+{
+	return cand && cand->con_addr && host && !strcmp(cand->con_addr, host);
+}
+
+static switch_bool_t ice_candidate_is_relay(const icand_t *cand)
+{
+	return cand && cand->cand_type && !strcasecmp(cand->cand_type, "relay");
+}
+
+static const char *ice_candidate_addr_safe(const icand_t *cand)
+{
+	return (cand && cand->con_addr) ? cand->con_addr : "(null)";
+}
+
+static const char *ice_candidate_type_safe(const icand_t *cand)
+{
+	return (cand && cand->cand_type) ? cand->cand_type : "(unknown)";
+}
+
 static void switch_rtp_change_ice_dest(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, const char *host, switch_port_t port)
 {
 	int is_rtcp = ice == &rtp_session->rtcp_ice;
 	const char *err = "";
 	int i;
-	uint8_t ice_cand_found_idx = 0;
+	int ice_cand_found_idx = -1;
 
 	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
-		if (!strcmp(host, ice->ice_params->cands[i][ice->proto].con_addr) && port == ice->ice_params->cands[i][ice->proto].con_port) {
+		if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], host, port)) {
 			ice_cand_found_idx = i;
 		}
 	}
 
-	if (!ice_cand_found_idx) {
+	if (ice_cand_found_idx < 0) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE candidate [%s:%d] replaced with [%s:%d]\n",
-			ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, host, port);
+			ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, host, port);
 		ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr = switch_core_strdup(rtp_session->pool, host);
 		ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port = port;
 	} else {
@@ -1250,7 +1275,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			{
 				ice->rready = 1;
 				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
-					if (!strcmp(ice->ice_params->cands[i][ice->proto].con_addr, from_host) && ice->ice_params->cands[i][ice->proto].con_port == from_port) {
+					if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
 						ice->ice_params->cands[i][ice->proto].use_candidate = 1;
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG6, "Got USE-CANDIDATE on %s cand %s:%d\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port);
 					}
@@ -1374,11 +1399,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 			if (ice->ice_params) {
 				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
-					if (!strcmp(ice->ice_params->cands[i][ice->proto].con_addr, from_host) && ice->ice_params->cands[i][ice->proto].con_port == from_port) {
+					if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
 						int is_relay = 0;
 
 						ice->ice_params->cands[i][ice->proto].responsive = 1;
-						if (!strcasecmp(ice->ice_params->cands[i][ice->proto].cand_type, "relay")) {
+						if (ice_candidate_is_relay(&ice->ice_params->cands[i][ice->proto])) {
 							is_relay = 1;
 						}
 
@@ -1413,7 +1438,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 							ice->last_ok = switch_micro_time_now();
 						}
 
-						if (!strcmp(ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, from_host) && ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port == from_port) {
+						if (ice_candidate_matches_addr(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto], from_host, from_port)) {
 							ice->cand_responsive = 1;
 							ice->initializing = 0;
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Chosen %s ICE candidate %s:%d is responsive (is_relay: %d)\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port, is_relay);
@@ -1586,8 +1611,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			cmp = switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE);
 
 			for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
-				if (!strcmp(ice->ice_params->cands[i][ice->proto].con_addr, from_host) && ice->ice_params->cands[i][ice->proto].con_port == from_port) {
-					if (!strcasecmp(ice->ice_params->cands[i][ice->proto].cand_type, "relay")) {
+				if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
+					if (ice_candidate_is_relay(&ice->ice_params->cands[i][ice->proto])) {
 						is_relay = 1;
 					}
 
@@ -1608,7 +1633,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				if (!rtp_session->adj_window && (!ice->ready || !ice->rready || (!rtp_session->dtls || rtp_session->dtls->state != DS_READY))) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE set ADJUST window to 10 seconds on binding request from %s:%d (is_relay: %d, is_responsivie: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 									switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
-									ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+									ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 					rtp_session->adj_window = now + 10000000;
 				}
@@ -1617,12 +1642,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					if (rtp_session->adj_window > now) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE check: %d >= 3000 or window closed and not from relay on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 										switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", rtp_session->elapsed_stun, from_host, from_port, is_relay, is_responsive, use_candidate,
-										ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+										ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 						if (!is_relay && (rtp_session->elapsed_stun >= 3000 || rtp_session->adj_window == (now + 10000000))) {
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST HIT 1 on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 											switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
-											ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+											ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 							do_adj++;
 							rtp_session->last_adj = now;
@@ -1634,7 +1659,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE CHECK SAME IP DIFFT PORT %d %d on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 								switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp",ice->initializing, switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE), from_host, from_port, is_relay, is_responsive, use_candidate,
-								ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+								ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 				if (!do_adj && (switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE) || (use_candidate && !is_relay))) {
 					do_adj++;
@@ -1642,7 +1667,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST HIT 2 on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 									switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
-									ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+									ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 				}
 			}
 
@@ -1653,20 +1678,20 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST ELAPSED vs 1000 %d on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 								switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp" ,rtp_session->elapsed_adj, from_host, from_port, is_relay, is_responsive, use_candidate,
-								ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+								ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 				if (rtp_session->elapsed_adj > 1000) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE IF DTLS NOT READY or %d >= 3000 or media too long %d or stun too long %d on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 									switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", rtp_session->elapsed_stun, rtp_session->elapsed_media >= MEDIA_TOO_LONG,
 									rtp_session->elapsed_stun >= STUN_TOO_LONG, from_host, from_port, is_relay, is_responsive, use_candidate,
-									ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+									ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 					if (!is_relay && ((rtp_session->dtls && rtp_session->dtls->state != DS_READY) ||
 						((!ice->ready || !ice->rready) && (rtp_session->elapsed_stun >= 3000 || switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE))))) {
 
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST HIT 3 on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 										switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
-										ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+										ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 						do_adj++;
 						rtp_session->last_adj = now;
@@ -1674,7 +1699,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST HIT 4 (FLIP TO TURN) on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 										switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
-										ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+										ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 						do_adj++;
 						rtp_session->last_adj = now;
@@ -1683,14 +1708,14 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST HIT 5 on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 										switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
-										ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type);
+										ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 						do_adj++;
 						rtp_session->last_adj = now;
 					}
 
 					for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
-						if (!strcmp(ice->ice_params->cands[i][ice->proto].con_addr, from_host)) {
+						if (ice_candidate_matches_host(&ice->ice_params->cands[i][ice->proto], from_host)) {
 							cur_idx = i;
 						}
 					}

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -143,6 +143,13 @@ FST_TEARDOWN_END()
 			ice.pass = "pass";
 			ice.type = ICE_VANILLA;
 			ice.addr = switch_rtp_session_get_remote_addr(rtp_session);
+			ice.proto = 0;
+			ice.ice_params->chosen[ice.proto] = 0;
+			ice.ice_params->cand_idx[ice.proto] = 1;
+			ice.ice_params->cands[0][ice.proto].con_addr = (char *) tx_host;
+			ice.ice_params->cands[0][ice.proto].con_port = tx_port;
+			ice.ice_params->cands[0][ice.proto].priority = 197684917;
+			ice.ice_params->cands[0][ice.proto].cand_type = NULL;
 
 			memcpy(ice.last_sent_id, id, 12);
 


### PR DESCRIPTION
Sync `telnyx/telephony/deploy-development` → `telnyx/telephony/master` for v103.2 build.

Brings:
- TELCORE-139 — fix NULL deref in switch_rtp_pvt_handle_ice ICE candidate compares (#592) — `6b595f9`

Part of b2bua-rtc v102.2/v103.2 deployment (control room <https://telnyx.slack.com/archives/C0B44ESAFDF>).