### PR TITLE
TELCORE-223: drain in-flight record threads before conference teardown

### DIFF
--- a/src/mod/applications/mod_conference/conference_record.c
+++ b/src/mod/applications/mod_conference/conference_record.c
@@ -69,9 +69,23 @@ void conference_record_launch_thread(conference_obj_t *conference, char *path, i
 		rec->canvas_id = canvas_id;
 	}
 
+	/* TELCORE-223: register the thread before spawning it, but only while the
+	 * conference is still running. Serialising this CFLAG_RUNNING check and the
+	 * count bump against the teardown's flag-clear (both under flag_mutex)
+	 * guarantees the teardown either waits for this thread (registered before the
+	 * flag was cleared) or this thread is never launched (flag already cleared) -
+	 * it can never slip in after the teardown has drained. */
 	switch_mutex_lock(conference->flag_mutex);
+	if (!conference_utils_test_flag(conference, CFLAG_RUNNING)) {
+		switch_mutex_unlock(conference->flag_mutex);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						  "Not launching record thread for %s: conference is shutting down\n", path);
+		switch_core_destroy_memory_pool(&pool);
+		return;
+	}
 	rec->next = conference->rec_node_head;
 	conference->rec_node_head = rec;
+	conference->record_thread_count++;
 	switch_mutex_unlock(conference->flag_mutex);
 
 	switch_threadattr_create(&thd_attr, rec->pool);
