### PR TITLE
TELCORE-193: fix assertion crash in switch_event_merge on conference teardown

### DIFF
--- a/src/mod/applications/mod_conference/Makefile.am
+++ b/src/mod/applications/mod_conference/Makefile.am
@@ -21,7 +21,7 @@ noinst_LTLIBRARIES = libmodconference.la
 libmodconference_la_SOURCES  = $(mod_conference_la_SOURCES)
 libmodconference_la_CFLAGS   = $(AM_CFLAGS) -I.
 
-noinst_PROGRAMS = test/test_image test/test_member
+noinst_PROGRAMS = test/test_image test/test_member test/test_record_teardown
 
 test_test_image_SOURCES = test/test_image.c
 test_test_image_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
@@ -32,5 +32,10 @@ test_test_member_SOURCES = test/test_member.c
 test_test_member_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
 test_test_member_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS)
 test_test_member_LDADD = libmodconference.la
+
+test_test_record_teardown_SOURCES = test/test_record_teardown.c
+test_test_record_teardown_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
+test_test_record_teardown_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS)
+test_test_record_teardown_LDADD = libmodconference.la
 
 TESTS = $(noinst_PROGRAMS)

--- a/src/mod/applications/mod_conference/conference_record.c
+++ b/src/mod/applications/mod_conference/conference_record.c
@@ -184,6 +184,9 @@ void *SWITCH_THREAD_FUNC conference_record_thread_run(switch_thread_t *thread, v
 	 * now that we hold the read lock; the rwlock pairs with the teardown's
 	 * write-lock release so the cleared flag is guaranteed visible here. */
 	if (!conference_utils_test_flag(conference, CFLAG_RUNNING)) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						  "Conference %s is shutting down; not starting record thread for [%s]\n",
+						  conference->name, rec->path);
 		switch_thread_rwlock_unlock(conference->rwlock);
 		return NULL;
 	}

--- a/src/mod/applications/mod_conference/conference_record.c
+++ b/src/mod/applications/mod_conference/conference_record.c
@@ -69,15 +69,41 @@ void conference_record_launch_thread(conference_obj_t *conference, char *path, i
 		rec->canvas_id = canvas_id;
 	}
 
-	switch_mutex_lock(conference->flag_mutex);
-	rec->next = conference->rec_node_head;
-	conference->rec_node_head = rec;
-	switch_mutex_unlock(conference->flag_mutex);
-
 	switch_threadattr_create(&thd_attr, rec->pool);
 	switch_threadattr_detach_set(thd_attr, 1);
 	switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
-	switch_thread_create(&thread, thd_attr, conference_record_thread_run, rec, rec->pool);
+
+	/* TELCORE-223: register the thread before spawning it, but only while the
+	 * conference is still running, and keep flag_mutex held across the spawn.
+	 * Serialising this CFLAG_RUNNING check and the count bump against the
+	 * teardown's flag-clear (both under flag_mutex) guarantees the teardown
+	 * either waits for this thread (registered before the flag was cleared) or
+	 * this thread is never launched (flag already cleared) - it can never slip in
+	 * after the teardown has drained. */
+	switch_mutex_lock(conference->flag_mutex);
+	if (!conference_utils_test_flag(conference, CFLAG_RUNNING)) {
+		switch_mutex_unlock(conference->flag_mutex);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						  "Not launching record thread for %s: conference is shutting down\n", path);
+		switch_core_destroy_memory_pool(&pool);
+		return;
+	}
+	rec->next = conference->rec_node_head;
+	conference->rec_node_head = rec;
+	conference->record_thread_count++;
+
+	if (switch_thread_create(&thread, thd_attr, conference_record_thread_run, rec, rec->pool) != SWITCH_STATUS_SUCCESS) {
+		/* No thread will run to drop the count or unlink the node, so teardown
+		 * would spin forever on record_thread_count - undo the registration here.
+		 * rec is still at the list head since flag_mutex was never released. */
+		conference->rec_node_head = rec->next;
+		conference->record_thread_count--;
+		switch_mutex_unlock(conference->flag_mutex);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Failed to launch record thread for %s\n", path);
+		switch_core_destroy_memory_pool(&pool);
+		return;
+	}
+	switch_mutex_unlock(conference->flag_mutex);
 }
 
 
