### PR TITLE
TELCORE-137: close leaked sockets in switch_rtp_new + crtp bind retry

### DIFF
--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -397,6 +397,11 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
 												 tech_pvt->read_codec.implementation->samples_per_packet, ptime * 1000,
 												 rtp_flags, "soft", &err, switch_core_session_get_pool(*new_session)))) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't setup RTP session: [%s]\n", err);
+        /* switch_rtp_new already released the port internally on failure.
+         * Clear the cached value so channel_on_destroy (reached via the
+         * fail -> switch_core_session_destroy path below) does not call
+         * switch_rtp_release_port a second time. */
+        tech_pvt->local_port = 0;
         goto fail;
     }
 

--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -253,6 +253,102 @@ void crtp_init(switch_loadable_module_interface_t *mod_interface)
 
 }
 
+/* Create the RTP session for a crtp leg, retrying with a freshly allocated
+ * port on transient bind failures.
+ *
+ * The underlying problem is a timing race rather than real port exhaustion:
+ * when a previous session's pool has not yet been collected, its bound UDP
+ * socket can outlive the release of its port back to the allocator, and
+ * the next caller that picks the same port hits EADDRINUSE. Requesting a
+ * different port and trying again is usually enough to escape the conflict.
+ *
+ * Only retries on bind-specific failures ("Bind Error" / "RTCP Bind Error"
+ * from switch_rtp_set_local_address / enable_local_rtcp_socket) -- other
+ * failures (missing args, socket create errors, etc.) are terminal and
+ * surfaced immediately.
+ *
+ * Port lifecycle: switch_rtp_new always disposes of the port it was given
+ * -- on success the new rtp_session owns it (and switch_rtp_destroy will
+ * release it later); on failure switch_rtp_new calls
+ * switch_rtp_release_port itself before returning NULL. This helper
+ * therefore never needs to release a port on its own NULL-return paths,
+ * and the caller must not release tech_pvt->local_port either (clearing
+ * tech_pvt->local_port to 0 is the right pattern to keep
+ * channel_on_destroy from double-releasing).
+ *
+ * Returns the new rtp_session on success (with tech_pvt->local_port
+ * reflecting the actually-bound port -- it may have been updated mid-way
+ * if a retry was needed). Returns NULL on failure with *err set.
+ *
+ * Retry budget defaults to 3. Override per call via the
+ * "rtp_bind_max_retries" channel variable (0..10).
+ */
+static switch_rtp_t *create_rtp_session_with_bind_retry(crtp_private_t *tech_pvt,
+                                                        switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID],
+                                                        const char **err)
+{
+    switch_channel_t *channel = tech_pvt->channel;
+    switch_rtp_t *rtp_session = NULL;
+    int max_bind_retries = 3;
+    int retry_count = 0;
+    const char *var;
+
+    var = switch_channel_get_variable(channel, "rtp_bind_max_retries");
+    if (!zstr(var) && switch_is_number(var)) {
+        int v = atoi(var);
+        if (v >= 0 && v <= 10) {
+            max_bind_retries = v;
+        } else {
+            switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+                              "rtp_bind_max_retries=%d out of range [0,10], using default %d\n",
+                              v, max_bind_retries);
+        }
+    }
+
+    for (;;) {
+        rtp_session = switch_rtp_new(tech_pvt->local_address, tech_pvt->local_port,
+                                     tech_pvt->remote_address, tech_pvt->remote_port,
+                                     tech_pvt->agreed_pt,
+                                     tech_pvt->read_codec.implementation->samples_per_packet,
+                                     tech_pvt->ptime * 1000,
+                                     flags, "soft", err,
+                                     switch_core_session_get_pool(tech_pvt->session));
+        if (rtp_session) {
+            return rtp_session;
+        }
+
+        /* switch_rtp_new released tech_pvt->local_port back to the
+         * allocator before returning NULL -- do not release it again. */
+
+        if (!*err
+            || (strncmp(*err, "Bind Error", 10) != 0
+                && strncmp(*err, "RTCP Bind Error", 15) != 0)
+            || retry_count >= max_bind_retries) {
+            return NULL;
+        }
+
+        retry_count++;
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+                          "RTP bind failure on %s:%d [%s], retrying with fresh port (attempt %d/%d)\n",
+                          tech_pvt->local_address, tech_pvt->local_port, *err,
+                          retry_count, max_bind_retries);
+
+        {
+            switch_port_t new_port = switch_rtp_request_port(tech_pvt->local_address);
+            if (new_port == 0) {
+                /* Previous iteration's port was already released by
+                 * switch_rtp_new; no new port was obtained here, so
+                 * nothing to release. */
+                switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+                                  "RTP bind retry: port allocator returned no free port\n");
+                return NULL;
+            }
+            tech_pvt->local_port = new_port;
+            switch_channel_set_variable_printf(channel, "local_media_port", "%d", new_port);
+        }
+    }
+}
+
 static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *session, switch_event_t *var_event,
 													switch_caller_profile_t *outbound_profile,
 													switch_core_session_t **new_session,
