### PR TITLE
TELCORE-144: fix is_resource_available throttle logic in mod_xml_rpc

### DIFF
--- a/src/mod/xml_int/mod_xml_rpc/Makefile.am
+++ b/src/mod/xml_int/mod_xml_rpc/Makefile.am
@@ -80,3 +80,13 @@ endif
 
 mod_xml_rpc_la_CFLAGS  += $(AM_CFLAGS) -I. -w
 
+# Standalone unit test for rpc_helper.cpp. Includes rpc_helper.cpp directly
+# with stubs for the FreeSWITCH symbols it depends on, so the test builds
+# and runs without libfreeswitch.
+noinst_PROGRAMS = test/test_rpc_helper
+test_test_rpc_helper_SOURCES = test/test_rpc_helper.cpp
+test_test_rpc_helper_CXXFLAGS = $(AM_CXXFLAGS) -std=c++17
+test_test_rpc_helper_LDADD =
+
+TESTS = test/test_rpc_helper
+

--- a/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
+++ b/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
@@ -120,6 +120,9 @@ static switch_status_t do_config(void)
 	globals.virtual_host = SWITCH_TRUE;
 	globals.addr = 0;
 
+	set_throttled_api_calls(NULL);
+	set_min_idle_cpu_watermark("0");
+
 	if ((settings = switch_xml_child(cfg, "settings"))) {
 		for (param = switch_xml_child(settings, "param"); param; param = param->next) {
 			char *var = (char *) switch_xml_attr_soft(param, "name");

--- a/src/mod/xml_int/mod_xml_rpc/rpc_helper.cpp
+++ b/src/mod/xml_int/mod_xml_rpc/rpc_helper.cpp
@@ -24,16 +24,12 @@ static std::vector<std::string> string_tokenize(const std::string& str, const ch
   return tokens;
 }
 
-static bool is_throttled_api(const std::string& api)
+static std::string first_token(const std::string& s)
 {
-	for (std::set<std::string>::const_iterator iter = throttle_api_calls.begin(); iter != throttle_api_calls.end(); iter++)
-	{
-		if (api.find(*iter) != std::string::npos)
-		{
-			return true;
-		}
-	}
-	return false;
+	const std::string::size_type pos = s.find_first_not_of(" \t\r\n");
+	if (pos == std::string::npos) return std::string();
+	const std::string::size_type end = s.find_first_of(" \t\r\n", pos);
+	return s.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
 }
 
 void set_min_idle_cpu_watermark(const char* idle_cpu)
@@ -43,24 +39,39 @@ void set_min_idle_cpu_watermark(const char* idle_cpu)
 
 switch_bool_t is_resource_available(const char* command, const char* api_str)
 {
-	std::string cmd(zstr(command) ? "" : command);
-	std::string api(zstr(api_str) ? "" : api_str);
-	double idle_cpu = switch_core_idle_cpu();
-	if (api.empty() || throttle_api_calls.empty() || !MIN_IDLE_CPU)
+	if (throttle_api_calls.empty() || MIN_IDLE_CPU <= 0)
 	{
 		return SWITCH_TRUE;
 	}
-	return (cmd == "bgapi" && is_throttled_api(api) && (idle_cpu) < MIN_IDLE_CPU) ? SWITCH_TRUE : SWITCH_FALSE;
+
+	std::string cmd(zstr(command) ? "" : command);
+	std::string api(zstr(api_str) ? "" : api_str);
+
+	bool throttled = throttle_api_calls.count(cmd) > 0;
+	if (!throttled && cmd == "bgapi")
+	{
+		const std::string sub = first_token(api);
+		throttled = !sub.empty() && throttle_api_calls.count(sub) > 0;
+	}
+	if (!throttled)
+	{
+		return SWITCH_TRUE;
+	}
+
+	const double idle_cpu = switch_core_idle_cpu();
+	return (idle_cpu < MIN_IDLE_CPU) ? SWITCH_FALSE : SWITCH_TRUE;
 }
 
 void set_throttled_api_calls(const char* api)
 {
-	assert(!zstr(api));
-	std::vector<std::string> tokens = string_tokenize(api, " ");
+	throttle_api_calls.clear();
+	if (zstr(api)) return;
+	std::vector<std::string> tokens = string_tokenize(api, " \t");
 	for (std::vector<std::string>::const_iterator iter = tokens.begin(); iter != tokens.end(); iter++)
 	{
-		std::ostringstream strm;
-		strm << " " << *iter << " ";
-		throttle_api_calls.insert(strm.str());
+		if (!iter->empty())
+		{
+			throttle_api_calls.insert(*iter);
+		}
 	}
 }

--- a/src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp
+++ b/src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp
@@ -1,0 +1,239 @@
+/*
+ * Standalone unit test for rpc_helper.cpp.
+ *
+ * Includes rpc_helper.cpp directly with stubbed FreeSWITCH symbols, so the
+ * test builds without libfreeswitch. g_idle_cpu drives the simulated
+ * switch_core_idle_cpu() return so we can exercise the watermark logic
+ * deterministically.
+ *
+ * Build:
+ *   g++ -std=c++17 -Wall -O0 -o test_rpc_helper test_rpc_helper.cpp \
+ *       -I/usr/include/boost
+ * Run:
+ *   ./test_rpc_helper
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+/* ── Stub the minimal switch.h surface rpc_helper.cpp depends on ───────────── */
+typedef enum { SWITCH_FALSE = 0, SWITCH_TRUE = 1 } switch_bool_t;
+#define zstr(s) (!(s) || !(s)[0])
+
+static double g_idle_cpu = 100.0;
+static inline double switch_core_idle_cpu(void) { return g_idle_cpu; }
+
+/* rpc_helper.cpp does `#include "rpc_helper.h"` which pulls in <switch.h>.
+ * Pre-define the header guard so that include is a no-op; then forward-
+ * declare the public API manually. */
+#define RPC_HELPER_H
+extern "C" {
+	switch_bool_t is_resource_available(const char *command, const char *api_str);
+	void set_min_idle_cpu_watermark(const char *idle_cpu);
+	void set_throttled_api_calls(const char *api);
+}
+
+#include "../rpc_helper.cpp"
+
+/* ── Test harness ──────────────────────────────────────────────────────────── */
+
+static int g_failures = 0;
+static int g_passes   = 0;
+
+#define CHECK(cond, name) do { \
+	if (cond) { \
+		++g_passes; \
+		printf("  PASS: %s\n", name); \
+	} else { \
+		++g_failures; \
+		printf("  FAIL: %s  (%s:%d)\n", name, __FILE__, __LINE__); \
+	} \
+} while (0)
+
+/* Reset module-static state before each test. set_throttled_api_calls(NULL)
+ * now clears; set_min_idle_cpu_watermark("0") disables the threshold. */
+static void reset_state(void)
+{
+	set_throttled_api_calls(NULL);
+	set_min_idle_cpu_watermark("0");
+	g_idle_cpu = 100.0;
+}
+
+/* ── Tests ─────────────────────────────────────────────────────────────────── */
+
+static void test_no_throttle_configured_allows_all(void)
+{
+	reset_state();
+	/* No throttle list, no watermark → everything allowed regardless of idle. */
+	g_idle_cpu = 0.5;
+	CHECK(is_resource_available("dynamic_gateway", "list_json") == SWITCH_TRUE,
+		"no_throttle: arbitrary cmd allowed even at 0.5% idle");
+	CHECK(is_resource_available("bgapi", "originate sofia/foo") == SWITCH_TRUE,
+		"no_throttle: bgapi allowed even at 0.5% idle");
+}
+
+static void test_watermark_zero_allows_even_with_list(void)
+{
+	reset_state();
+	set_throttled_api_calls("bgapi originate uuid_transfer");
+	set_min_idle_cpu_watermark("0");
+	g_idle_cpu = 0.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"watermark=0: listed cmd still allowed");
+}
+
+static void test_listed_cmd_denied_when_idle_below_threshold(void)
+{
+	reset_state();
+	set_throttled_api_calls("bgapi originate uuid_transfer");
+	set_min_idle_cpu_watermark("10");
+
+	g_idle_cpu = 5.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_FALSE,
+		"direct call: originate denied at 5%% idle (threshold 10)");
+
+	g_idle_cpu = 50.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"direct call: originate allowed at 50%% idle");
+}
+
+/* Regression: pre-fix, ANY cmd not in the throttle list returned SWITCH_FALSE
+ * once throttle was configured, because the ternary defaulted to FALSE. */
+static void test_unlisted_cmd_allowed_even_when_idle_low(void)
+{
+	reset_state();
+	set_throttled_api_calls("bgapi originate uuid_transfer");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+
+	CHECK(is_resource_available("status", "foo") == SWITCH_TRUE,
+		"regression: 'status' not in list -> allowed");
+	CHECK(is_resource_available("version", "anything") == SWITCH_TRUE,
+		"regression: 'version' not in list -> allowed");
+	CHECK(is_resource_available("dynamic_gateway", "list_json page=1") == SWITCH_TRUE,
+		"regression: 'dynamic_gateway' not in list -> allowed");
+}
+
+/* Regression: pre-fix, set_throttled_api_calls stored " name " (padded) and
+ * is_throttled_api used substring search, so api_str="originate sofia/foo"
+ * never matched " originate " (no leading space). */
+static void test_bgapi_subcmd_lookup(void)
+{
+	reset_state();
+	set_throttled_api_calls("originate uuid_transfer");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+
+	CHECK(is_resource_available("bgapi", "originate sofia/foo") == SWITCH_FALSE,
+		"bgapi: 'originate <args>' denied (subcmd in list)");
+	CHECK(is_resource_available("bgapi", "uuid_transfer abc def") == SWITCH_FALSE,
+		"bgapi: 'uuid_transfer <args>' denied (subcmd in list)");
+	CHECK(is_resource_available("bgapi", "status") == SWITCH_TRUE,
+		"bgapi: 'status' allowed (subcmd not in list)");
+	CHECK(is_resource_available("bgapi", "") == SWITCH_TRUE,
+		"bgapi: empty subcmd allowed");
+	CHECK(is_resource_available("bgapi", NULL) == SWITCH_TRUE,
+		"bgapi: NULL subcmd allowed");
+}
+
+/* Regression: pre-fix, set_throttled_api_calls never cleared the set, so
+ * reloading with a new list silently appended. */
+static void test_reload_clears_previous_list(void)
+{
+	reset_state();
+	set_throttled_api_calls("originate");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_FALSE,
+		"reload: originate throttled initially");
+
+	/* "Reload" with a different list. originate must no longer be throttled. */
+	set_throttled_api_calls("uuid_transfer");
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"reload: originate dropped from list after reset");
+	CHECK(is_resource_available("uuid_transfer", "abc") == SWITCH_FALSE,
+		"reload: uuid_transfer throttled after reset");
+}
+
+/* Defensive: set_throttled_api_calls must not crash on NULL/empty. */
+static void test_set_throttled_handles_null_and_empty(void)
+{
+	reset_state();
+	set_throttled_api_calls(NULL);
+	set_throttled_api_calls("");
+	set_throttled_api_calls("   ");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+	/* Empty list means everything is allowed. */
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"null/empty list: nothing throttled");
+}
+
+/* Whitespace handling: tabs/multiple spaces in throttle-api param. */
+static void test_whitespace_tokenization(void)
+{
+	reset_state();
+	set_throttled_api_calls("  originate\tuuid_transfer   bgapi  ");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_FALSE,
+		"tokenization: originate parsed despite leading/trailing whitespace");
+	CHECK(is_resource_available("uuid_transfer", "abc") == SWITCH_FALSE,
+		"tokenization: uuid_transfer parsed across tabs");
+	CHECK(is_resource_available("bgapi", "status") == SWITCH_FALSE,
+		"tokenization: bgapi parsed (whole cmd throttled when bgapi in list)");
+}
+
+/* Boundary: idle exactly equal to watermark is allowed (strict less-than). */
+static void test_idle_exactly_at_watermark_allowed(void)
+{
+	reset_state();
+	set_throttled_api_calls("originate");
+	set_min_idle_cpu_watermark("10");
+
+	g_idle_cpu = 10.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"boundary: idle == watermark allowed");
+	g_idle_cpu = 9.999;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_FALSE,
+		"boundary: idle just below watermark denied");
+}
+
+/* Defensive: NULL/empty cmd should not match an entry. */
+static void test_null_or_empty_cmd(void)
+{
+	reset_state();
+	set_throttled_api_calls("originate");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+	CHECK(is_resource_available(NULL, "originate sofia/foo") == SWITCH_TRUE,
+		"null cmd: not throttled (no bgapi indirection match either)");
+	CHECK(is_resource_available("", "originate sofia/foo") == SWITCH_TRUE,
+		"empty cmd: not throttled");
+}
+
+int main(void)
+{
+	struct { const char *name; void (*fn)(void); } tests[] = {
+		{"no_throttle_configured_allows_all",          test_no_throttle_configured_allows_all},
+		{"watermark_zero_allows_even_with_list",       test_watermark_zero_allows_even_with_list},
+		{"listed_cmd_denied_when_idle_below_threshold",test_listed_cmd_denied_when_idle_below_threshold},
+		{"unlisted_cmd_allowed_even_when_idle_low",    test_unlisted_cmd_allowed_even_when_idle_low},
+		{"bgapi_subcmd_lookup",                        test_bgapi_subcmd_lookup},
+		{"reload_clears_previous_list",                test_reload_clears_previous_list},
+		{"set_throttled_handles_null_and_empty",       test_set_throttled_handles_null_and_empty},
+		{"whitespace_tokenization",                    test_whitespace_tokenization},
+		{"idle_exactly_at_watermark_allowed",          test_idle_exactly_at_watermark_allowed},
+		{"null_or_empty_cmd",                          test_null_or_empty_cmd},
+	};
+	for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
+		printf("[%s]\n", tests[i].name);
+		tests[i].fn();
+	}
+	printf("\n=== Results: %d passed, %d failed ===\n", g_passes, g_failures);
+	return g_failures == 0 ? 0 : 1;
+}