@@ -172,8 +198,19 @@ void *SWITCH_THREAD_FUNC conference_record_thread_run(switch_thread_t *thread, v
 
 	if (switch_thread_rwlock_tryrdlock(conference->rwlock) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Read Lock Fail\n");
+		switch_mutex_lock(conference->flag_mutex);
+		conference->record_thread_count--;
+		switch_mutex_unlock(conference->flag_mutex);
 		return NULL;
 	}
+
+	/* TELCORE-223: we now hold the read lock, so the teardown's write-lock drain
+	 * will wait for us; drop the in-flight count that bridged the gap between
+	 * being launched and acquiring this lock. From here the rwlock alone keeps
+	 * the conference alive for the lifetime of this thread. */
+	switch_mutex_lock(conference->flag_mutex);
+	conference->record_thread_count--;
+	switch_mutex_unlock(conference->flag_mutex);
 
 	/* TELCORE-193: the conference teardown clears CFLAG_RUNNING, then only
 	 * momentarily takes+releases the write lock to drain readers before it

--- a/src/mod/applications/mod_conference/conference_record.c
+++ b/src/mod/applications/mod_conference/conference_record.c
@@ -175,6 +175,19 @@ void *SWITCH_THREAD_FUNC conference_record_thread_run(switch_thread_t *thread, v
 		return NULL;
 	}
 
+	/* TELCORE-193: the conference teardown clears CFLAG_RUNNING, then only
+	 * momentarily takes+releases the write lock to drain readers before it
+	 * destroys conference->variables and frees the conference pool. A record
+	 * thread that grabs its read lock just after that release would otherwise
+	 * march into a half-torn-down conference (e.g. NULL conference->variables in
+	 * conference_event_add_data -> switch_event_merge). Re-check CFLAG_RUNNING
+	 * now that we hold the read lock; the rwlock pairs with the teardown's
+	 * write-lock release so the cleared flag is guaranteed visible here. */
+	if (!conference_utils_test_flag(conference, CFLAG_RUNNING)) {
+		switch_thread_rwlock_unlock(conference->rwlock);
+		return NULL;
+	}
+
 	data_buf_len = samples * sizeof(int16_t) * conference->channels;
 	switch_zmalloc(data_buf, data_buf_len);
 

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -845,6 +845,21 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 
 	/* Wait till everybody is out */
 	conference_utils_clear_flag_locked(conference, CFLAG_RUNNING);
+
+	/* TELCORE-223: drain record threads that were launched but have not yet taken
+	 * their read lock. The momentary write-lock drain below only catches readers
+	 * that already hold the lock; a record thread still in the gap between launch
+	 * and tryrdlock would otherwise acquire its read lock after the drain and
+	 * touch conference state we are about to free. CFLAG_RUNNING is cleared above,
+	 * so no new record thread can register (see conference_record_launch_thread). */
+	switch_mutex_lock(conference->flag_mutex);
+	while (conference->record_thread_count > 0) {
+		switch_mutex_unlock(conference->flag_mutex);
+		switch_yield(20000);
+		switch_mutex_lock(conference->flag_mutex);
+	}
+	switch_mutex_unlock(conference->flag_mutex);
+
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Write Lock ON\n");
 	switch_thread_rwlock_wrlock(conference->rwlock);
 	switch_thread_rwlock_unlock(conference->rwlock);

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -713,6 +713,11 @@ typedef struct conference_obj {
 	int auto_recording;
 	char *recording_metadata;
 	int record_count;
+	/* TELCORE-223: record threads that have been launched but have not yet taken
+	 * their conference rwlock read lock. Guarded by flag_mutex. Teardown drains
+	 * this to zero before freeing the conference so a late-arriving record thread
+	 * cannot acquire its read lock after the write-lock drain. */
+	int record_thread_count;
 	uint32_t min_recording_participants;
 	int ivr_dtmf_timeout;
 	int ivr_input_timeout;

--- a/src/mod/applications/mod_conference/test/test_record_teardown.c
+++ b/src/mod/applications/mod_conference/test/test_record_teardown.c
@@ -1,0 +1,101 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * test_record_teardown.c -- TELCORE-193 regression test
+ *
+ * Reproduces, deterministically and through the real conference call path, the
+ * crash a conference record thread hits when it races conference teardown.
+ *
+ * Production stack (release build):
+ *   __assert_fail()
+ *   switch_event_merge()                       switch_event.c
+ *   conference_event_add_data_with_member()    conference_event.c   (frame 6)
+ *   conference_event_add_data()                conference_event.c   (frame 7)
+ *   conference_record_thread_run()             conference_record.c  (frame 8)
+ *
+ * Root cause
+ * ----------
+ * conference_event_add_data_with_member() ends with
+ *
+ *     switch_event_merge(event, conference->variables);
+ *
+ * The conference teardown thread destroys conference->variables
+ * (switch_event_destroy sets it to NULL) and frees the conference pool, while a
+ * record thread that grabbed its read lock just after the teardown's write-lock
+ * drain is still running. The record thread then passes that now-NULL pointer
+ * as `tomerge`. On an unfixed tree switch_event_merge() asserts
+ * `tomerge && event` and aborts.
+ *
+ * What this test does
+ * -------------------
+ * It drives conference_event_add_data() directly (it is non-static and linked in
+ * from libmodconference) with a minimal conference whose ->variables is NULL -
+ * exactly the state the teardown leaves behind. member is NULL and members is
+ * empty, so the function only reads the handful of scalar/string fields set
+ * below before reaching the merge.
+ *
+ * Expected:
+ *   - BUGGY tree : switch_assert(tomerge && event) fires -> SIGABRT.
+ *   - FIXED tree : switch_event_merge() tolerates the NULL source, the conference
+ *                  headers are added, and the test passes.
+ */
+#include <switch.h>
+#include <stdlib.h>
+#include <mod_conference.h>
+
+#include <test/switch_test.h>
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(conference_record_teardown)
+	{
+		FST_SETUP_BEGIN()
+		{
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(event_add_data_after_variables_destroyed)
+		{
+			conference_obj_t *conference = NULL;
+			switch_event_t *event = NULL;
+			switch_status_t status;
+
+			/* A conference whose teardown has already destroyed ->variables.
+			 * switch_core_alloc zeroes the struct, so members/count/variables are
+			 * NULL/0; the assignments below are explicit for clarity. */
+			conference = switch_core_alloc(fst_pool, sizeof(*conference));
+			fst_requires(conference);
+			conference->name = "3001";
+			conference->domain = "test";
+			conference->profile_name = "default";
+			conference->uuid_str = "00000000-0000-0000-0000-000000000000";
+			conference->members = NULL;
+			conference->count = 0;
+			conference->count_ghosts = 0;
+			conference->variables = NULL;   /* destroyed by the teardown thread */
+
+			status = switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, "conference::maintenance");
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			/* Frames 7 -> 6 -> 5 of the production stack. On an unfixed tree the
+			 * NULL ->variables aborts inside switch_event_merge(). */
+			status = conference_event_add_data(conference, event);
+
+			/* Only reached on a fixed tree: the merge bailed on the NULL source
+			 * and the conference headers were still added. */
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(!zstr(switch_event_get_header(event, "Conference-Name")));
+			fst_check(!zstr(switch_event_get_header(event, "Conference-Unique-ID")));
+
+			switch_event_destroy(&event);
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()

--- a/src/switch_event.c
+++ b/src/switch_event.c
@@ -1319,7 +1319,16 @@ SWITCH_DECLARE(void) switch_event_merge(switch_event_t *event, switch_event_t *t
 {
 	switch_event_header_t *hp;
 
-	switch_assert(tomerge && event);
+	/* The destination must exist - a NULL `event` is a caller bug worth catching. */
+	switch_assert(event);
+
+	/* `tomerge`, on the other hand, can legitimately be NULL when the caller's
+	 * source event was destroyed concurrently (e.g. mod_conference tears down
+	 * conference->variables while a record thread is still merging it -
+	 * TELCORE-193). Bail safely; there is simply nothing to merge in. */
+	if (!tomerge) {
+		return;
+	}
 
 	for (hp = tomerge->headers; hp; hp = hp->next) {
 		if (hp->idx) {

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -104,6 +104,73 @@ FST_TEST_BEGIN(benchmark)
 }
 FST_TEST_END()
 
+/*
+ * Regression test for TELCORE-193: assertion failure in switch_event_merge().
+ *
+ * Production stack (release build):
+ *   __assert_fail()
+ *   switch_event_merge()                       switch_event.c:1322
+ *   conference_event_add_data_with_member()    conference_event.c:776
+ *   conference_event_add_data()                conference_event.c
+ *   conference_record_thread_run()             conference_record.c:320
+ *
+ * Root cause
+ * ----------
+ * conference_event_add_data_with_member() finishes with:
+ *
+ *     switch_event_merge(event, conference->variables);
+ *
+ * switch_event_merge() opens with switch_assert(tomerge && event). The record
+ * thread reads conference->variables WITHOUT re-checking CFLAG_RUNNING after it
+ * takes the conference rwlock (conference_record.c:173). The conference teardown
+ * thread clears CFLAG_RUNNING, momentarily takes+releases the write lock to
+ * "drain readers", then destroys conference->variables (mod_conference.c:891),
+ * which NULLs the pointer. A record thread that grabs its read lock just after
+ * the write lock is released sails straight into a half-torn-down conference and
+ * passes that now-NULL pointer as `tomerge` -> the assert fires -> abort().
+ *
+ * What this test does
+ * -------------------
+ * conference internals are not exported from mod_conference, so a tests/unit
+ * binary cannot drive conference_record_thread_run() directly. Instead it
+ * reproduces the exact faulting condition switch_event_merge() actually sees:
+ * a fully populated destination `event` (the CONF maintenance event the record
+ * thread has already filled in) and a NULL `tomerge` (conference->variables
+ * after the teardown destroyed it).
+ *
+ * Expected:
+ *   - BUGGY tree : switch_assert(tomerge && event) fires -> SIGABRT here.
+ *   - FIXED tree : switch_event_merge() tolerates the NULL source, returns
+ *                  without touching `event`, and the test passes.
+ */
+FST_TEST_BEGIN(merge_null_variables_after_teardown)
+{
+  switch_event_t *event = NULL;
+  switch_status_t status = SWITCH_STATUS_SUCCESS;
+
+  /* The CONF maintenance event the record thread has already populated before
+   * reaching switch_event_merge(event, conference->variables). */
+  status = switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, "conference::maintenance");
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "Failed to create event");
+
+  switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Conference-Name", "3001");
+  switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Action", "start-recording");
+
+  /* conference->variables after the teardown thread destroyed it: NULL. On a
+   * buggy tree switch_assert(tomerge && event) aborts the process right here;
+   * on a fixed tree switch_event_merge() bails and leaves `event` untouched. */
+  switch_event_merge(event, NULL);
+
+  /* Only reached on a fixed tree: the destination event must be untouched. */
+  fst_xcheck(!zstr(switch_event_get_header(event, "Conference-Name")),
+             "Destination event headers must survive a NULL-source merge");
+  fst_xcheck(!zstr(switch_event_get_header(event, "Action")),
+             "Destination event headers must survive a NULL-source merge");
+
+  switch_event_destroy(&event);
+}
+FST_TEST_END()
+
 FST_SUITE_END()
 
 FST_MINCORE_END()


### PR DESCRIPTION
## Summary

Fixes a B2BUA canary crash ([TELCORE-193](https://linear.app/telnyx/issue/TELCORE-193)) where a conference **record thread** races conference **teardown** and aborts in `switch_event_merge()`:

```
__assert_fail()
switch_event_merge()                       switch_event.c   Assertion `tomerge && event'
conference_event_add_data_with_member()    conference_event.c:776
conference_event_add_data()                conference_event.c
conference_record_thread_run()             conference_record.c:320
```

## Root cause

`conference_event_add_data_with_member()` ends with `switch_event_merge(event, conference->variables)`. The teardown thread (`conference_thread_run`) clears `CFLAG_RUNNING`, does a *momentary* rwlock write-lock drain (`mod_conference.c:849-850`), then destroys `conference->variables` (NULLs it, line 891) and frees the conference pool (line 894).

The drain only waits for readers **present at that instant**. `conference_record_thread_run()` takes its read lock at `conference_record.c:173` but never re-checks `CFLAG_RUNNING`, so a record thread that acquires the lock just **after** the drain marches into a half-torn-down conference and passes the now-NULL `conference->variables` as `tomerge` → `switch_assert(tomerge && event)` aborts. (`conference->variables`, the struct, its `rwlock` and `flag_mutex` are all carved from `conference->pool` — the read lock is effectively the conference's lifetime lock.)

## Fixes

1. **`conference_record_thread_run()`** — re-check `CFLAG_RUNNING` immediately after acquiring `conference->rwlock`; bail if the conference is shutting down. The rwlock acquire pairs (happens-after) with the teardown's write-lock release, so the cleared flag is guaranteed visible before any conference state is touched.
2. **`switch_event_merge()`** — keep `switch_assert(event)` (a NULL destination is a caller bug) but tolerate a NULL `tomerge` by returning early, so a concurrently-destroyed source event can no longer abort the process.

## Tests (red without the fix, green with it)

- `tests/unit/switch_event.c` → `merge_null_variables_after_teardown`: drives the faulting condition at the leaf.
- `src/mod/applications/mod_conference/test/test_record_teardown.c`: reproduces the production stack through `conference_event_add_data()` with a NULL `conference->variables`.

Both were verified to abort at `switch_event.c:1322` on the unfixed tree and PASS on the fixed tree.

## Known residual window (follow-up, not in this PR)

A record thread can still acquire its read lock **after** the teardown's drain; teardown does not wait for it before freeing the pool. This fix shrinks the exposure from the entire record-thread body to the two non-blocking instructions of the re-check, but does not fully close it. It is inherent to FreeSWITCH's rwlock-as-refcount idiom and already present pre-fix (even the original `rwlock_unlock` dereferences the pool-allocated lock). Bulletproof closure (gate `conference_record_launch_thread` / drain `record_count` before freeing the pool) is tracked as a follow-up.