### PR TITLE
TELCORE-212: Fix re-INVITE failure dialog preservation

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -2678,6 +2678,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 			if (msg->numeric_arg || msg->string_arg) {
 				int code = msg->numeric_arg;
 				const char *reason = NULL;
+				switch_bool_t preserve_reinvite_failure = SWITCH_FALSE;
 
 				if (code > 0) {
 					reason = msg->string_arg;
@@ -2693,6 +2694,13 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 
 				if (!code) {
 					code = 488;
+				}
+
+				if (switch_channel_test_flag(channel, CF_ANSWERED) &&
+					!zstr(msg->string_array_arg[0]) &&
+					!strcmp(msg->string_array_arg[0], SOFIA_RESPOND_REINVITE_FAILURE) &&
+					code >= 300 && code != 408 && code != 481) {
+					preserve_reinvite_failure = SWITCH_TRUE;
 				}
 
 				if (!switch_channel_test_flag(channel, CF_ANSWERED) && code >= 300) {
@@ -2805,7 +2813,9 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 								switch_core_session_pass_indication(session, SWITCH_MESSAGE_INDICATE_ANSWER);
 							}
 						} else {
-							if (msg->numeric_arg && !(switch_channel_test_flag(channel, CF_ANSWERED) && code == 488)) {
+							if (msg->numeric_arg &&
+								!(switch_channel_test_flag(channel, CF_ANSWERED) && code == 488) &&
+								!preserve_reinvite_failure) {
 								if (code > 399) {
 									switch_call_cause_t cause = sofia_glue_sip_cause_to_freeswitch(code);
 									if (code == 401 || cause == 407) cause = SWITCH_CAUSE_USER_CHALLENGE;
@@ -2826,6 +2836,11 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 									switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Cannot respond.\n");
 								}
 							} else {
+								if (preserve_reinvite_failure) {
+									switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+												  "Preserving answered dialog on re-INVITE failure "
+												  "response %d [%s]\n", code, reason);
+								}
 								nua_respond(tech_pvt->nh, code, su_strdup(nua_handle_home(tech_pvt->nh), reason),
 											SIPTAG_CONTACT_STR(tech_pvt->reply_contact),
 											TAG_IF(!zstr(extra_headers), SIPTAG_HEADER_STR(extra_headers)),

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -64,6 +64,7 @@
 #define MAX_MISMATCH_FRAMES 5
 #define MODNAME "mod_sofia"
 #define SOFIA_DEFAULT_CONTACT_USER MODNAME
+#define SOFIA_RESPOND_REINVITE_FAILURE "reinvite_failure"
 static const switch_state_handler_table_t noop_state_handler = { 0 };
 struct sofia_gateway;
 typedef struct sofia_gateway sofia_gateway_t;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -7725,6 +7725,9 @@ static void sofia_handle_sip_r_invite(switch_core_session_t *session, int status
 					msg->from = __FILE__;
 					msg->numeric_arg = status;
 					msg->string_arg = switch_core_session_strdup(other_session, phrase);
+					if (status > 299) {
+						msg->string_array_arg[0] = SOFIA_RESPOND_REINVITE_FAILURE;
+					}
 
 					if (status == 200 && switch_channel_test_flag(tech_pvt->channel, CF_T38_PASSTHRU) && has_t38) {
 						msg->pointer_arg = switch_core_session_strdup(other_session, "t38");


### PR DESCRIPTION
## Summary
- Marks failed forwarded re-INVITE/media-update responses before they are queued to the partner Sofia leg.
- Preserves already-answered dialogs for marked non-terminal re-INVITE failures instead of sending the partner leg through the generic `SWITCH_MESSAGE_INDICATE_RESPOND` hangup path.
- Leaves terminal `408` / `481` responses on the existing hangup path and keeps the pre-existing answered `488` exemption intact.

## Root cause
For proxied/media-update re-INVITEs, `sofia_handle_sip_r_invite()` forwards a failed downstream response to the other leg as `SWITCH_MESSAGE_INDICATE_RESPOND`. The receiving `mod_sofia.c` handler treats `numeric_arg > 399` as fatal, except for the narrow answered-channel `488` exemption, and calls `switch_channel_hangup()`. That makes a downstream `500 re-INVITE already in-progress` tear down an established dialog, followed by the normal Sofia answered-dialog BYE cleanup.

RFC 3261 §14.1 says a non-2xx final response to a re-INVITE leaves session parameters unchanged; only `481`, `408`, or timeout/no response should terminate the dialog.

## Fix details
- Adds a private marker for the specific forwarded failed re-INVITE response path: `SOFIA_RESPOND_REINVITE_FAILURE`.
- Sets the marker only in the `TFLAG_SENT_UPDATE` forwarding branch in `sofia_handle_sip_r_invite()`.
- In `SWITCH_MESSAGE_INDICATE_RESPOND`, skips the fatal hangup only when:
  - the channel is already answered;
  - the response carries that re-INVITE failure marker;
  - the code is `>= 300`; and
  - the code is not `408` or `481`.

## Validation
- `git diff --check` passed.
- Added a structural source check confirming:
  - marker is defined once;
  - marker is assigned once in `sofia.c`;
  - marker is checked once in `mod_sofia.c`;
  - `408` and `481` remain excluded from preservation;
  - the existing answered `488` behavior remains intact.
- Independent source review found no source-level blocker and confirmed `string_array_arg[0]` is safe for this queued message path because the value is a string literal and the message is not `SCSMF_DYNAMIC`.

## Local build note
Full local bootstrap/build was not run on this Mac mini because the checkout does not have generated build files and `./bootstrap.sh -j` is blocked by missing `autoconf`. A direct `clang -fsyntax-only` probe is likewise blocked before these files by missing generated `switch_am_config.h`.

## TELCORE-212 packet/source evidence
Observed packet sequence from the TELCORE-212 pcap:
- in-dialog `INVITE` CSeq `116043443`;
- `500 re-INVITE already in-progress` with `Retry-After: 4`;
- ACK;
- immediate BYE from B2BUA.

The code path patched here is the source path that turns that failed re-INVITE response into the local hangup/BYE.
