### PR TITLE
TELCORE-156: clear stale EOC/PAC state in switch_core_media_clear_ice()

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4838,6 +4838,18 @@ SWITCH_DECLARE(void) switch_core_media_clear_ice(switch_core_session_t *session)
 	channel = switch_core_session_get_channel(session);
 	if (channel) {
 		switch_channel_set_variable(channel, "sip_trickle_accept", NULL);
+
+		/* Clear stale EOC (End-of-Candidates) and PAC timer variables so that
+		   a subsequent trickle ICE negotiation (e.g. modify/updateMedia) starts
+		   with a clean slate instead of seeing leftover state from the initial
+		   attach.  Without this, check_ice() sees rtp_in_session_eoc=true from
+		   the previous negotiation, falls through the PAC timer, and punts with
+		   "no suitable candidates found" before any trickled candidates arrive. */
+		switch_channel_set_variable(channel, "rtp_in_session_eoc", NULL);
+		switch_channel_set_variable(channel, "rtp_in_audio_eoc", NULL);
+		switch_channel_set_variable(channel, "rtp_in_video_eoc", NULL);
+		switch_channel_set_variable(channel, "rtp_in_text_eoc", NULL);
+		switch_channel_set_variable(channel, "rtp_ice_pac_until_us", NULL);
 	}
 }
 


### PR DESCRIPTION
## Summary

Trickle ICE modify (`updateMedia`) fails with `CODEC NEGOTIATION ERROR` even though audio codecs match perfectly. Confirmed on both QA test 23 CI and a real customer call (`8243a1e8-5c03-4840-884c-8cd94aba37cc`).

## Root cause

`switch_core_media_clear_ice()` clears ICE structures but leaves stale End-of-Candidates (EOC) channel variables from the initial trickle attach:

1. Initial trickle attach completes → `rtp_in_session_eoc=true` set (`switch_core_media.c:5361`)
2. Modify handler calls `switch_core_media_clear_ice()` → ICE structures cleared, **EOC variables not cleared**
3. `negotiate_sdp()` → codecs match → `check_ice()` called
4. `check_ice()`: no candidates in trickle SDP → enters PAC timer logic
5. PAC timer sees stale `rtp_in_session_eoc=true` → **falls through** instead of starting a new timer
6. Returns `SWITCH_STATUS_FALSE` ("no suitable candidates found") → `match = 0` → `CODEC NEGOTIATION ERROR`

## Fix

Clear all EOC and PAC timer channel variables in `switch_core_media_clear_ice()` so that `check_ice()` enters the `!until_us` branch on a fresh modify, starts a new PAC timer, and returns `SWITCH_STATUS_SUCCESS` while candidates trickle in:

- `rtp_in_session_eoc`
- `rtp_in_audio_eoc`
- `rtp_in_video_eoc`
- `rtp_in_text_eoc`
- `rtp_ice_pac_until_us`

All callers of `switch_core_media_clear_ice()` are fresh SDP/ICE negotiations (mod_verto attach and updateMedia), none rely on preserved EOC state. Non-trickle reinvite case is safe — these variables are only consulted when `trickle_accept_enabled()` is true.

Linear: https://linear.app/telnyx/issue/TELCORE-156