### PR TITLE
TELCORE-192: fix crash segfault in switch_core_session_write_frame (foreign codec teardown)

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -19125,6 +19125,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 	switch_frame_t *enc_frame = NULL, *write_frame = frame;
 	unsigned int flag = 0, need_codec = 0, perfect = 0, do_bugs = 0, do_write = 0, do_resample = 0, ptime_mismatch = 0, pass_cng = 0, resample = 0;
 	int did_write_resample = 0;
+	switch_mutex_t *write_codec_mutex = NULL, *frame_codec_mutex = NULL;
 
 	switch_assert(session != NULL);
 	switch_assert(frame != NULL);
@@ -19192,8 +19193,20 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 		return SWITCH_STATUS_FALSE;
 	}
 
-	switch_mutex_lock(session->write_codec->mutex);
-	switch_mutex_lock(frame->codec->mutex);
+	/* Snapshot the codec mutexes so the same objects are locked and unlocked.
+	 * frame->codec may be a codec owned by another session (e.g. the peer codec
+	 * setup_ringback() passes during originate ringback / bridge_early_media);
+	 * our session->codec_write_mutex does not protect its lifetime, so it can be
+	 * torn down concurrently, leaving its mutex NULL. Bail rather than fault. */
+	write_codec_mutex = session->write_codec->mutex;
+	frame_codec_mutex = frame->codec->mutex;
+	if (!write_codec_mutex || !frame_codec_mutex) {
+		switch_mutex_unlock(session->codec_write_mutex);
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_mutex_lock(write_codec_mutex);
+	switch_mutex_lock(frame_codec_mutex);
 
 	if (!(switch_core_codec_ready(session->write_codec) && switch_core_codec_ready(frame->codec))) goto error;
 
@@ -19808,8 +19821,9 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 
   error:
 
-	switch_mutex_unlock(session->write_codec->mutex);
-	switch_mutex_unlock(frame->codec->mutex);
+	/* Unlock the same mutex objects we locked above (see snapshot rationale). */
+	switch_mutex_unlock(frame_codec_mutex);
+	switch_mutex_unlock(write_codec_mutex);
 	switch_mutex_unlock(session->codec_write_mutex);
 
 	return status;

--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -1323,10 +1323,21 @@ static switch_status_t setup_ringback(originate_global_t *oglobals, originate_st
 				if (read_impl.impl_id == write_impl.impl_id &&
 					read_impl.microseconds_per_packet == write_impl.microseconds_per_packet &&
 					read_impl.actual_samples_per_second == write_impl.actual_samples_per_second) {
-						ringback->asis++;
-						write_frame->codec = switch_core_session_get_write_codec(originate_status[0].peer_session);
-						write_frame->datalen = write_frame->codec->implementation->decoded_bytes_per_packet;
-						switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(caller_channel), SWITCH_LOG_DEBUG, "bridge_early_media: passthrough enabled\n");
+						/* Passthrough: the peer-read and caller-write impls are identical, so use
+						 * the CALLER's own write codec rather than borrowing the peer session's.
+						 * write_frame() locks frame->codec->mutex; a peer-owned codec can be torn
+						 * down concurrently (the peer leg dies mid-originate), leaving a dangling
+						 * mutex and crashing write_frame(). The caller's own codec shares the
+						 * caller's lifetime and is guarded by its codec_write_mutex. */
+						switch_codec_t *caller_write_codec = switch_core_session_get_write_codec(oglobals->session);
+						if (caller_write_codec && switch_core_codec_ready(caller_write_codec) && caller_write_codec->implementation) {
+							ringback->asis++;
+							write_frame->codec = caller_write_codec;
+							write_frame->datalen = write_impl.decoded_bytes_per_packet;
+							switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(caller_channel), SWITCH_LOG_DEBUG, "bridge_early_media: passthrough enabled\n");
+						} else {
+							switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(caller_channel), SWITCH_LOG_DEBUG, "bridge_early_media: caller write codec not ready, passthrough disabled\n");
+						}
 					} else {
 						switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(caller_channel), SWITCH_LOG_DEBUG, "bridge_early_media: codecs don't match (%s@%uh@%di / %s@%uh@%di)\n",
 							read_impl.iananame, read_impl.actual_samples_per_second, read_impl.microseconds_per_packet / 1000,

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 			   switch_ivr_play_say switch_core_codec switch_rtp switch_xml
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log switch_stun switch_trickle_ice
 
-noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash
+noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec
 
 if HAVE_SOFIA_SIP
 noinst_PROGRAMS += switch_sdp

--- a/tests/unit/test_write_frame_foreign_codec.c
+++ b/tests/unit/test_write_frame_foreign_codec.c
@@ -1,0 +1,175 @@
+/*
+ * Regression test for the crash in switch_core_session_write_frame().
+ *
+ * Production stack (release build line numbers):
+ *   switch_mutex_unlock()                 switch_apr.c
+ *   switch_core_session_write_frame()     switch_core_media.c   <-- crash
+ *   switch_ivr_originate()                switch_ivr_originate.c
+ *   audio_bridge_function()               mod_dptools.c
+ *
+ * Root cause
+ * ----------
+ * switch_core_session_write_frame() does, near the top:
+ *
+ *      switch_mutex_lock(session->write_codec->mutex);
+ *      switch_mutex_lock(frame->codec->mutex);          // <-- frame->codec
+ *      ...
+ *  error:
+ *      switch_mutex_unlock(session->write_codec->mutex);
+ *      switch_mutex_unlock(frame->codec->mutex);        // <-- crash
+ *      switch_mutex_unlock(session->codec_write_mutex);
+ *
+ * It holds `session->codec_write_mutex`, which only serialises against the
+ * SAME session's codec teardown. But `frame->codec` is frequently a codec that
+ * belongs to a *different* session. In switch_ivr_originate()'s ringback /
+ * bridge_early_media path, setup_ringback() sets:
+ *
+ *      write_frame->codec = switch_core_session_get_write_codec(peer_session);
+ *
+ * so write_frame() locks/unlocks the PEER's codec mutex while holding only its
+ * own codec_write_mutex. When that peer codec is torn down concurrently (codec
+ * renegotiation, or the peer session being reaped during originate), its
+ * `mutex` field is cleared / freed, and write_frame() dereferences it after the
+ * readiness check at the top - faulting inside __pthread_mutex_lock/unlock.
+ *
+ * This is the cross-session sibling of the read_frame crash fixed in TEL-6515
+ * ("Properly lock mutexes", test_inuse_race.c): that fix made a session's own
+ * teardown take codec_read_mutex/codec_write_mutex, which closes the
+ * SAME-session race but cannot protect a codec borrowed from another session.
+ *
+ * What this test does
+ * -------------------
+ * It reproduces the exact faulting condition deterministically:
+ *
+ *   1. Originate an answered "null" session to write TO (kept alive/rwlocked).
+ *   2. Build a frame whose ->codec is a SEPARATE codec we own (standing in for
+ *      the peer's codec passed by setup_ringback()).
+ *   3. Baseline write -> succeeds, proving the frame->codec->mutex lock path is
+ *      actually exercised.
+ *   4. Simulate the codec being torn down underneath the writer by clearing its
+ *      ->mutex (this is the state switch_core_codec_destroy() leaves it in: the
+ *      whole codec struct is memset, so ->mutex is NULL). The codec is otherwise
+ *      still flagged ready, mimicking the narrow window where write_frame() has
+ *      already passed its readiness check but the codec is being destroyed.
+ *   5. Write again -> on a buggy tree write_frame() dereferences the now-NULL
+ *      frame->codec->mutex and crashes; on a fixed tree it must bail safely.
+ *
+ * Expected:
+ *   - BUGGY tree  : SIGSEGV inside switch_core_session_write_frame().
+ *   - FIXED tree  : write_frame() returns without crashing; test passes.
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+
+/* Originate one answered "null" session. Returns it rwlocked (caller unlocks). */
+static switch_core_session_t *originate_null_session(void)
+{
+	switch_core_session_t *session = NULL;
+	switch_call_cause_t cause = SWITCH_CAUSE_NONE;
+	switch_status_t status;
+
+	status = switch_ivr_originate(NULL, &session, &cause,
+								  "null/+15553334444",
+								  0, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+
+	if (status != SWITCH_STATUS_SUCCESS || !session) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "[TEST] originate failed: status=%d cause=%d\n", status, cause);
+		return NULL;
+	}
+	return session;
+}
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(write_frame_foreign_codec)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_loopback");
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(test_write_frame_codec_mutex_torndown)
+		{
+			switch_core_session_t *session_w = NULL; /* written to, stays alive */
+			switch_channel_t *channel_w = NULL;
+			switch_codec_t foreign_codec = { 0 };    /* stands in for peer's codec */
+			switch_codec_implementation_t write_impl = { 0 };
+			switch_mutex_t *saved_mutex = NULL;
+			switch_frame_t write_frame = { 0 };
+			switch_status_t status;
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "========== WRITE_FRAME FOREIGN-CODEC TEARDOWN TEST ==========\n");
+
+			/* 1. Session we write to - keep rwlocked so it stays alive/writable. */
+			session_w = originate_null_session();
+			fst_requires(session_w);
+			channel_w = switch_core_session_get_channel(session_w);
+			fst_requires(switch_core_session_get_write_impl(session_w, &write_impl) == SWITCH_STATUS_SUCCESS);
+
+			/* 2. A codec NOT owned by session_w, matching its write impl, exactly
+			 *    like the foreign codec setup_ringback() hands to write_frame(). */
+			fst_requires(switch_core_codec_init(&foreign_codec,
+												"L16", NULL, NULL,
+												write_impl.actual_samples_per_second,
+												write_impl.microseconds_per_packet / 1000,
+												write_impl.number_of_channels,
+												SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+												NULL, fst_pool) == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_core_codec_ready(&foreign_codec));
+
+			switch_zmalloc(write_frame.data, SWITCH_RECOMMENDED_BUFFER_SIZE);
+			write_frame.buflen = SWITCH_RECOMMENDED_BUFFER_SIZE;
+			write_frame.codec = &foreign_codec;
+			write_frame.datalen = foreign_codec.implementation->decoded_bytes_per_packet;
+			write_frame.samples = write_frame.datalen / 2;
+			write_frame.payload = (switch_payload_t) foreign_codec.implementation->ianacode;
+			write_frame.rate = foreign_codec.implementation->actual_samples_per_second;
+			/* zeroed data -> SLN silence; no SFF_CNG/SFF_PROXY_PACKET so write_frame()
+			 * takes the path that locks frame->codec->mutex. */
+
+			/* 3. Baseline: prove the frame->codec->mutex lock path is exercised. */
+			status = switch_core_session_write_frame(session_w, &write_frame, SWITCH_IO_FLAG_NONE, 0);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] baseline write (codec intact) returned %d - path exercised\n", status);
+
+			/* 4. Simulate the foreign codec being torn down underneath the writer:
+			 *    switch_core_codec_destroy() memsets the codec, so ->mutex becomes
+			 *    NULL. Clear it directly to freeze that state deterministically. */
+			saved_mutex = foreign_codec.mutex;
+			foreign_codec.mutex = NULL;
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] cleared frame->codec->mutex (simulated teardown); writing again...\n");
+
+			/* 5. The crash: write_frame() locks/unlocks frame->codec->mutex (NULL).
+			 *    Buggy tree -> SIGSEGV here. Fixed tree -> safe bail. */
+			status = switch_core_session_write_frame(session_w, &write_frame, SWITCH_IO_FLAG_NONE, 0);
+
+			/* Only reached on a fixed tree. */
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] write_frame survived torn-down codec (status=%d) - FIXED\n", status);
+			fst_check(status != SWITCH_STATUS_SUCCESS); /* it must NOT have written */
+
+			/* Cleanup. */
+			foreign_codec.mutex = saved_mutex;
+			switch_core_codec_destroy(&foreign_codec);
+			switch_safe_free(write_frame.data);
+			switch_channel_hangup(channel_w, SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session_w);
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "========== TEST COMPLETED ==========\n\n");
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()


