### PR TITLE
TELCORE-155: respond immediately to inbound BYE after local teardown

### DIFF
--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -22,6 +22,11 @@ typedef struct {
 		switch_time_t last_ok;
 		uint8_t cand_responsive;
 		uint8_t dtls_handshake;
+		switch_time_t first_responsive_us;
+		uint8_t promoted_to_controlling;
+		uint8_t nomination_fallback_cached;
+		uint8_t nomination_fallback_enabled;
+		uint32_t nomination_fallback_ms;
 } switch_rtp_ice_t;
 
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);

--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -253,6 +253,115 @@ void crtp_init(switch_loadable_module_interface_t *mod_interface)
 
 }
 
+/* Create the RTP session for a crtp leg, retrying with a freshly allocated
+ * port on transient bind failures.
+ *
+ * The underlying problem is a timing race rather than real port exhaustion:
+ * when a previous session's pool has not yet been collected, its bound UDP
+ * socket can outlive the release of its port back to the allocator, and
+ * the next caller that picks the same port hits EADDRINUSE. Requesting a
+ * different port and trying again is usually enough to escape the conflict.
+ *
+ * Only retries on bind-specific failures ("Bind Error" / "RTCP Bind Error"
+ * from switch_rtp_set_local_address / enable_local_rtcp_socket) -- other
+ * failures (missing args, socket create errors, etc.) are terminal and
+ * surfaced immediately.
+ *
+ * Port lifecycle: switch_rtp_new always disposes of the port it was given
+ * -- on success the new rtp_session owns it (and switch_rtp_destroy will
+ * release it later); on failure switch_rtp_new calls
+ * switch_rtp_release_port itself before returning NULL. This helper
+ * therefore never needs to release a port on its own NULL-return paths,
+ * and the caller must not release tech_pvt->local_port either (clearing
+ * tech_pvt->local_port to 0 is the right pattern to keep
+ * channel_on_destroy from double-releasing).
+ *
+ * Returns the new rtp_session on success (with tech_pvt->local_port
+ * reflecting the actually-bound port -- it may have been updated mid-way
+ * if a retry was needed). Returns NULL on failure with *err set.
+ *
+ * Retry budget defaults to 3. Override per call via the
+ * "rtp_bind_max_retries" channel variable (0..10).
+ */
+static switch_rtp_t *create_rtp_session_with_bind_retry(crtp_private_t *tech_pvt,
+                                                        switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID],
+                                                        const char **err)
+{
+    switch_channel_t *channel = tech_pvt->channel;
+    switch_rtp_t *rtp_session = NULL;
+    int max_bind_retries = 3;
+    int retry_count = 0;
+    const char *var;
+
+    var = switch_channel_get_variable(channel, "rtp_bind_max_retries");
+    if (!zstr(var)) {
+        char *end = NULL;
+        long v;
+        errno = 0;
+        v = strtol(var, &end, 10);
+        if (errno != 0 || end == var || *end != '\0') {
+            switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+                              "rtp_bind_max_retries='%s' is not a valid integer, using default %d\n",
+                              var, max_bind_retries);
+        } else if (v < 0 || v > 10) {
+            switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+                              "rtp_bind_max_retries=%ld out of range [0,10], using default %d\n",
+                              v, max_bind_retries);
+        } else {
+            max_bind_retries = (int)v;
+        }
+    }
+
+    for (;;) {
+        rtp_session = switch_rtp_new(tech_pvt->local_address, tech_pvt->local_port,
+                                     tech_pvt->remote_address, tech_pvt->remote_port,
+                                     tech_pvt->agreed_pt,
+                                     tech_pvt->read_codec.implementation->samples_per_packet,
+                                     tech_pvt->ptime * 1000,
+                                     flags, "soft", err,
+                                     switch_core_session_get_pool(tech_pvt->session));
+        if (rtp_session) {
+            return rtp_session;
+        }
+
+        /* switch_rtp_new released tech_pvt->local_port back to the
+         * allocator before returning NULL -- do not release it again. */
+
+        /* Match the full known error prefixes including the trailing '!'
+         * so a future error message that happens to start with "Bind
+         * Error" (e.g. "Bind ErrorValidation") is not silently retried. */
+        if (!*err
+            || (strncmp(*err, "Bind Error!", 11) != 0
+                && strncmp(*err, "RTCP Bind Error!", 16) != 0)
+            || retry_count >= max_bind_retries) {
+            return NULL;
+        }
+
+        retry_count++;
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+                          "RTP bind failure on %s:%d [%s], retrying with fresh port (attempt %d/%d)\n",
+                          tech_pvt->local_address, tech_pvt->local_port, *err,
+                          retry_count, max_bind_retries);
+
+        {
+            switch_port_t new_port = switch_rtp_request_port(tech_pvt->local_address);
+            if (new_port == 0) {
+                /* Previous iteration's port was already released by
+                 * switch_rtp_new; no new port was obtained here, so
+                 * nothing to release. Overwrite *err so the caller's
+                 * log reflects the real reason for giving up instead
+                 * of the previous iteration's bind error. */
+                *err = "Port allocator exhausted during bind retry";
+                switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+                                  "RTP bind retry: port allocator returned no free port\n");
+                return NULL;
+            }
+            tech_pvt->local_port = new_port;
+            switch_channel_set_variable_printf(channel, "local_media_port", "%d", new_port);
+        }
+    }
+}
+
 static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *session, switch_event_t *var_event,
 													switch_caller_profile_t *outbound_profile,
 													switch_core_session_t **new_session,