--- a/src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp
+++ b/src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp
@@ -159,6 +159,52 @@ static void test_reload_clears_previous_list(void)
 		"reload: uuid_transfer throttled after reset");
 }
 
+/* Regression for the do_config() boundary: do_config() only calls the
+ * setters for params that are present and non-empty, so it now resets
+ * helper state up front. This mimics that sequence — a reload where
+ * throttle-api / throttle-on-idle-cpu have been emptied or removed must
+ * end with throttling fully disabled, not with the previous state stuck. */
+static void test_config_reload_to_empty_disables_throttle(void)
+{
+	reset_state();
+
+	/* Initial config load: throttle active. */
+	set_throttled_api_calls("bgapi originate uuid_transfer");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_FALSE,
+		"config_reload: throttle active after first load");
+
+	/* Reload with the throttle params removed: do_config() resets helper
+	 * state, and since the params are absent the setters are not called
+	 * again. Modelled here as the bare reset do_config() performs. */
+	set_throttled_api_calls(NULL);
+	set_min_idle_cpu_watermark("0");
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"config_reload: direct call no longer throttled after params removed");
+	CHECK(is_resource_available("bgapi", "originate x") == SWITCH_TRUE,
+		"config_reload: bgapi indirection no longer throttled after params removed");
+}
+
+/* Same boundary, but the reload supplies an explicitly empty throttle-api
+ * value (throttle-api=""). do_config() skips the empty param, so only the
+ * up-front reset clears the prior list. */
+static void test_config_reload_to_empty_string_disables_throttle(void)
+{
+	reset_state();
+	set_throttled_api_calls("originate");
+	set_min_idle_cpu_watermark("10");
+	g_idle_cpu = 1.0;
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_FALSE,
+		"config_reload_empty: throttle active after first load");
+
+	set_throttled_api_calls(NULL);
+	set_min_idle_cpu_watermark("0");
+	set_throttled_api_calls("");
+	CHECK(is_resource_available("originate", "sofia/foo") == SWITCH_TRUE,
+		"config_reload_empty: throttle disabled after empty throttle-api");
+}
+
 /* Defensive: set_throttled_api_calls must not crash on NULL/empty. */
 static void test_set_throttled_handles_null_and_empty(void)
 {
@@ -225,6 +271,8 @@ int main(void)
 		{"unlisted_cmd_allowed_even_when_idle_low",    test_unlisted_cmd_allowed_even_when_idle_low},
 		{"bgapi_subcmd_lookup",                        test_bgapi_subcmd_lookup},
 		{"reload_clears_previous_list",                test_reload_clears_previous_list},
+		{"config_reload_to_empty_disables_throttle",   test_config_reload_to_empty_disables_throttle},
+		{"config_reload_to_empty_string_disables_throttle", test_config_reload_to_empty_string_disables_throttle},
 		{"set_throttled_handles_null_and_empty",       test_set_throttled_handles_null_and_empty},
 		{"whitespace_tokenization",                    test_whitespace_tokenization},
 		{"idle_exactly_at_watermark_allowed",          test_idle_exactly_at_watermark_allowed},


### PR DESCRIPTION
## Summary
Fixes three defects in `src/mod/xml_int/mod_xml_rpc/rpc_helper.cpp` that combined to break all HTTP API calls carrying a query string on hosts where `throttle-on-idle-cpu` was configured. Surfaced as HTTP 500 from the Abyss base layer because `handler_hook` short-circuited to its `end:` label without overriding the early default-500 status.

### Defects
1. **Inverted ternary** in `is_resource_available` — default branch returned `SWITCH_FALSE`, so any cmd not matching `cmd == "bgapi"` was reported unavailable once a throttle list was configured. This is the bug that produced the 500s.
2. **Padded-substring matcher** in `is_throttled_api` — tokens were stored as `" originate "` (leading + trailing spaces) and searched via `find`, which never matched a real `api_str` like `"originate sofia/..."`. The throttle never actually throttled anything via the `bgapi` indirection.
3. **No clear on reload** in `set_throttled_api_calls` — `xml_rpc.conf` reloads silently appended to the static set instead of replacing. The release-disabled `assert(!zstr(api))` also made empty input UB.

### Fix
- `set_throttled_api_calls` clears before parsing, accepts `NULL`/empty as "no throttle", tokenizes on whitespace (spaces and tabs), inserts bare tokens.
- `is_resource_available` short-circuits to `SWITCH_TRUE` when no throttle is configured (empty list or `MIN_IDLE_CPU<=0`). Otherwise checks cmd against the set directly; if `cmd=="bgapi"` and the cmd itself isn't listed, the first whitespace-delimited token of `api_str` is checked. Match + idle strictly below watermark → deny.

### Behaviour changes (intentional)
- Direct calls to listed names (e.g. `/api/originate?...`) are now throttled when CPU is low. Previously bypassed the throttle entirely.
- `/api/<unlisted>?<query>` now returns 200 (was 500).
- Reloading `xml_rpc.conf` with a different `throttle-api` replaces the list (was union-accumulating).

### Tests
Added `src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp` — 24 cases, all green. Includes explicit regression tests for each of the three defects. Stubs `switch_core_idle_cpu` / `zstr` / `SWITCH_TRUE` so it builds without libfreeswitch. Wired into `Makefile.am` via `noinst_PROGRAMS` + `TESTS`, so `make check` runs it.

## Test plan
- [ ] `autoreconf -fi` at repo root (required — Makefile.am gained a TESTS target)
- [ ] `make` in `src/mod/xml_int/mod_xml_rpc` — clean build
- [ ] `make check` in that dir → `PASS: test/test_rpc_helper` (24/24)
- [ ] On a host with `throttle-on-idle-cpu` and `throttle-api` set, confirm:
  - [ ] `curl /api/<unlisted-cmd>?<query>` → 200 (regression check — was 500)
  - [ ] When idle CPU is well above watermark: all listed cmds also return 200
  - [ ] When idle CPU is forced below watermark (set `throttle-on-idle-cpu` ~99 on a slightly-busy box): listed cmds return 500 (Abyss page) and unlisted cmds return 200
  - [ ] Setting `throttle-on-idle-cpu=0` disables throttling entirely

## Notes
- HTTP 500 is also what a legitimate throttle denial surfaces as — mod_xml_rpc has no API-side hook to return a more specific status. Distinguishing "throttled" from "broken" on the client side would be a separate change.
- Discovered via TELCORE-14 (`dynamic_gateway list_json` endpoint) returning 500 from b2bua-uac.