### PR DESCRIPTION
## TELCORE-192: B2BUA canary crash — segfault in `switch_core_session_write_frame`

### Problem
Crash observed on canary:

```
0 __pthread_mutex_unlock_usercnt
1 fspr_thread_mutex_unlock
2 switch_mutex_unlock                 switch_apr.c
3 switch_core_session_write_frame     switch_core_media.c
4 switch_ivr_originate                switch_ivr_originate.c
5 audio_bridge_function               mod_dptools.c
```

`switch_core_session_write_frame()` locks/unlocks `frame->codec->mutex` while
holding only `session->codec_write_mutex`. That mutex serialises this session's
own codec teardown — but `frame->codec` is frequently a codec owned by a
**different** session. In the originate ringback / `bridge_early_media` path,
`setup_ringback()` set:

```c
write_frame->codec = switch_core_session_get_write_codec(peer_session);
```

so `write_frame()` ends up locking/unlocking the **peer** session's codec mutex.
When the peer leg dies mid-originate (the normal case), that codec is torn down
concurrently — its `mutex` field is cleared/freed — and the next
lock/unlock dereferences it and faults.

This is the cross-session sibling of the `read_frame` crash fixed in TEL-6515
("Properly lock mutexes"). That fix made a session's own teardown take
`codec_read_mutex`/`codec_write_mutex`, which closes the **same-session** race
but cannot protect a codec borrowed from another session.