@@ -265,7 +374,7 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
     switch_caller_profile_t *caller_profile;
     switch_rtp_flag_t rtp_flags[SWITCH_RTP_FLAG_INVALID] = {0};
 
-    const char *err;
+    const char *err = NULL;
 
 
     const char  *local_addr = switch_event_get_header_nil(var_event, kLOCALADDR),
@@ -393,12 +502,24 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
     switch_channel_set_variable(channel, "local_media_ip", local_addr);
     switch_channel_set_variable_printf(channel, "local_media_port", "%d", local_port);
 
-    if (!(tech_pvt->rtp_session = switch_rtp_new(local_addr, local_port, remote_addr, remote_port, tech_pvt->agreed_pt,
-												 tech_pvt->read_codec.implementation->samples_per_packet, ptime * 1000,
-												 rtp_flags, "soft", &err, switch_core_session_get_pool(*new_session)))) {
+    if (!(tech_pvt->rtp_session = create_rtp_session_with_bind_retry(tech_pvt, rtp_flags, &err))) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't setup RTP session: [%s]\n", err);
+        /* The helper has already released (via switch_rtp_new) every port
+         * it tried and never allocated a replacement on the failure path;
+         * clear the cached value so channel_on_destroy does not call
+         * switch_rtp_release_port a second time. */
+        tech_pvt->local_port = 0;
+        /* The helper may have updated "local_media_port" to the last
+         * (failed) retry port; unset it so downstream consumers / events
+         * / CDR do not see a port that this session never owned. */
+        switch_channel_set_variable(channel, "local_media_port", NULL);
         goto fail;
     }
