### PR TITLE
TELCORE-234: remove pinned reviewpr model

### DIFF
--- a/.github/workflows/reviewpr.yml
+++ b/.github/workflows/reviewpr.yml
@@ -27,5 +27,4 @@ jobs:
         uses: team-telnyx/reviewpr-internal@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          model: gpt-5.2-codex
           github_event_number: ${{ github.event.inputs.github_event_number || '' }}


### PR DESCRIPTION
## What
- Remove the explicit `model: gpt-5.2-codex` input from `.github/workflows/reviewpr.yml`.
- Keep the existing `team-telnyx/reviewpr-internal@main` action and manual-dispatch `github_event_number` wiring.

## Why
- `gpt-5.2-codex` fails in the PR Review GHA because Codex sends `text.verbosity: "low"`, which that model no longer supports.
- `team-telnyx/reviewpr-internal@main` now defaults the model to `gpt-5.4`, matching the guidance from TELCORE-234 / the Slack thread that the workflow should stop pinning the old model.

## Verification
- Parsed `.github/workflows/reviewpr.yml` with Ruby `YAML.load_file`.
- Ran `git diff --check`.
- Confirmed the workflow has zero remaining `model:` entries and still passes `github_event_number` for `workflow_dispatch`.

Linear: https://linear.app/telnyx/issue/TELCORE-234/update-reviewpryml-to-fix-fail-gha-issue
