### PR TITLE
TELCORE-160: fix b2bua-rtc trickle ICE NULL ufrag/pwd race

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5827,6 +5827,12 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 				}
 			}
 
+			/* Trickle-recheck can race the SDP-answer path; ensure local ufrag/pwd
+			   exist before activating ICE so outbound STUN is signed correctly. */
+			if (zstr(engine->ice_out.ufrag) || zstr(engine->ice_out.pwd)) {
+				gen_ice(smh->session, type, NULL, 0);
+			}
+
 			switch_rtp_activate_ice(engine->rtp_session,
 									engine->ice_in.ufrag,
 									engine->ice_out.ufrag,

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -6011,6 +6011,22 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 
 	switch_mutex_lock(rtp_session->ice_mutex);
 
+	/* VANILLA ICE requires all four creds to sign outbound STUN; refuse and log
+	   loudly rather than emit USERNAME with NULL/empty values. */
+	if ((type & ICE_VANILLA) &&
+		(zstr(login) || zstr(rlogin) || zstr(password) || zstr(rpassword))) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR,
+			"Refusing to activate %s ICE: missing credentials "
+			"(login=%s rlogin=%s password=%s rpassword=%s)\n",
+			proto == IPR_RTP ? "RTP" : "RTCP",
+			zstr(login) ? "EMPTY" : "set",
+			zstr(rlogin) ? "EMPTY" : "set",
+			zstr(password) ? "EMPTY" : "set",
+			zstr(rpassword) ? "EMPTY" : "set");
+		switch_mutex_unlock(rtp_session->ice_mutex);
+		return SWITCH_STATUS_FALSE;
+	}
+
 	if (proto == IPR_RTP) {
 		ice = &rtp_session->ice;
 		rtp_session->flags[SWITCH_RTP_FLAG_PAUSE] = 0;


### PR DESCRIPTION
## Summary

The trickle-recheck path in `check_ice()` activated ICE without calling `gen_ice()` first. When trickle candidates drained before the SDP-answer path populated local ufrag/pwd, FreeSWITCH armed ICE with NULL local credentials and produced outbound STUN `USERNAME="<remote>:(null)"` signed with an empty key. Peers responded 401 to every check → one-way ICE → media never established.

## Root cause

Race between two paths in `check_ice()`:
- **Path A** (SDP-answer): runs `gen_ice()` (populates `engine->ice_out.ufrag`/`pwd`) then activates.
- **Path B** (trickle-recheck, added in TEL-6622 PR #449): calls `switch_rtp_activate_ice()` without `gen_ice()`. If queued trickle candidates drain before Path A reaches `gen_ice()`, Path B wins and arms ICE with NULL local ufrag/pwd. The `ice_t` captures `"<remote>:(null)"` as `ice_user` and `""` as `pass` — stuck until next activate, which never comes.

## Fix

1. `src/switch_core_media.c` — call `gen_ice(smh->session, type, NULL, 0)` before the trickle-recheck `switch_rtp_activate_ice()` inside `if (engine->new_ice)`, gated on `zstr(engine->ice_out.ufrag) || zstr(engine->ice_out.pwd)` so it only runs when creds are actually missing.
2. `src/switch_rtp.c` — defensive guard at the top of `switch_rtp_activate_ice()`: if VANILLA ICE and any of `login`/`rlogin`/`password`/`rpassword` is empty, log at ERROR (without leaking values), unlock `ice_mutex`, and return `SWITCH_STATUS_FALSE`. Fails loud so future regressions surface in logs instead of silently dying on the wire.