@@ -172,8 +186,19 @@ void *SWITCH_THREAD_FUNC conference_record_thread_run(switch_thread_t *thread, v
 
 	if (switch_thread_rwlock_tryrdlock(conference->rwlock) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Read Lock Fail\n");
+		switch_mutex_lock(conference->flag_mutex);
+		conference->record_thread_count--;
+		switch_mutex_unlock(conference->flag_mutex);
 		return NULL;
 	}
+
+	/* TELCORE-223: we now hold the read lock, so the teardown's write-lock drain
+	 * will wait for us; drop the in-flight count that bridged the gap between
+	 * being launched and acquiring this lock. From here the rwlock alone keeps
+	 * the conference alive for the lifetime of this thread. */
+	switch_mutex_lock(conference->flag_mutex);
+	conference->record_thread_count--;
+	switch_mutex_unlock(conference->flag_mutex);
 
 	/* TELCORE-193: the conference teardown clears CFLAG_RUNNING, then only
 	 * momentarily takes+releases the write lock to drain readers before it

--- a/src/mod/applications/mod_conference/conference_record.c
+++ b/src/mod/applications/mod_conference/conference_record.c
@@ -69,12 +69,17 @@ void conference_record_launch_thread(conference_obj_t *conference, char *path, i
 		rec->canvas_id = canvas_id;
 	}
 
+	switch_threadattr_create(&thd_attr, rec->pool);
+	switch_threadattr_detach_set(thd_attr, 1);
+	switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+
 	/* TELCORE-223: register the thread before spawning it, but only while the
-	 * conference is still running. Serialising this CFLAG_RUNNING check and the
-	 * count bump against the teardown's flag-clear (both under flag_mutex)
-	 * guarantees the teardown either waits for this thread (registered before the
-	 * flag was cleared) or this thread is never launched (flag already cleared) -
-	 * it can never slip in after the teardown has drained. */
+	 * conference is still running, and keep flag_mutex held across the spawn.
+	 * Serialising this CFLAG_RUNNING check and the count bump against the
+	 * teardown's flag-clear (both under flag_mutex) guarantees the teardown
+	 * either waits for this thread (registered before the flag was cleared) or
+	 * this thread is never launched (flag already cleared) - it can never slip in
+	 * after the teardown has drained. */
 	switch_mutex_lock(conference->flag_mutex);
 	if (!conference_utils_test_flag(conference, CFLAG_RUNNING)) {
 		switch_mutex_unlock(conference->flag_mutex);
@@ -86,12 +91,19 @@ void conference_record_launch_thread(conference_obj_t *conference, char *path, i
 	rec->next = conference->rec_node_head;
 	conference->rec_node_head = rec;
 	conference->record_thread_count++;
-	switch_mutex_unlock(conference->flag_mutex);
 
-	switch_threadattr_create(&thd_attr, rec->pool);
-	switch_threadattr_detach_set(thd_attr, 1);
-	switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
-	switch_thread_create(&thread, thd_attr, conference_record_thread_run, rec, rec->pool);
+	if (switch_thread_create(&thread, thd_attr, conference_record_thread_run, rec, rec->pool) != SWITCH_STATUS_SUCCESS) {
+		/* No thread will run to drop the count or unlink the node, so teardown
+		 * would spin forever on record_thread_count - undo the registration here.
+		 * rec is still at the list head since flag_mutex was never released. */
+		conference->rec_node_head = rec->next;
+		conference->record_thread_count--;
+		switch_mutex_unlock(conference->flag_mutex);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Failed to launch record thread for %s\n", path);
+		switch_core_destroy_memory_pool(&pool);
+		return;
+	}
+	switch_mutex_unlock(conference->flag_mutex);
 }
 
 

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -845,6 +845,21 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 
 	/* Wait till everybody is out */
 	conference_utils_clear_flag_locked(conference, CFLAG_RUNNING);
+
+	/* TELCORE-223: drain record threads that were launched but have not yet taken
+	 * their read lock. The momentary write-lock drain below only catches readers
+	 * that already hold the lock; a record thread still in the gap between launch
+	 * and tryrdlock would otherwise acquire its read lock after the drain and
+	 * touch conference state we are about to free. CFLAG_RUNNING is cleared above,
+	 * so no new record thread can register (see conference_record_launch_thread). */
+	switch_mutex_lock(conference->flag_mutex);
+	while (conference->record_thread_count > 0) {
+		switch_mutex_unlock(conference->flag_mutex);
+		switch_yield(20000);
+		switch_mutex_lock(conference->flag_mutex);
+	}
+	switch_mutex_unlock(conference->flag_mutex);
+
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Write Lock ON\n");
 	switch_thread_rwlock_wrlock(conference->rwlock);
 	switch_thread_rwlock_unlock(conference->rwlock);

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -713,6 +713,11 @@ typedef struct conference_obj {
 	int auto_recording;
 	char *recording_metadata;
 	int record_count;
+	/* TELCORE-223: record threads that have been launched but have not yet taken
+	 * their conference rwlock read lock. Guarded by flag_mutex. Teardown drains
+	 * this to zero before freeing the conference so a late-arriving record thread
+	 * cannot acquire its read lock after the write-lock drain. */
+	int record_thread_count;
 	uint32_t min_recording_participants;
 	int ivr_dtmf_timeout;
 	int ivr_input_timeout;


### PR DESCRIPTION
## Summary

Follow-up to [TELCORE-223](https://linear.app/telnyx/issue/TELCORE-223) — closes the residual pool-lifetime race left open by TELCORE-193 (#609).

> **Stacked on #609.** Base is the `damir/telcore-193-...` branch so this diff shows only the TELCORE-223 changes. Retarget to `telnyx/telephony/deploy-development` once #609 merges.

## The residual race

`conference->variables`, the `conference` struct, its `rwlock` and `flag_mutex` are all carved from `conference->pool`, which teardown frees at `mod_conference.c:894`. Teardown's only synchronization before that free is the *momentary* write-lock drain (`849-850`), which waits only for readers **already holding** the lock.

`conference_record_launch_thread()` spawns the record thread detached; the thread takes its own read lock asynchronously at `conference_record.c:173`. A thread that acquires the lock just **after** the drain is never waited for, so teardown can free the pool out from under it. The TELCORE-193 `CFLAG_RUNNING` re-check shrank the exposure to two instructions but did not close it.

## Fix — launch/teardown handshake

A new in-flight counter (`record_thread_count`, guarded by `flag_mutex`) bridges only the gap between launch and read-lock acquisition; the existing rwlock covers the thread's lifetime from there.

- **`conference_record_launch_thread()`** — under `flag_mutex`: refuse to launch if `CFLAG_RUNNING` is already clear (drop the node, free the pool); otherwise bump `record_thread_count` and spawn. Serializing this against teardown's flag-clear (also under `flag_mutex`) means a thread either registers *before* the flag clears (teardown waits for it) or is never launched.
- **`conference_record_thread_run()`** — decrement `record_thread_count` immediately after `tryrdlock` (both success and Read-Lock-Fail paths). Once the read lock is held, the write-lock drain covers the thread, so the counter's job is done.
- **`conference_thread_run()`** — after clearing `CFLAG_RUNNING`, wait for `record_thread_count == 0` before the write-lock drain.

## Why it's correct & deadlock-free

- The counter covers **launch → rdlock**; the rwlock covers **rdlock → exit**. The handoff is seamless because the decrement runs *after* the lock is acquired.
- During the wait, teardown holds no rwlock and only briefly holds `flag_mutex` (released across the `switch_yield`), so threads always make progress to decrement.
- The decrement runs while the conference is still alive — the pool free is gated behind *both* the count drain and the wrlock drain.
- No new lock ordering: threads take `rdlock → flag_mutex`; teardown takes `flag_mutex` alone, then `wrlock` alone.

## Testing

- mod_conference builds clean; the TELCORE-193 `test_record_teardown` regression test still passes.
- The race is timing-dependent, so a deterministic green-on-fixed unit test is not feasible (see TELCORE-193 discussion); recommend validating under TSan/ASan with a create → record → destroy stress loop.