### PR TITLE
TELCORE-219: Fix 8-byte payload truncation on RTP header-extension forward

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -9721,7 +9721,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_zerocopy_read_frame(switch_rtp_t *rtp
 	} else {
 
 		frame->packet = &rtp_session->recv_msg;
-		frame->packetlen = bytes + rtp_session->recv_rtp_exts_size;
+		frame->packetlen = rtp_session->last_recv_bytes;
 		frame->source = __FILE__;
 
 		switch_set_flag(frame, SFF_RAW_RTP);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -9721,9 +9721,18 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_zerocopy_read_frame(switch_rtp_t *rtp
 	} else {
 
 		frame->packet = &rtp_session->recv_msg;
-		/* Full datagram length of the returned packet (payload offset + payload), derived from
-		 * the frame itself so JB reordering / fork rx/tx can't desync it like last_recv_bytes. */
-		frame->packetlen = (uint32_t)((char *)frame->data - (char *)&rtp_session->recv_msg) + (bytes - rtp_header_len);
+		/* read_rtp_packet strips only the RTP header extension from `bytes` (which still
+		 * includes header + CSRC + payload). Add just the extension back, derived from the
+		 * returned frame's payload offset, so packetlen is the full datagram length: correct
+		 * for any extension size, does not double-count CSRC, and -- being taken from the
+		 * returned frame rather than session state -- stays correct under jitter-buffer
+		 * reordering / fork rx/tx. */
+		{
+			uint32_t csrc_len = rtp_session->recv_msg.header.cc * 4;
+			uint32_t payload_offset = (uint32_t)((char *)frame->data - (char *)&rtp_session->recv_msg);
+			uint32_t ext_len = payload_offset >= (uint32_t)(rtp_header_len + csrc_len) ? payload_offset - rtp_header_len - csrc_len : 0;
+			frame->packetlen = bytes + ext_len;
+		}
 		frame->source = __FILE__;
 
 		switch_set_flag(frame, SFF_RAW_RTP);
@@ -11303,9 +11312,10 @@ SWITCH_DECLARE(void) switch_rtp_handle_extensions(switch_rtp_t *rtp_session)
 {
 	if (!rtp_session->has_rtp) return;
 
-	if (rtp_session->recv_msg.header.cc > 0) {
-		rtp_session->recv_msg.ebody = RTP_BODY(rtp_session) + (rtp_session->recv_msg.header.cc * 4);
-	}
+	/* Do not advance recv_msg.ebody past the CSRC list here; read_rtp_packet() does that
+	 * once. Advancing it in both places double-counted CSRC, mislocating the extension so
+	 * it was never reliably stripped when cc > 0. This function only needs to *read* the
+	 * extension, so it locates it at body + CSRC locally below. */
 
 	if (rtp_session->recv_rtp_exts_size && !rtp_session->recv_msg.header.x) {
 		rtp_session->recv_rtp_exts_size = 0;
@@ -11324,7 +11334,7 @@ SWITCH_DECLARE(void) switch_rtp_handle_extensions(switch_rtp_t *rtp_session)
 		uint16_t ext_payload_len = 0;
 		uint32_t ssrc_recv = ntohl(rtp_session->recv_msg.header.ssrc);
 
-		rtp_session->recv_msg.ext = (switch_rtp_hdr_ext_t *) RTP_BODY(rtp_session);
+		rtp_session->recv_msg.ext = (switch_rtp_hdr_ext_t *) (RTP_BODY(rtp_session) + (rtp_session->recv_msg.header.cc * 4));
 		ext_len_field = ntohs(rtp_session->recv_msg.ext->length);
 
 		if (ext_len_field > 0) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -9721,7 +9721,9 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_zerocopy_read_frame(switch_rtp_t *rtp
 	} else {
 
 		frame->packet = &rtp_session->recv_msg;
-		frame->packetlen = rtp_session->last_recv_bytes;
+		/* Full datagram length of the returned packet (payload offset + payload), derived from
+		 * the frame itself so JB reordering / fork rx/tx can't desync it like last_recv_bytes. */
+		frame->packetlen = (uint32_t)((char *)frame->data - (char *)&rtp_session->recv_msg) + (bytes - rtp_header_len);
 		frame->source = __FILE__;
 
 		switch_set_flag(frame, SFF_RAW_RTP);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -9721,7 +9721,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_zerocopy_read_frame(switch_rtp_t *rtp
 	} else {
 
 		frame->packet = &rtp_session->recv_msg;
-		frame->packetlen = bytes;
+		frame->packetlen = bytes + rtp_session->recv_rtp_exts_size;
 		frame->source = __FILE__;
 
 		switch_set_flag(frame, SFF_RAW_RTP);

--- a/tests/unit/switch_rtp_pcap.c
+++ b/tests/unit/switch_rtp_pcap.c
@@ -649,6 +649,72 @@ FST_TEARDOWN_END()
 		rtp_test_end_call(&session);
 	}
 	FST_TEST_END()
+
+	FST_TEST_BEGIN(test_rtp_header_extension_passthrough_length_csrc)
+	{
+		switch_core_session_t *session = NULL;
+		switch_status_t status;
+		switch_socket_t *sock_rtp = NULL;
+		switch_sockaddr_t *sock_addr = NULL;
+		const char *str_err = NULL;
+		switch_frame_t rframe = { 0 };
+		const int payload_len = 20;
+		const int cc = 2;
+		const int csrc_len = cc * 4;                          /* 8 */
+		const int ext_len = 8;                               /* 0xbede, 1 word */
+		const int full_len = 12 + csrc_len + ext_len + payload_len;   /* 48 */
+		const int exp_datalen = csrc_len + payload_len;      /* current read leaves CSRC in datalen */
+		unsigned char pkt[12 + 8 + 8 + 20];
+		switch_size_t tmp_len;
+		int n = 0, i, x, got = 0;
+
+		status = rtp_test_start_call(&session);
+		fst_requires(status == SWITCH_STATUS_SUCCESS);
+		fst_requires(session);
+		rtp_session = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO);
+		fst_requires(rtp_session);
+		switch_rtp_clear_flag(rtp_session, SWITCH_RTP_FLAG_PAUSE);
+
+		if (switch_socket_create(&sock_rtp, AF_INET, SOCK_DGRAM, 0, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
+			fst_requires(0);
+		}
+		switch_sockaddr_new(&sock_addr, rx_host, audio_rx_port, switch_core_session_get_pool(session));
+		fst_requires(sock_addr);
+		switch_rtp_set_remote_address(rtp_session, tx_host, switch_sockaddr_get_port(sock_addr), 0, SWITCH_FALSE, &str_err);
+		switch_rtp_reset(rtp_session);
+
+		memset(pkt, 0, sizeof(pkt));
+		pkt[0] = 0x92; pkt[1] = 0x00;                        /* V=2, X=1, CC=2, pt=0 */
+		pkt[2] = 0x03; pkt[3] = 0x00;                        /* seq */
+		pkt[4] = 0x00; pkt[5] = 0x00; pkt[6] = 0x1e; pkt[7] = 0x00; /* ts */
+		pkt[8] = 0x61; pkt[9] = 0x5a; pkt[10] = 0xe1; pkt[11] = 0x37; /* ssrc */
+		n = 12;
+		for (i = 0; i < csrc_len; i++) pkt[n++] = (unsigned char)(0xa0 + i);   /* 2 CSRC */
+		pkt[n++] = 0xbe; pkt[n++] = 0xde; pkt[n++] = 0x00; pkt[n++] = 0x01;    /* ext: 1 word */
+		pkt[n++] = 0x10; pkt[n++] = 0x64; pkt[n++] = 0x00; pkt[n++] = 0x00;
+		for (i = 0; i < payload_len; i++) pkt[n++] = (unsigned char)(0x80 + i);
+
+		for (x = 0; x < 100 && !got; x++) {
+			tmp_len = full_len;
+			if (switch_socket_sendto(sock_rtp, sock_addr, MSG_CONFIRM, (const char *)pkt, &tmp_len) != SWITCH_STATUS_SUCCESS) {
+				fst_requires(0);
+			}
+			memset(&rframe, 0, sizeof(rframe));
+			if (switch_rtp_zerocopy_read_frame(rtp_session, &rframe, io_flags) == SWITCH_STATUS_SUCCESS
+				&& rframe.datalen == (uint32_t)exp_datalen) {
+				got = 1;
+			} else {
+				switch_yield(20000);
+			}
+		}
+
+		fst_xcheck(got == 1, "received the injected RTP packet with CSRC + extension");
+		fst_xcheck(rframe.packetlen == (uint32_t)full_len,
+			"packetlen must equal full wire length with CSRC + extension (must not double-count CSRC)");
+
+		rtp_test_end_call(&session);
+	}
+	FST_TEST_END()
 }
 FST_SUITE_END()
 }

--- a/tests/unit/switch_rtp_pcap.c
+++ b/tests/unit/switch_rtp_pcap.c
@@ -574,61 +574,6 @@ FST_TEARDOWN_END()
 	}
 	FST_TEST_END()
 
-	FST_TEST_BEGIN(test_rtp_header_extension_passthrough_length)
-	{
-		switch_core_session_t *session = NULL;
-		switch_status_t status;
-		switch_socket_t *sock_rtp = NULL;
-		switch_sockaddr_t *sock_addr = NULL;
-		const char *str_err = NULL;
-		switch_frame_t rframe = { 0 };
-		const int payload_len = 20;
-		const int full_len = 12 + 8 + 20;
-		unsigned char pkt[12 + 8 + 20] = { 0x90,0x00,0xcd,0x16, 0x00,0x01,0x00,0x00, 0x61,0x5a,0xe1,0x37, 0xbe,0xde,0x00,0x01, 0x10,0x64,0x00,0x00 };
-		switch_size_t tmp_len;
-		int x, got = 0;
-
-		status = rtp_test_start_call(&session);
-		fst_requires(status == SWITCH_STATUS_SUCCESS);
-		fst_requires(session);
-
-		rtp_session = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO);
-		fst_requires(rtp_session);
-		switch_rtp_clear_flag(rtp_session, SWITCH_RTP_FLAG_PAUSE);
-
-		if (switch_socket_create(&sock_rtp, AF_INET, SOCK_DGRAM, 0, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
-			fst_requires(0);
-		}
-		switch_sockaddr_new(&sock_addr, rx_host, audio_rx_port, switch_core_session_get_pool(session));
-		fst_requires(sock_addr);
-		switch_rtp_set_remote_address(rtp_session, tx_host, switch_sockaddr_get_port(sock_addr), 0, SWITCH_FALSE, &str_err);
-		switch_rtp_reset(rtp_session);
-
-		for (x = 0; x < payload_len; x++) pkt[20 + x] = (unsigned char)(x + 1);
-
-		for (x = 0; x < 100 && !got; x++) {
-			tmp_len = full_len;
-			if (switch_socket_sendto(sock_rtp, sock_addr, MSG_CONFIRM, (const char *)pkt, &tmp_len) != SWITCH_STATUS_SUCCESS) {
-				fst_requires(0);
-			}
-			memset(&rframe, 0, sizeof(rframe));
-			if (switch_rtp_zerocopy_read_frame(rtp_session, &rframe, io_flags) == SWITCH_STATUS_SUCCESS
-				&& rframe.datalen == (uint32_t)payload_len) {
-				got = 1;
-			} else {
-				switch_yield(20000);
-			}
-		}
-
-		fst_xcheck(got == 1, "received the injected RTP-with-extension packet");
-		fst_xcheck(rframe.datalen == (uint32_t)payload_len, "datalen is the payload length (extension excluded)");
-		fst_xcheck(rframe.packetlen == (uint32_t)full_len,
-			"frame->packetlen must include the RTP header extension; a short value truncates the payload on raw forward");
-
-		rtp_test_end_call(&session);
-	}
-	FST_TEST_END()
-
 	FST_TEST_BEGIN(test_rtp_header_extension_passthrough_length_edge_cases)
 	{
 		switch_core_session_t *session = NULL;
@@ -638,7 +583,7 @@ FST_TEARDOWN_END()
 		const char *str_err = NULL;
 		switch_frame_t rframe = { 0 };
 		const int payload_len = 20;
-		int cases[] = { 1, 0, 3, 0, 2, 0 };   /* 1->0 and 3->0 exercise stale recv_rtp_exts_size */
+		int cases[] = { 1, 0, 3, 0, 2, 0 };   /* mixed extension sizes; 1->0 and 3->0 catch a length derived from stale per-session state */
 		int ncases = (int)(sizeof(cases) / sizeof(cases[0]));
 		uint16_t seq = 0x200;
 		uint32_t tsv = 960;

--- a/tests/unit/switch_rtp_pcap.c
+++ b/tests/unit/switch_rtp_pcap.c
@@ -573,6 +573,61 @@ FST_TEARDOWN_END()
 		fst_check(got_media_timeout);
 	}
 	FST_TEST_END()
+
+	FST_TEST_BEGIN(test_rtp_header_extension_passthrough_length)
+	{
+		switch_core_session_t *session = NULL;
+		switch_status_t status;
+		switch_socket_t *sock_rtp = NULL;
+		switch_sockaddr_t *sock_addr = NULL;
+		const char *str_err = NULL;
+		switch_frame_t rframe = { 0 };
+		const int payload_len = 20;
+		const int full_len = 12 + 8 + 20;
+		unsigned char pkt[12 + 8 + 20] = { 0x90,0x00,0xcd,0x16, 0x00,0x01,0x00,0x00, 0x61,0x5a,0xe1,0x37, 0xbe,0xde,0x00,0x01, 0x10,0x64,0x00,0x00 };
+		switch_size_t tmp_len;
+		int x, got = 0;
+
+		status = rtp_test_start_call(&session);
+		fst_requires(status == SWITCH_STATUS_SUCCESS);
+		fst_requires(session);
+
+		rtp_session = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO);
+		fst_requires(rtp_session);
+		switch_rtp_clear_flag(rtp_session, SWITCH_RTP_FLAG_PAUSE);
+
+		if (switch_socket_create(&sock_rtp, AF_INET, SOCK_DGRAM, 0, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
+			fst_requires(0);
+		}
+		switch_sockaddr_new(&sock_addr, rx_host, audio_rx_port, switch_core_session_get_pool(session));
+		fst_requires(sock_addr);
+		switch_rtp_set_remote_address(rtp_session, tx_host, switch_sockaddr_get_port(sock_addr), 0, SWITCH_FALSE, &str_err);
+		switch_rtp_reset(rtp_session);
+
+		for (x = 0; x < payload_len; x++) pkt[20 + x] = (unsigned char)(x + 1);
+
+		for (x = 0; x < 100 && !got; x++) {
+			tmp_len = full_len;
+			if (switch_socket_sendto(sock_rtp, sock_addr, MSG_CONFIRM, (const char *)pkt, &tmp_len) != SWITCH_STATUS_SUCCESS) {
+				fst_requires(0);
+			}
+			memset(&rframe, 0, sizeof(rframe));
+			if (switch_rtp_zerocopy_read_frame(rtp_session, &rframe, io_flags) == SWITCH_STATUS_SUCCESS
+				&& rframe.datalen == (uint32_t)payload_len) {
+				got = 1;
+			} else {
+				switch_yield(20000);
+			}
+		}
+
+		fst_xcheck(got == 1, "received the injected RTP-with-extension packet");
+		fst_xcheck(rframe.datalen == (uint32_t)payload_len, "datalen is the payload length (extension excluded)");
+		fst_xcheck(rframe.packetlen == (uint32_t)full_len,
+			"frame->packetlen must include the RTP header extension; a short value truncates the payload on raw forward");
+
+		rtp_test_end_call(&session);
+	}
+	FST_TEST_END()
 }
 FST_SUITE_END()
 }

