### PR TITLE
Fix PR review Codex model

### DIFF
--- a/.github/workflows/reviewpr.yml
+++ b/.github/workflows/reviewpr.yml
@@ -27,5 +27,5 @@ jobs:
         uses: team-telnyx/reviewpr-internal@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          model: gpt-5.2-codex
+          model: gpt-5.4
           github_event_number: ${{ github.event.inputs.github_event_number || '' }}


### PR DESCRIPTION
The PR Review workflow was still passing `gpt-5.2-codex` into `team-telnyx/reviewpr-internal`. The current Codex action rejects its default `text.verbosity=low` for that model, causing review jobs to fail before analysis.

Switch to `gpt-5.4`, matching the shared action default in `reviewpr-internal`.

Triggered by: Tajamul