+    /* The helper may have migrated tech_pvt->local_port to a different
+     * port after a retry; keep the stack `local_port` in sync so any
+     * future fail-branch using `local_port` does not act on the
+     * already-released original. */
+    local_port = tech_pvt->local_port;
 
     if (switch_core_session_thread_launch(*new_session) != SWITCH_STATUS_SUCCESS) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't start session thread.\n");

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -1568,6 +1568,22 @@ static void our_sofia_event_callback(nua_event_t event,
 				}
 
 				if (channel && switch_channel_down(channel)) {
+					if (event == nua_i_bye) {
+						/* RFC 3261 15.1.2 glare: channel already torn down, but we still owe a final response to the in-dialog BYE. */
+						const char *session_id_header = sofia_glue_session_id_header(session, profile);
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+										  "Channel is already hungup, responding 200 OK to inbound BYE immediately.\n");
+						sofia_set_flag_locked(tech_pvt, TFLAG_BYE);
+						tech_pvt->got_bye = 1;
+						nua_respond(nh, SIP_200_OK, NUTAG_WITH_THIS_MSG(de->data->e_msg),
+									TAG_IF(!zstr(session_id_header), SIPTAG_HEADER_STR(session_id_header)),
+									TAG_END());
+						if (sofia_private) {
+							sofia_private->destroy_me = 1;
+							sofia_private->destroy_nh = 1;
+						}
+						goto done;
+					}
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Channel is already hungup.\n");
 					goto done;
 				}

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -1569,9 +1569,15 @@ static void our_sofia_event_callback(nua_event_t event,
 
 				if (channel && switch_channel_down(channel)) {
 					if (event == nua_i_bye) {
-						/* RFC 3261 15.1.2 glare: channel already torn down, but we still owe a final response to the in-dialog BYE. */
+						/* RFC 3261 §15.1.2 / §17.2.2: peer is owed a final response to its in-dialog BYE even though our local channel is already torn down. */
 						const char *session_id_header = sofia_glue_session_id_header(session, profile);
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+
+						/* sofia_on_hangup will skip its send_bye disposition write once we set TFLAG_BYE below, so backfill recv_bye for CDR unless something already claimed the disposition. */
+						if (zstr(switch_channel_get_variable(channel, "sip_hangup_disposition"))) {
+							switch_channel_set_variable(channel, "sip_hangup_disposition", "recv_bye");
+						}
+
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE,
 										  "Channel is already hungup, responding 200 OK to inbound BYE immediately.\n");
 						sofia_set_flag_locked(tech_pvt, TFLAG_BYE);
 						tech_pvt->got_bye = 1;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -77,6 +77,7 @@
 #define WRITE_DEC(rtp_session) rtp_session->writing--; switch_mutex_unlock(rtp_session->write_mutex)
 
 #define RTP_STUN_FREQ 1000000
+#define DEFAULT_ICE_NOMINATION_FALLBACK_MS 10000
 #define rtp_header_len 12
 #define RTP_START_PORT 16384
 #define RTP_END_PORT 32768
@@ -1119,6 +1120,50 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	ice->next_run = now + RTP_STUN_FREQ;
 
+	/* Non-DTLS ICE-CONTROLLED peers that never send USE-CANDIDATE hang media
+	 * forever. After the fallback window since first responsive STUN,
+	 * self-promote to controlling and nominate. */
+	if ((ice->type & ICE_VANILLA) && (ice->type & ICE_CONTROLLED)
+		&& !(ice->type & (ICE_LITE | ICE_LITE_INBOUND))
+		&& !rtp_session->dtls
+		&& !ice->promoted_to_controlling && ice->cand_responsive && ice->first_responsive_us) {
+		if (!ice->nomination_fallback_cached) {
+			/* rtp_ice_nomination_fallback_ms=0 (or negative) disables the fallback for this leg. */
+			if (rtp_session->session && rtp_session->session->channel) {
+				const char *fb_var = switch_channel_get_variable(rtp_session->session->channel, "rtp_ice_nomination_fallback");
+				int raw = switch_safe_atoi(
+					switch_channel_get_variable(rtp_session->session->channel, "rtp_ice_nomination_fallback_ms"),
+					DEFAULT_ICE_NOMINATION_FALLBACK_MS);
+				ice->nomination_fallback_enabled = zstr(fb_var) || switch_true(fb_var);
+				ice->nomination_fallback_ms = (raw > 0) ? (uint32_t)raw : 0;
+			} else {
+				ice->nomination_fallback_enabled = 1;
+				ice->nomination_fallback_ms = DEFAULT_ICE_NOMINATION_FALLBACK_MS;
+			}
+			ice->nomination_fallback_cached = 1;
+		}
+		if (ice->nomination_fallback_enabled && ice->nomination_fallback_ms > 0
+			&& (now - ice->first_responsive_us) >= ((switch_time_t)ice->nomination_fallback_ms * 1000)) {
+			uint32_t i;
+			int peer_use_candidate = 0;
+			if (ice->ice_params && ice->ice_params->cand_idx[ice->proto] > 0) {
+				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
+					if (ice->ice_params->cands[i][ice->proto].use_candidate) {
+						peer_use_candidate = 1;
+						break;
+					}
+				}
+			}
+			if (!peer_use_candidate) {
+				ice->type &= ~ICE_CONTROLLED;
+				ice->promoted_to_controlling = 1;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+					"%s ICE peer never nominated in %u ms; promoting to CONTROLLING\n",
+					rtp_type(rtp_session), ice->nomination_fallback_ms);
+			}
+		}
+	}
+
 	if (ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output) {
 		sock_output = rtp_session->rtcp_sock_output;
 	}
@@ -1281,6 +1326,15 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					}
 				}
 