--- a/tests/unit/switch_rtp_pcap.c
+++ b/tests/unit/switch_rtp_pcap.c
@@ -628,6 +628,82 @@ FST_TEARDOWN_END()
 		rtp_test_end_call(&session);
 	}
 	FST_TEST_END()
+
+	FST_TEST_BEGIN(test_rtp_header_extension_passthrough_length_edge_cases)
+	{
+		switch_core_session_t *session = NULL;
+		switch_status_t status;
+		switch_socket_t *sock_rtp = NULL;
+		switch_sockaddr_t *sock_addr = NULL;
+		const char *str_err = NULL;
+		switch_frame_t rframe = { 0 };
+		const int payload_len = 20;
+		int cases[] = { 1, 0, 3, 0, 2, 0 };   /* 1->0 and 3->0 exercise stale recv_rtp_exts_size */
+		int ncases = (int)(sizeof(cases) / sizeof(cases[0]));
+		uint16_t seq = 0x200;
+		uint32_t tsv = 960;
+		int ci, x, fail = 0;
+
+		status = rtp_test_start_call(&session);
+		fst_requires(status == SWITCH_STATUS_SUCCESS);
+		fst_requires(session);
+		rtp_session = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO);
+		fst_requires(rtp_session);
+		switch_rtp_clear_flag(rtp_session, SWITCH_RTP_FLAG_PAUSE);
+
+		if (switch_socket_create(&sock_rtp, AF_INET, SOCK_DGRAM, 0, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
+			fst_requires(0);
+		}
+		switch_sockaddr_new(&sock_addr, rx_host, audio_rx_port, switch_core_session_get_pool(session));
+		fst_requires(sock_addr);
+		switch_rtp_set_remote_address(rtp_session, tx_host, switch_sockaddr_get_port(sock_addr), 0, SWITCH_FALSE, &str_err);
+		switch_rtp_reset(rtp_session);
+
+		for (ci = 0; ci < ncases; ci++) {
+			int ew = cases[ci];
+			int extlen = 4 + ew * 4;                 /* 0xbede header(4) + ew words of data */
+			int full = 12 + extlen + payload_len;
+			unsigned char pkt[12 + 4 + 64 * 4 + 20];
+			switch_size_t tmp_len;
+			int n = 0, i, got = 0;
+
+			memset(pkt, 0, sizeof(pkt));
+			pkt[0] = 0x90; pkt[1] = 0x00;            /* V=2, X=1, pt=0 */
+			pkt[2] = (seq >> 8) & 0xff; pkt[3] = seq & 0xff;
+			pkt[4] = (tsv >> 24) & 0xff; pkt[5] = (tsv >> 16) & 0xff; pkt[6] = (tsv >> 8) & 0xff; pkt[7] = tsv & 0xff;
+			pkt[8] = 0x61; pkt[9] = 0x5a; pkt[10] = 0xe1; pkt[11] = 0x37;
+			n = 12;
+			pkt[n++] = 0xbe; pkt[n++] = 0xde; pkt[n++] = (ew >> 8) & 0xff; pkt[n++] = ew & 0xff;
+			for (i = 0; i < ew * 4; i++) pkt[n++] = (i == 0) ? 0x10 : (unsigned char)(0x40 + i);
+			for (i = 0; i < payload_len; i++) pkt[n++] = (unsigned char)(0x80 + i);
+			seq++; tsv += 160;
+
+			for (x = 0; x < 100 && !got; x++) {
+				tmp_len = full;
+				if (switch_socket_sendto(sock_rtp, sock_addr, MSG_CONFIRM, (const char *)pkt, &tmp_len) != SWITCH_STATUS_SUCCESS) {
+					fst_requires(0);
+				}
+				memset(&rframe, 0, sizeof(rframe));
+				if (switch_rtp_zerocopy_read_frame(rtp_session, &rframe, io_flags) == SWITCH_STATUS_SUCCESS
+					&& rframe.datalen == (uint32_t)payload_len) {
+					got = 1;
+				} else {
+					switch_yield(20000);
+				}
+			}
+			if (!got || rframe.packetlen != (uint32_t)full) {
+				fail++;
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+					"ext_words=%d full=%d got=%d datalen=%u packetlen=%u (expected %d)\n",
+					ew, full, got, rframe.datalen, rframe.packetlen, full);
+			}
+		}
+
+		fst_xcheck(fail == 0, "packetlen must equal full wire length for all extension sizes (0/1/2/3 words incl. stale-state sequence)");
+
+		rtp_test_end_call(&session);
+	}
+	FST_TEST_END()
 }
 FST_SUITE_END()
 }