### Fix
- **`setup_ringback()` (root cause):** in the passthrough branch the peer-read
  and caller-write impls are already verified identical, so tag the frame with
  the **caller's own** write codec instead of borrowing the peer's. This makes
  `frame->codec` and the write target the **same** session (`oglobals->session`,
  the session passed to `switch_core_session_write_frame()` in the ringback
  loop). That codec cannot be swapped or torn down underneath the writer:
  `switch_core_session_set_write_codec()` only mutates the codec while holding
  `session->codec_write_mutex`, the exact lock `write_frame()` holds for its
  whole duration, and `write_frame()` re-validates `switch_core_codec_ready()`
  under that lock before use. The cross-session lifetime hazard becomes a
  same-session one that the existing `codec_write_mutex` serialisation already
  covers.
- **`switch_core_session_write_frame()` (defense-in-depth):** snapshot
  `write_codec->mutex` and `frame->codec->mutex` into locals, bail with
  `SWITCH_STATUS_FALSE` if either is NULL, and unlock the same snapshots. This
  catches the already-NULL mutex that `switch_core_codec_destroy()` leaves and
  guarantees lock and unlock always target the same objects. It is **not** a
  general foreign-codec use-after-free guard — it does not close the window
  between the NULL-check and the lock for a codec owned by another session. The
  actual cross-session fix is the `setup_ringback()` change above.