+				/* Peer nominated after we self-promoted: yield, peer wins. */
+				if (ice->promoted_to_controlling) {
+					ice->type |= ICE_CONTROLLED;
+					ice->promoted_to_controlling = 0;
+					ice->nomination_fallback_enabled = 0;
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+						"%s late peer USE-CANDIDATE after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
+				}
+
 				/* RFC 8445: controlled agent must accept the nominated pair. */
 				if (ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE)) {
 					/* Once DTLS is established, don't switch addresses from competing nominations. */
@@ -1320,7 +1374,17 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 								  );
 
 				if ((ice->type & ICE_VANILLA) && code == 487) {
-					if ((ice->type & ICE_CONTROLLED)) {
+					/* Three role-conflict cases:
+					 *   1. We self-promoted (fallback) and peer rejects -> revert to CONTROLLED, disable fallback.
+					 *   2. We were CONTROLLED and peer 487s us -> RFC role-conflict flip to CONTROLLING.
+					 *   3. We were CONTROLLING and peer 487s us -> RFC role-conflict flip to CONTROLLED. */
+					if (ice->promoted_to_controlling && !(ice->type & ICE_CONTROLLED)) {
+						/* Peer rejected our self-promotion: it is legitimately controlling. Revert and stand down. */
+						ice->type |= ICE_CONTROLLED;
+						ice->promoted_to_controlling = 0;
+						ice->nomination_fallback_enabled = 0;
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN got role-conflict 487 after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
+					} else if ((ice->type & ICE_CONTROLLED)) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN Changing role to CONTROLLING\n", rtp_type(rtp_session));
 						ice->type &= ~ICE_CONTROLLED;
 					} else {
@@ -1441,6 +1505,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						if (ice_candidate_matches_addr(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto], from_host, from_port)) {
 							ice->cand_responsive = 1;
 							ice->initializing = 0;
+							if (!ice->first_responsive_us) {
+								ice->first_responsive_us = switch_micro_time_now();
+							}
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Chosen %s ICE candidate %s:%d is responsive (is_relay: %d)\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port, is_relay);
 						}
 					}
@@ -1749,6 +1816,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				ice->cand_responsive = is_responsive;
 				if (ice->cand_responsive) {
 					ice->initializing = 0;
+					if (!ice->first_responsive_us) {
+						ice->first_responsive_us = switch_micro_time_now();
+					}
 				}
 
 				ice->last_ok = now;
@@ -6034,6 +6104,11 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 		ice->ready = ice->rready = 1;
 		ice->cand_responsive = 0;
 	}