### PR DESCRIPTION
## Problem

On Opus passthrough (raw-forward) legs, the B2BUA drops the last 8 bytes of the Opus payload on RTP frames that carry a one-word `0xbede` header extension (e.g. the RFC 6464 audio-level extension WebRTC clients send). The decoder then garbles the short frame → audible distortion.

## Cause

In `switch_rtp_zerocopy_read_frame`, `frame->packetlen` was set from a byte count that had the RTP header-extension size subtracted in the read path, while `frame->packet` still contains the extension. The raw-forward path transmits `packetlen` bytes from `frame->packet`, so the trailing ext-size payload bytes are cut (8 for a one-word extension).

## Fix

```c
frame->packetlen = rtp_session->last_recv_bytes;
```

`last_recv_bytes` is the full received datagram length captured before extension stripping, and is already used as the forward length on the fork/recording path. It is correct for any extension size and avoids reconstructing the length from cached per-session extension state (`recv_rtp_exts_size` is `uint8_t`, is not reset per packet, and is only assigned when the extension length field is non-zero — so it can be stale or wrapped, which over-forwards past the datagram on a zero-length extension following a non-zero one).

## Tests

`tests/unit/switch_rtp_pcap.c` — `make test-run`:
- `test_rtp_header_extension_passthrough_length`: common one-word extension (the original symptom).
- `test_rtp_header_extension_passthrough_length_edge_cases`: zero-, two-, three-word extensions and a mixed/stale-state sequence (`1→0→3→0→2→0`), asserting `frame->packetlen` equals the full wire length for each. Fails with the cached-size approach, passes with `last_recv_bytes`.

QA: 16 real-call samples (both legs), `truncated_8B = 0` across all; 6 hit the passthrough path with extension frames forwarded byte-identical.