### Scope
This PR is scoped to the `setup_ringback()` crash topology that matches the
canary stack above — that is the production path proven to hand a foreign codec
to `write_frame()`. Other direct `write_frame()` callers that may pass a
non-owned codec (e.g. `switch_ivr_bridge.c`, `mod_spandsp_fax.c`, `mod_cv`,
`mod_fsv`, `mod_dptools`) are separate paths and out of scope here; the
NULL-mutex bail gives them a soft floor but they are not audited or fixed by
this PR.

### Test
New unit test `tests/unit/test_write_frame_foreign_codec.c`
(`test_write_frame_codec_mutex_torndown`):

1. Originate an answered `null` session to write to (kept alive/rwlocked).
2. Point a frame at a separately-owned codec (stands in for the peer codec).
3. Baseline write → succeeds, proving the `frame->codec->mutex` lock path is
   exercised.
4. Clear that codec's `mutex` (the state `switch_core_codec_destroy()` leaves)
   to freeze the teardown window deterministically.
5. Write again.

Results:
- **Before the fix** (test-only commit): SIGSEGV at
  `switch_core_session_write_frame` (`switch_core_media.c:19178`,
  `switch_mutex_lock(frame->codec->mutex)`), exit 139 — reproduces the crash.
- **After the fix:** `write_frame()` bails safely (`SWITCH_STATUS_FALSE`);
  `PASSED (1/1)`, exit 0, stable across repeated runs.

Build: `libfreeswitch` rebuilt clean (no warnings, no
`-Wdeclaration-after-statement`) with both core changes.

Note: the unit test exercises the `write_frame` NULL-mutex guard (the
deterministically reproducible state). The harder production variant — peer
session pool freed and reused so `frame->codec` holds garbage — is closed by the
`setup_ringback` change (not reproducible deterministically in a unit test).