+	ice->first_responsive_us = 0;
+	ice->promoted_to_controlling = 0;
+	ice->nomination_fallback_cached = 0;
+	ice->nomination_fallback_enabled = 0;
+	ice->nomination_fallback_ms = 0;
 
 	ice->ice_user = switch_core_strdup(rtp_session->pool, ice_user);
 	ice->user_ice = switch_core_strdup(rtp_session->pool, user_ice);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1129,10 +1129,11 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		&& !ice->promoted_to_controlling && ice->cand_responsive && ice->first_responsive_us) {
 		if (!ice->nomination_fallback_cached) {
 			/* rtp_ice_nomination_fallback_ms=0 (or negative) disables the fallback for this leg. */
-			if (rtp_session->session && rtp_session->session->channel) {
-				const char *fb_var = switch_channel_get_variable(rtp_session->session->channel, "rtp_ice_nomination_fallback");
+			switch_channel_t *channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+			if (channel) {
+				const char *fb_var = switch_channel_get_variable(channel, "rtp_ice_nomination_fallback");
 				int raw = switch_safe_atoi(
-					switch_channel_get_variable(rtp_session->session->channel, "rtp_ice_nomination_fallback_ms"),
+					switch_channel_get_variable(channel, "rtp_ice_nomination_fallback_ms"),
 					DEFAULT_ICE_NOMINATION_FALLBACK_MS);
 				ice->nomination_fallback_enabled = zstr(fb_var) || switch_true(fb_var);
 				ice->nomination_fallback_ms = (raw > 0) ? (uint32_t)raw : 0;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -5529,9 +5529,12 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_create(switch_rtp_t **new_rtp_session
 	}
 
 
-	if (channel) {
-		switch_channel_set_private(channel, "__rtcp_audio_rtp_session", rtp_session);
-	}
+	/* The "__rtcp_audio_rtp_session" private pointer is published by
+	 * switch_rtp_new once setup completes successfully. Doing it here
+	 * would leave a dangling pointer in the channel if any subsequent
+	 * step in switch_rtp_new (set_local_address / set_remote_address)
+	 * fails, since the rtp_session lives in the session pool that the
+	 * caller will then tear down. */
 
 
 	/* Jitter */
@@ -5593,12 +5596,62 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_create(switch_rtp_t **new_rtp_session
 
 	rtp_session->ready = 1;
 	*new_rtp_session = rtp_session;
-	
-	if (create_probe){
-		create_probe(rtp_session, channel);
-	}
+
+	/* The homer RTCP probe (if registered) is created by switch_rtp_new
+	 * once setup completes successfully, not here. Creating it before
+	 * set_local_address / set_remote_address would register a probe on a
+	 * session that switch_rtp_new abandons on a failed bind/retry. */
 
 	return SWITCH_STATUS_SUCCESS;
+}
+
+/* Synchronously close any RTP/RTCP sockets owned by an rtp_session that is
+ * about to be abandoned mid-setup. Mirrors the close sequence at the end of
+ * switch_rtp_destroy: handles sock_input == sock_output aliasing (used when
+ * the local and remote ends share an address family) and rtcp_sock_*
+ * aliasing onto sock_*.
+ *
+ * Used by switch_rtp_new's failure paths. The session pool is destroyed
+ * asynchronously by the pool_thread (~1s sleep cycle), but the port is
+ * returned to the allocator immediately on failure. Without an explicit
+ * close here the kernel bind outlives the port release, and the next caller
+ * that picks the same port hits EADDRINUSE. The session has not been
+ * published to other threads at this point, so no shutdown/ping is needed --
+ * a plain close is enough to drop the kernel bind.
+ */
+static void close_rtp_sockets(switch_rtp_t *rtp_session)
+{
+	switch_socket_t *sock;
+
+	if (rtp_session->rtcp_sock_input == rtp_session->sock_input) {
+		rtp_session->rtcp_sock_input = NULL;
+	}
+	if (rtp_session->rtcp_sock_output == rtp_session->sock_output) {
+		rtp_session->rtcp_sock_output = NULL;
+	}
+
+	sock = rtp_session->sock_input;
+	rtp_session->sock_input = NULL;
+	if (sock) {
+		switch_socket_close(sock);
+	}
+
+	if (rtp_session->sock_output && rtp_session->sock_output != sock) {
+		sock = rtp_session->sock_output;
+		rtp_session->sock_output = NULL;
+		switch_socket_close(sock);
+	}
+
+	if ((sock = rtp_session->rtcp_sock_input)) {
+		rtp_session->rtcp_sock_input = NULL;
+		switch_socket_close(sock);
+	}
+
+	if (rtp_session->rtcp_sock_output && rtp_session->rtcp_sock_output != sock) {
+		sock = rtp_session->rtcp_sock_output;
+		rtp_session->rtcp_sock_output = NULL;
+		switch_socket_close(sock);
+	}
 }
 
 SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
@@ -5653,12 +5706,14 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 	switch_mutex_lock(rtp_session->flag_mutex);
 
 	if (switch_rtp_set_local_address(rtp_session, rx_host, rx_port, err) != SWITCH_STATUS_SUCCESS) {
+		close_rtp_sockets(rtp_session);
 		switch_mutex_unlock(rtp_session->flag_mutex);
 		rtp_session = NULL;
 		goto end;
 	}
 
 	if (switch_rtp_set_remote_address(rtp_session, tx_host, tx_port, 0, SWITCH_TRUE, err) != SWITCH_STATUS_SUCCESS) {
+		close_rtp_sockets(rtp_session);
 		switch_mutex_unlock(rtp_session->flag_mutex);
 		rtp_session = NULL;
 		goto end;
@@ -5676,6 +5731,24 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rtp_new(const char *rx_host,
 		rtp_session->rx_port = rx_port;
 		switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_FLUSH);
 		switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_DETECT_SSRC);
+
+		/* Publish on the channel only once setup has fully succeeded.
+		 * Readers (e.g. RTCP relay on the partner leg) rely on this key
+		 * pointing to a live rtp_session whose pool is still owned. */
+		if (rtp_session->session) {
+			switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+			if (channel) {
+				switch_channel_set_private(channel, "__rtcp_audio_rtp_session", rtp_session);
+
+				/* Register the homer RTCP probe (if any) now that setup has
+				 * succeeded, rather than in switch_rtp_create before the
+				 * bind: keeps probe registration off sessions abandoned on a
+				 * failed bind/retry, symmetric with the publish above. */
+				if (create_probe) {
+					create_probe(rtp_session, channel);
+				}
+			}
+		}
 	} else {
 		switch_rtp_release_port(rx_host, rx_port);
 	}


### PR DESCRIPTION
## Summary
Fixes delayed 200 OK responses to inbound BYE when mod_sofia has already moved the channel into hangup during BYE glare or late inbound BYE after local teardown.

Linear: https://linear.app/telnyx/issue/TELCORE-155

## Root cause
`our_sofia_event_callback()` exited early when `switch_channel_down(channel)` was true. For inbound BYE, that skipped the `nua_respond(SIP_200_OK ...)` path and could delay the peer's BYE transaction response by ~3s (until Sofia dialog usage teardown / Timer F), violating RFC 3261 §15.1.2.

## Fix
Handle `nua_i_bye` inside the channel-down guard with a minimal inline responder: mark BYE state, send 200 OK using the original message, mark the Sofia private handle for cleanup, then jump to normal `done:` cleanup. Avoids auth/challenge/watch-header/full-BYE-handler side effects and preserves existing hangup metadata (`sip_term_status`, `sip_term_cause`, `sip_hangup_disposition`).