@@ -393,13 +489,11 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
     switch_channel_set_variable(channel, "local_media_ip", local_addr);
     switch_channel_set_variable_printf(channel, "local_media_port", "%d", local_port);
 
-    if (!(tech_pvt->rtp_session = switch_rtp_new(local_addr, local_port, remote_addr, remote_port, tech_pvt->agreed_pt,
-												 tech_pvt->read_codec.implementation->samples_per_packet, ptime * 1000,
-												 rtp_flags, "soft", &err, switch_core_session_get_pool(*new_session)))) {
+    if (!(tech_pvt->rtp_session = create_rtp_session_with_bind_retry(tech_pvt, rtp_flags, &err))) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't setup RTP session: [%s]\n", err);
-        /* switch_rtp_new already released the port internally on failure.
-         * Clear the cached value so channel_on_destroy (reached via the
-         * fail -> switch_core_session_destroy path below) does not call
+        /* The helper has already released (via switch_rtp_new) every port
+         * it tried and never allocated a replacement on the failure path;
+         * clear the cached value so channel_on_destroy does not call
          * switch_rtp_release_port a second time. */
         tech_pvt->local_port = 0;
         goto fail;

--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -327,9 +327,12 @@ static switch_rtp_t *create_rtp_session_with_bind_retry(crtp_private_t *tech_pvt
         /* switch_rtp_new released tech_pvt->local_port back to the
          * allocator before returning NULL -- do not release it again. */
 
+        /* Match the full known error prefixes including the trailing '!'
+         * so a future error message that happens to start with "Bind
+         * Error" (e.g. "Bind ErrorValidation") is not silently retried. */
         if (!*err
-            || (strncmp(*err, "Bind Error", 10) != 0
-                && strncmp(*err, "RTCP Bind Error", 15) != 0)
+            || (strncmp(*err, "Bind Error!", 11) != 0
+                && strncmp(*err, "RTCP Bind Error!", 16) != 0)
             || retry_count >= max_bind_retries) {
             return NULL;
         }
@@ -371,7 +374,7 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
     switch_caller_profile_t *caller_profile;
     switch_rtp_flag_t rtp_flags[SWITCH_RTP_FLAG_INVALID] = {0};
 
-    const char *err;
+    const char *err = NULL;
 
 
     const char  *local_addr = switch_event_get_header_nil(var_event, kLOCALADDR),
@@ -512,6 +515,11 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
         switch_channel_set_variable(channel, "local_media_port", NULL);
         goto fail;
     }
+    /* The helper may have migrated tech_pvt->local_port to a different
+     * port after a retry; keep the stack `local_port` in sync so any
+     * future fail-branch using `local_port` does not act on the
+     * already-released original. */
+    local_port = tech_pvt->local_port;
 
     if (switch_core_session_thread_launch(*new_session) != SWITCH_STATUS_SUCCESS) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't start session thread.\n");

--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -294,14 +294,21 @@ static switch_rtp_t *create_rtp_session_with_bind_retry(crtp_private_t *tech_pvt
     const char *var;
 
     var = switch_channel_get_variable(channel, "rtp_bind_max_retries");
-    if (!zstr(var) && switch_is_number(var)) {
-        int v = atoi(var);
-        if (v >= 0 && v <= 10) {
-            max_bind_retries = v;
-        } else {
+    if (!zstr(var)) {
+        char *end = NULL;
+        long v;
+        errno = 0;
+        v = strtol(var, &end, 10);
+        if (errno != 0 || end == var || *end != '\0') {
             switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-                              "rtp_bind_max_retries=%d out of range [0,10], using default %d\n",
+                              "rtp_bind_max_retries='%s' is not a valid integer, using default %d\n",
+                              var, max_bind_retries);
+        } else if (v < 0 || v > 10) {
+            switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+                              "rtp_bind_max_retries=%ld out of range [0,10], using default %d\n",
                               v, max_bind_retries);
+        } else {
+            max_bind_retries = (int)v;
         }
     }
 
@@ -338,7 +345,10 @@ static switch_rtp_t *create_rtp_session_with_bind_retry(crtp_private_t *tech_pvt
             if (new_port == 0) {
                 /* Previous iteration's port was already released by
                  * switch_rtp_new; no new port was obtained here, so
-                 * nothing to release. */
+                 * nothing to release. Overwrite *err so the caller's
+                 * log reflects the real reason for giving up instead
+                 * of the previous iteration's bind error. */
+                *err = "Port allocator exhausted during bind retry";
                 switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
                                   "RTP bind retry: port allocator returned no free port\n");
                 return NULL;
@@ -496,6 +506,10 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
          * clear the cached value so channel_on_destroy does not call
          * switch_rtp_release_port a second time. */
         tech_pvt->local_port = 0;
+        /* The helper may have updated "local_media_port" to the last
+         * (failed) retry port; unset it so downstream consumers / events
+         * / CDR do not see a port that this session never owned. */
+        switch_channel_set_variable(channel, "local_media_port", NULL);
         goto fail;
     }
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -5601,6 +5601,55 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_create(switch_rtp_t **new_rtp_session
 	return SWITCH_STATUS_SUCCESS;
 }
 
+/* Synchronously close any RTP/RTCP sockets owned by an rtp_session that is
+ * about to be abandoned mid-setup. Mirrors the close sequence at the end of
+ * switch_rtp_destroy: handles sock_input == sock_output aliasing (used when
+ * the local and remote ends share an address family) and rtcp_sock_*
+ * aliasing onto sock_*.
+ *
+ * Used by switch_rtp_new's failure paths. The session pool is destroyed
+ * asynchronously by the pool_thread (~1s sleep cycle), but the port is
+ * returned to the allocator immediately on failure. Without an explicit
+ * close here the kernel bind outlives the port release, and the next caller
+ * that picks the same port hits EADDRINUSE. The session has not been
+ * published to other threads at this point, so no shutdown/ping is needed --
+ * a plain close is enough to drop the kernel bind.
+ */
+static void close_rtp_sockets(switch_rtp_t *rtp_session)
+{
+	switch_socket_t *sock;
+
+	if (rtp_session->rtcp_sock_input == rtp_session->sock_input) {
+		rtp_session->rtcp_sock_input = NULL;
+	}
+	if (rtp_session->rtcp_sock_output == rtp_session->sock_output) {
+		rtp_session->rtcp_sock_output = NULL;
+	}
+
+	sock = rtp_session->sock_input;
+	rtp_session->sock_input = NULL;
+	if (sock) {
+		switch_socket_close(sock);
+	}
+
+	if (rtp_session->sock_output && rtp_session->sock_output != sock) {
+		sock = rtp_session->sock_output;
+		rtp_session->sock_output = NULL;
+		switch_socket_close(sock);
+	}
+
+	if ((sock = rtp_session->rtcp_sock_input)) {
+		rtp_session->rtcp_sock_input = NULL;
+		switch_socket_close(sock);
+	}
+
+	if (rtp_session->rtcp_sock_output && rtp_session->rtcp_sock_output != sock) {
+		sock = rtp_session->rtcp_sock_output;
+		rtp_session->rtcp_sock_output = NULL;
+		switch_socket_close(sock);
+	}
+}
+
 SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 											  switch_port_t rx_port,
 											  const char *tx_host,
@@ -5653,12 +5702,14 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 	switch_mutex_lock(rtp_session->flag_mutex);
 
 	if (switch_rtp_set_local_address(rtp_session, rx_host, rx_port, err) != SWITCH_STATUS_SUCCESS) {
+		close_rtp_sockets(rtp_session);
 		switch_mutex_unlock(rtp_session->flag_mutex);
 		rtp_session = NULL;
 		goto end;
 	}
 
 	if (switch_rtp_set_remote_address(rtp_session, tx_host, tx_port, 0, SWITCH_TRUE, err) != SWITCH_STATUS_SUCCESS) {
+		close_rtp_sockets(rtp_session);
 		switch_mutex_unlock(rtp_session->flag_mutex);
 		rtp_session = NULL;
 		goto end;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -5529,9 +5529,12 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_create(switch_rtp_t **new_rtp_session
 	}
 
 
-	if (channel) {
-		switch_channel_set_private(channel, "__rtcp_audio_rtp_session", rtp_session);
-	}
+	/* The "__rtcp_audio_rtp_session" private pointer is published by
+	 * switch_rtp_new once setup completes successfully. Doing it here
+	 * would leave a dangling pointer in the channel if any subsequent
+	 * step in switch_rtp_new (set_local_address / set_remote_address)
+	 * fails, since the rtp_session lives in the session pool that the
+	 * caller will then tear down. */
 
 
 	/* Jitter */
@@ -5727,6 +5730,16 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 		rtp_session->rx_port = rx_port;
 		switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_FLUSH);
 		switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_DETECT_SSRC);
+
+		/* Publish on the channel only once setup has fully succeeded.
+		 * Readers (e.g. RTCP relay on the partner leg) rely on this key
+		 * pointing to a live rtp_session whose pool is still owned. */
+		if (rtp_session->session) {
+			switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+			if (channel) {
+				switch_channel_set_private(channel, "__rtcp_audio_rtp_session", rtp_session);
+			}
+		}
 	} else {
 		switch_rtp_release_port(rx_host, rx_port);
 	}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -5596,10 +5596,11 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_create(switch_rtp_t **new_rtp_session
 
 	rtp_session->ready = 1;
 	*new_rtp_session = rtp_session;
-	
-	if (create_probe){
-		create_probe(rtp_session, channel);
-	}
+
+	/* The homer RTCP probe (if registered) is created by switch_rtp_new
+	 * once setup completes successfully, not here. Creating it before
+	 * set_local_address / set_remote_address would register a probe on a
+	 * session that switch_rtp_new abandons on a failed bind/retry. */
 
 	return SWITCH_STATUS_SUCCESS;
 }
@@ -5738,6 +5739,14 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 			switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
 			if (channel) {
 				switch_channel_set_private(channel, "__rtcp_audio_rtp_session", rtp_session);
+
+				/* Register the homer RTCP probe (if any) now that setup has
+				 * succeeded, rather than in switch_rtp_create before the
+				 * bind: keeps probe registration off sessions abandoned on a
+				 * failed bind/retry, symmetric with the publish above. */
+				if (create_probe) {
+					create_probe(rtp_session, channel);
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
## Summary

- **Root-cause fix for EADDRINUSE under bursty origination.** `switch_rtp_new`'s failure paths released the port to the allocator immediately but the kernel UDP bind survived until the `pool_thread` destroyed the session pool (~1s sleep cycle). The next caller could pick the same port back from the allocator before the kernel released the bind. A new static `close_rtp_sockets()` helper now synchronously closes the bound sockets on every failure exit, mirroring the close block in `switch_rtp_destroy`.
- **Eliminate a double-release of `tech_pvt->local_port`** in `mod_sofia/rtp.c`. `switch_rtp_new` already released the port internally on failure; `channel_on_destroy` then released it again. The allocator's `track[index] > 0` guard silently absorbed it, but the contract was wrong.
- **Defer `__rtcp_audio_rtp_session` channel-private publication** from `switch_rtp_create` (which fires before `switch_rtp_set_local_address` / `set_remote_address`) into `switch_rtp_new`'s success branch. Closes a dangling-pointer window where the partner-leg RTCP relay reader at `switch_rtp.c:9019` could find a pointer to a soon-to-be-destroyed rtp_session.
- **Add a bounded bind-retry loop** around `switch_rtp_new` in `channel_outgoing_channel`. Defaults to 3 retries (4 total attempts), overrideable per call via the `rtp_bind_max_retries` channel variable (range 0..10). Retries only on `Bind Error!` / `RTCP Bind Error!` prefixes — other failures (missing args, socket-create errors) surface immediately. WARN log per retry attempt, ERROR on final give-up.
- **Tighten the retry-helper diagnostics**: `strtol` + `errno` validation of `rtp_bind_max_retries` (rejects decimals like `3.5` that `switch_is_number` + `atoi` silently truncated), set `*err` on the allocator-exhaustion path so the caller's log reflects the real cause, unset `local_media_port` channel var on terminal failure so events/CDR don't see a stale port, and match the error prefix including the trailing `!` so future strings starting with `Bind Error...` aren't silently retried.

## Background

Under sustained outbound RTP origination on busy boxes, callers were hitting `Bind Error! <ip>:<port>` even though the port allocator reported the port as free. Root cause: `switch_rtp_new` returned the port to the allocator immediately on failure, but pool destruction (which closes the bound UDP socket) was deferred to a background thread (`pool_thread` in `switch_core_memory.c:640`) that sleeps 1s between drains. Under bursty origination, the same port was handed back out before the kernel released the bind. The allocator's `-4` cooldown was insufficient because random-walk index selection lets concurrent requests decrement it past the cooldown faster than the pool_thread drains.

The six commits compose so the retry layer (commit 4) is safe to add: commit 1 ensures every failed iteration leaves a fully-clean port for the next iteration to try.

## Commits (atomic, branch order)

1. `close RTP sockets in switch_rtp_new failure paths` — the actual fix
2. `avoid double-release of local RTP port on mod_sofia/rtp.c origination failure`
3. `defer __rtcp_audio_rtp_session publish until switch_rtp_new succeeds`
4. `retry crtp RTP session creation on transient bind failures`
5. `fix diagnostic and UX bugs in crtp bind-retry helper`
6. `defensive guards in crtp bind-retry helper and caller`

## Configuration

| Channel variable | Default | Range | Effect |
|---|---|---|---|
| `rtp_bind_max_retries` | `3` | `0..10` | Bind-retry budget for crtp originations. `0` disables retry. Non-numeric or out-of-range values log a WARNING and use the default. |

## Test plan

- [x] `make freeswitch_build` (in Docker) compiles cleanly with all 6 commits, no warnings on touched files
- [x] Route-by-route audit: every happy and unhappy path through `channel_outgoing_channel`, `create_rtp_session_with_bind_retry`, `switch_rtp_new`, and `close_rtp_sockets` verified for correct port/socket/mutex/codec cleanup
- [ ] Manual: bursty outbound RTP origination — confirm `EADDRINUSE` cascade no longer reproduces under load
- [ ] Manual: set `rtp_bind_max_retries=0` on the originate — confirm bind error surfaces on the first attempt with no retry
- [ ] Manual: set `rtp_bind_max_retries=foo` — confirm WARN log and default of 3 in effect
- [ ] Manual: set `rtp_bind_max_retries=15` — confirm WARN log about out-of-range and default of 3 in effect
- [ ] Regression: normal single-attempt RTP call setup unaffected
- [ ] Regression: voicemail flow (AUTOADJ flag set, no RTCP) unaffected
- [ ] Regression: partner-leg RTCP relay still works (since we moved when `__rtcp_audio_rtp_session` is published)

## Known deferred items

Surfaced during review, decided to defer:
- Per-retry `rtp_session` allocations accumulate in the session pool until session destroy (~few KB per abandoned iteration, bounded by `max_retries`). Real but not a leak.
- `close_rtp_sockets` does not clear `read_pollfd` / `rtcp_read_pollfd` references in the abandoned rtp_session — currently benign since no one polls the abandoned set, but the most fragile of the deferred items.
- `create_probe` (mod_homer_rtcp) fires per retry on abandoned sessions if the probe is registered — depends on probe idempotency.