### PR TITLE
TELCORE-226: fix libspandsp t38_gateway crash (data race across the two gateway legs)

### DIFF
--- a/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
+++ b/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
@@ -2048,7 +2048,14 @@ static switch_status_t t38_gateway_on_soft_execute(switch_core_session_t *sessio
 		}
 
 		if (switch_test_flag(read_frame, SFF_UDPTL_PACKET)) {
-			if (udptl_rx_packet(pvt->udptl_state, read_frame->packet, read_frame->packetlen) < 0) {
+			int udptl_status;
+			/* pvt->mutex serializes access to the shared t38_gateway_state against the audio leg
+			   (t38_gateway_on_consume_media -> t38_gateway_rx/tx). udptl_rx_packet feeds
+			   t38_core_rx_ifp_packet, which can reinitialise the rx modem. See TELCORE-226. */
+			switch_mutex_lock(pvt->mutex);
+			udptl_status = udptl_rx_packet(pvt->udptl_state, read_frame->packet, read_frame->packetlen);
+			switch_mutex_unlock(pvt->mutex);
+			if (udptl_status < 0) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%s Error decoding UDPTL (%u bytes)\n", switch_channel_get_name(channel), read_frame->packetlen);
                         }
 		}
@@ -2225,20 +2232,30 @@ static switch_status_t t38_gateway_on_consume_media(switch_core_session_t *sessi
 		if (switch_test_flag(read_frame, SFF_CNG)) {
 			/* We have no real signal data for the FAX software, but we have a space in time if we have a CNG indication.
 			   Do a fill-in operation in the FAX machine, to keep things rolling along. */
+			/* pvt->mutex serializes access to the shared t38_gateway_state against the T.38 leg
+			   (t38_gateway_on_soft_execute -> udptl_rx_packet). See TELCORE-226. */
+			switch_mutex_lock(pvt->mutex);
 			t38_gateway_rx_fillin(pvt->t38_gateway_state, read_impl.samples_per_packet);
+			switch_mutex_unlock(pvt->mutex);
 		} else {
 			if (read_fd != FAX_INVALID_SOCKET) {
 				switch_ssize_t rv;
 				do { rv = write(read_fd, read_frame->data, read_frame->datalen); } while (rv == -1 && errno == EINTR);
 			}
 			switch_telnyx_set_current_trace_message(uuid);
+			switch_mutex_lock(pvt->mutex);
 			if (t38_gateway_rx(pvt->t38_gateway_state, (int16_t *) read_frame->data, read_frame->samples)) {
+					switch_mutex_unlock(pvt->mutex);
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "fax_rx reported an error\n");
 					goto end_unlock;
 			}
+			switch_mutex_unlock(pvt->mutex);
 		}
 
-		if ((tx = t38_gateway_tx(pvt->t38_gateway_state, buf, write_codec.implementation->samples_per_packet)) < 0) {
+		switch_mutex_lock(pvt->mutex);
+		tx = t38_gateway_tx(pvt->t38_gateway_state, buf, write_codec.implementation->samples_per_packet);
+		switch_mutex_unlock(pvt->mutex);
+		if (tx < 0) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "fax_tx reported an error\n");
 			goto end_unlock;
 		}

--- a/tests/test_t38_gateway_race/.gitignore
+++ b/tests/test_t38_gateway_race/.gitignore
@@ -1,3 +1,3 @@
 gwrace
-gwrace_tsan
+gwrace_*
 *.o

--- a/tests/test_t38_gateway_race/.gitignore
+++ b/tests/test_t38_gateway_race/.gitignore
@@ -1,0 +1,3 @@
+gwrace
+gwrace_tsan
+*.o

--- a/tests/test_t38_gateway_race/README.md
+++ b/tests/test_t38_gateway_race/README.md
@@ -25,6 +25,7 @@ SIGSEGV in `span_log_test()` reading `s->level`.
 ```sh
 ./run.sh crash   # link the installed libspandsp.so, run -> SIGSEGV (production stack)
 ./run.sh tsan    # build TSan-instrumented libspandsp, run -> data-race report
+./run.sh fixed   # same, but -DSERIALIZE (models the fix) -> no race, clean exit
 ```
 
 `tsan` mode needs the spandsp source tree (default `~/work/fs_docker_deps/spandsp`,
@@ -41,7 +42,10 @@ distinct race sites on the shared state.
 
 ## Fix
 
-Serialize access to the gateway state: take a per-`pvt` mutex around
-`t38_gateway_rx`/`t38_gateway_rx_fillin`/`t38_gateway_tx` (audio leg) and
-`udptl_rx_packet`/`t38_core_rx_ifp_packet` (T.38 leg); or funnel both legs
-through a single thread.
+Serialize access to the gateway state with the existing per-`pvt` mutex
+(`pvt->mutex` in `mod_spandsp_fax.c`): take it around
+`t38_gateway_rx`/`t38_gateway_rx_fillin`/`t38_gateway_tx` (audio leg, in
+`t38_gateway_on_consume_media`) and `udptl_rx_packet` (T.38 leg, in
+`t38_gateway_on_soft_execute`). This mirrors the lock already used for
+terminal mode. `./run.sh fixed` validates the approach: the same workload
+under `-DSERIALIZE` runs to completion with zero TSan reports.

--- a/tests/test_t38_gateway_race/README.md
+++ b/tests/test_t38_gateway_race/README.md
@@ -1,0 +1,47 @@
+# TELCORE-226 — libspandsp t38_gateway crash reproducer
+
+Standalone reproducer for the B2BUA segfault in `libspandsp` during T.38
+gateway processing (crash in `span_log_test` ← `span_log` ← `hdlc_rx_status`).
+
+## Root cause
+
+In `mod_spandsp` gateway mode, a single `t38_gateway_state_t` is driven by **two
+FreeSWITCH session threads with no mutex**:
+
+| Thread        | FreeSWITCH handler                  | spandsp entry            |
+|---------------|-------------------------------------|--------------------------|
+| Audio leg     | `t38_gateway_on_consume_media`      | `t38_gateway_rx()`       |
+| T.38 leg      | `t38_gateway_on_soft_execute`       | `udptl_rx_packet()` → `t38_core_rx_ifp_packet()` |
+
+When an incoming T.38 control message (e.g. CFR) on the T.38 leg drives
+`restart_rx_modem()`, it calls `hdlc_rx_init()` which `memset`s the `hdlc_rx`
+struct and then restores `frame_user_data`. Meanwhile the audio leg is inside
+`hdlc_rx_status()` reading that same `frame_user_data` and dereferencing it in
+`span_log(&s->logging, ...)`. A torn read yields a non-NULL garbage pointer →
+SIGSEGV in `span_log_test()` reading `s->level`.
+
+## Running
+
+```sh
+./run.sh crash   # link the installed libspandsp.so, run -> SIGSEGV (production stack)
+./run.sh tsan    # build TSan-instrumented libspandsp, run -> data-race report
+```
+
+`tsan` mode needs the spandsp source tree (default `~/work/fs_docker_deps/spandsp`,
+override with `SPANDSP_SRC=...`). On newer kernels TSan needs `setarch -R` to avoid
+the "unexpected memory mapping" ASLR failure; `run.sh` already does this.
+
+## Captured evidence
+
+`tsan-report.txt` contains a captured run: the race on
+`hdlc_rx.frame_user_data` (write at `hdlc.c:389` in `hdlc_rx_init` from the T.38
+leg vs. read at `t38_gateway.c:1722` in `hdlc_rx_status` from the audio leg), the
+TSan-caught SEGV at the exact production crash line, and the full list of 122
+distinct race sites on the shared state.
+
+## Fix
+
+Serialize access to the gateway state: take a per-`pvt` mutex around
+`t38_gateway_rx`/`t38_gateway_rx_fillin`/`t38_gateway_tx` (audio leg) and
+`udptl_rx_packet`/`t38_core_rx_ifp_packet` (T.38 leg); or funnel both legs
+through a single thread.

--- a/tests/test_t38_gateway_race/run.sh
+++ b/tests/test_t38_gateway_race/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# TELCORE-226: reproduce the libspandsp t38_gateway crash / data race.
+#
+# Two modes:
+#   ./run.sh crash   - link against the installed libspandsp.so and just run.
+#                      Segfaults with the exact production stack (span_log_test
+#                      <- span_log <- hdlc_rx_status <- ... <- t38_gateway_rx).
+#   ./run.sh tsan    - build a ThreadSanitizer-instrumented libspandsp from
+#                      source and run under it; TSan reports the data race on
+#                      hdlc_rx.frame_user_data between the audio leg and the
+#                      T.38 leg (see tsan-report.txt for a captured run).
+#
+# Override the spandsp source tree with SPANDSP_SRC=/path/to/spandsp.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+src="$here/t38_gateway_race.c"
+SPANDSP_SRC="${SPANDSP_SRC:-$HOME/work/fs_docker_deps/spandsp}"
+build="${TMPDIR:-/tmp}/telcore226-spandsp-tsan"
+mode="${1:-tsan}"
+
+case "$mode" in
+crash)
+    cc -O1 -g -I/usr/local/include "$src" -o "$here/gwrace" \
+       -L/usr/local/lib -lspandsp -lpthread -lm
+    echo ">>> running (expect SIGSEGV in span_log_test) ..."
+    LD_LIBRARY_PATH=/usr/local/lib "$here/gwrace"
+    ;;
+tsan)
+    TS="-fsanitize=thread -g -O1 -fno-omit-frame-pointer"
+    if [ ! -f "$build/src/.libs/libspandsp.a" ]; then
+        echo ">>> building TSan-instrumented libspandsp (one-time) ..."
+        [ -x "$SPANDSP_SRC/configure" ] || (cd "$SPANDSP_SRC" && ./autogen.sh)
+        rm -rf "$build"; mkdir -p "$build"; cd "$build"
+        "$SPANDSP_SRC/configure" --enable-static --disable-shared --disable-doc >/dev/null
+        make -C src -j"$(nproc)" CFLAGS="$TS" libspandsp.la >/dev/null
+    fi
+    cc $TS -I"$build/src" -I/usr/local/include "$src" \
+       "$build/src/.libs/libspandsp.a" -ltiff -ljpeg -lm -lpthread \
+       -o "$here/gwrace_tsan"
+    echo ">>> running under ThreadSanitizer (setarch -R works around the"
+    echo "    'unexpected memory mapping' ASLR issue on newer kernels) ..."
+    # halt_on_error=1: stop at the first race so the output is the smoking gun.
+    TSAN_OPTIONS="halt_on_error=1 history_size=4" setarch -R "$here/gwrace_tsan"
+    ;;
+*)
+    echo "usage: $0 {crash|tsan}" >&2; exit 2;;
+esac

--- a/tests/test_t38_gateway_race/run.sh
+++ b/tests/test_t38_gateway_race/run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
-# TELCORE-226: reproduce the libspandsp t38_gateway crash / data race.
+# TELCORE-226: reproduce (and verify the fix for) the libspandsp t38_gateway
+# crash / data race.
 #
-# Two modes:
+# Modes:
 #   ./run.sh crash   - link against the installed libspandsp.so and just run.
 #                      Segfaults with the exact production stack (span_log_test
 #                      <- span_log <- hdlc_rx_status <- ... <- t38_gateway_rx).
@@ -10,6 +11,10 @@
 #                      source and run under it; TSan reports the data race on
 #                      hdlc_rx.frame_user_data between the audio leg and the
 #                      T.38 leg (see tsan-report.txt for a captured run).
+#   ./run.sh fixed   - same as tsan, but compiled with -DSERIALIZE so the two
+#                      threads take a shared lock around every spandsp call
+#                      (what the mod_spandsp fix does). TSan reports no race and
+#                      the program completes cleanly.
 #
 # Override the spandsp source tree with SPANDSP_SRC=/path/to/spandsp.
 set -euo pipefail
@@ -19,6 +24,17 @@ src="$here/t38_gateway_race.c"
 SPANDSP_SRC="${SPANDSP_SRC:-$HOME/work/fs_docker_deps/spandsp}"
 build="${TMPDIR:-/tmp}/telcore226-spandsp-tsan"
 mode="${1:-tsan}"
+TS="-fsanitize=thread -g -O1 -fno-omit-frame-pointer"
+
+build_tsan_lib() {
+    if [ ! -f "$build/src/.libs/libspandsp.a" ]; then
+        echo ">>> building TSan-instrumented libspandsp (one-time) ..."
+        [ -x "$SPANDSP_SRC/configure" ] || (cd "$SPANDSP_SRC" && ./autogen.sh)
+        rm -rf "$build"; mkdir -p "$build"; cd "$build"
+        "$SPANDSP_SRC/configure" --enable-static --disable-shared --disable-doc >/dev/null
+        make -C src -j"$(nproc)" CFLAGS="$TS" libspandsp.la >/dev/null
+    fi
+}
 
 case "$mode" in
 crash)
@@ -27,23 +43,17 @@ crash)
     echo ">>> running (expect SIGSEGV in span_log_test) ..."
     LD_LIBRARY_PATH=/usr/local/lib "$here/gwrace"
     ;;
-tsan)
-    TS="-fsanitize=thread -g -O1 -fno-omit-frame-pointer"
-    if [ ! -f "$build/src/.libs/libspandsp.a" ]; then
-        echo ">>> building TSan-instrumented libspandsp (one-time) ..."
-        [ -x "$SPANDSP_SRC/configure" ] || (cd "$SPANDSP_SRC" && ./autogen.sh)
-        rm -rf "$build"; mkdir -p "$build"; cd "$build"
-        "$SPANDSP_SRC/configure" --enable-static --disable-shared --disable-doc >/dev/null
-        make -C src -j"$(nproc)" CFLAGS="$TS" libspandsp.la >/dev/null
-    fi
-    cc $TS -I"$build/src" -I/usr/local/include "$src" \
-       "$build/src/.libs/libspandsp.a" -ltiff -ljpeg -lm -lpthread \
-       -o "$here/gwrace_tsan"
+tsan|fixed)
+    [ "$mode" = fixed ] && def=-DSERIALIZE || def=
+    out="$here/gwrace_${mode}"
+    build_tsan_lib
+    cc $def $TS -I"$build/src" -I/usr/local/include "$src" \
+       "$build/src/.libs/libspandsp.a" -ltiff -ljpeg -lm -lpthread -o "$out"
     echo ">>> running under ThreadSanitizer (setarch -R works around the"
     echo "    'unexpected memory mapping' ASLR issue on newer kernels) ..."
     # halt_on_error=1: stop at the first race so the output is the smoking gun.
-    TSAN_OPTIONS="halt_on_error=1 history_size=4" setarch -R "$here/gwrace_tsan"
+    TSAN_OPTIONS="halt_on_error=1 history_size=4" setarch -R "$out"
     ;;
 *)
-    echo "usage: $0 {crash|tsan}" >&2; exit 2;;
+    echo "usage: $0 {crash|tsan|fixed}" >&2; exit 2;;
 esac

--- a/tests/test_t38_gateway_race/t38_gateway_race.c
+++ b/tests/test_t38_gateway_race/t38_gateway_race.c
@@ -108,6 +108,19 @@ static const uint8_t ind_no_signal[1]    = { (T38_IND_NO_SIGNAL << 1) };
 static t38_gateway_state_t *gw;
 static t38_core_state_t *core;
 
+/* When built with -DSERIALIZE this mutex models the mod_spandsp fix: a single
+ * per-pvt lock taken around every spandsp call that touches t38_gateway_state,
+ * on both the audio leg and the T.38 leg. With it, TSan reports no race and the
+ * program no longer crashes. */
+#ifdef SERIALIZE
+static pthread_mutex_t gw_lock = PTHREAD_MUTEX_INITIALIZER;
+#define GW_LOCK()   pthread_mutex_lock(&gw_lock)
+#define GW_UNLOCK() pthread_mutex_unlock(&gw_lock)
+#else
+#define GW_LOCK()   ((void) 0)
+#define GW_UNLOCK() ((void) 0)
+#endif
+
 /* Audio leg: exactly what t38_gateway_on_consume_media does. */
 static void *audio_thread(void *arg)
 {
@@ -120,9 +133,13 @@ static void *audio_thread(void *arg)
         amp[i] = (int16_t) ((i * 1373) ^ (i << 7));
 
     for (i = 0; i < ITERATIONS; i++) {
-        t38_gateway_rx(gw, amp, 160);
         int16_t out[160];
+        GW_LOCK();
+        t38_gateway_rx(gw, amp, 160);
+        GW_UNLOCK();
+        GW_LOCK();
         t38_gateway_tx(gw, out, 160);
+        GW_UNLOCK();
     }
     return NULL;
 }
@@ -139,9 +156,15 @@ static void *t38_thread(void *arg)
     for (i = 0; i < ITERATIONS; i++) {
         /* Alternate carrier indicators and a CFR control frame; both drive
          * concurrent mutation of the gateway's rx-modem state. */
+        GW_LOCK();
         t38_core_rx_ifp_packet(core, ind_v21_preamble, 1, seq++);
+        GW_UNLOCK();
+        GW_LOCK();
         t38_core_rx_ifp_packet(core, cfr, cfr_len, seq++);
+        GW_UNLOCK();
+        GW_LOCK();
         t38_core_rx_ifp_packet(core, ind_no_signal, 1, seq++);
+        GW_UNLOCK();
     }
     return NULL;
 }

--- a/tests/test_t38_gateway_race/t38_gateway_race.c
+++ b/tests/test_t38_gateway_race/t38_gateway_race.c
@@ -1,0 +1,181 @@
+/*
+ * TELCORE-226 reproducer: data race / crash in libspandsp t38_gateway.
+ *
+ * In mod_spandsp gateway mode a single t38_gateway_state_t is driven by TWO
+ * FreeSWITCH session threads with no mutex:
+ *
+ *   - audio leg  (t38_gateway_on_consume_media): t38_gateway_rx()
+ *   - T.38 leg   (t38_gateway_on_soft_execute):  udptl_rx_packet()
+ *                                                  -> t38_core_rx_ifp_packet()
+ *
+ * The T.38 leg, on receiving a V.21 control frame (e.g. CFR) or carrier
+ * transition, calls restart_rx_modem() which does:
+ *
+ *     hdlc_rx_init(&t->hdlc_rx, ...):  memset(s,0,sizeof *s); ... s->frame_user_data = user_data;
+ *     fsk_rx_init(&t->v21_rx,  ...):  memset of the V.21 receiver
+ *
+ * ...reinitialising the exact hdlc_rx / v21_rx structs that the audio leg is
+ * concurrently reading inside t38_gateway_rx() -> fsk_rx() ->
+ * report_status_change() -> hdlc_rx_status(), which reads t->frame_user_data
+ * and dereferences it in span_log(&s->logging, ...). A torn read of
+ * frame_user_data yields a non-NULL garbage pointer -> SIGSEGV in
+ * span_log_test() reading s->level. That is the crash in TELCORE-226.
+ *
+ * Build with ThreadSanitizer to observe the race directly:
+ *     see run.sh
+ *
+ * This program is standalone: it links libspandsp only, no FreeSWITCH.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <spandsp.h>
+
+/* T.30 frame control field, internal (post bit-reverse) value. */
+#ifndef T30_CFR
+#define T30_CFR 0x84
+#endif
+
+static volatile int g_saw_restart = 0;
+
+/* Capture spandsp log lines so we can confirm the CFR / modem-restart path
+ * is actually exercised by the crafted IFP packets. */
+static void log_message(void *user_data, int level, const char *text)
+{
+    (void) user_data;
+    (void) level;
+    if (strstr(text, "Restart rx modem") || strstr(text, "CFR"))
+        g_saw_restart = 1;
+    /* Uncomment for verbose tracing:
+    fputs(text, stderr);
+    */
+}
+
+/* The T.38 tx packet handler is invoked when the gateway emits T.38 toward
+ * the (imaginary) far end. We just drop the packets. */
+static int tx_packet_handler(t38_core_state_t *s, void *user_data,
+                             const uint8_t *buf, int len, int count)
+{
+    (void) s; (void) user_data; (void) buf; (void) len; (void) count;
+    return 0;
+}
+
+/* Build a V.21 IFP data packet (T.38 version 0 encoding) carrying one HDLC
+ * frame field followed by an FCS_OK field, so process_rx_data() ->
+ * monitor_control_messages() -> restart_rx_modem() fires for a CFR frame.
+ *
+ * Wire bytes of the HDLC frame: 0xFF 0x03 0x21  (address, control, CFR FCF).
+ * spandsp bit-reverses them internally: 0x21 -> 0x84 == T30_CFR.
+ */
+static int build_cfr_ifp(uint8_t *out)
+{
+    int n = 0;
+    /* type-of-msg octet:
+     *   bit7 data_field_present = 1
+     *   bit6 type = T38_TYPE_OF_MSG_T30_DATA (1)
+     *   bit5 extension = 0
+     *   bits1-4 data_type = T38_DATA_V21 (0)
+     */
+    out[n++] = 0x80 | 0x40 | (T38_DATA_V21 << 1);
+    out[n++] = 2;                       /* number of fields */
+
+    /* Field 0: HDLC_DATA with 3 octets of data (version-0 field encoding). */
+    out[n++] = 0x80 | (T38_FIELD_HDLC_DATA << 4);  /* data present, field type */
+    out[n++] = 0x00;                    /* field length hi: numocts-1 = 2 */
+    out[n++] = 0x02;                    /* field length lo */
+    out[n++] = 0xFF;                    /* HDLC address */
+    out[n++] = 0x03;                    /* HDLC control */
+    out[n++] = 0x21;                    /* CFR FCF (bit-reversed -> 0x84) */
+
+    /* Field 1: HDLC_FCS_OK, no data field (version-0 "other half" octet). */
+    out[n++] = (T38_FIELD_HDLC_FCS_OK << 4);
+    return n;
+}
+
+/* Two single-byte indicator IFP packets (no data field):
+ *   type=indicator(0), bits1-4 = indicator value. */
+static const uint8_t ind_v21_preamble[1] = { (T38_IND_V21_PREAMBLE << 1) };
+static const uint8_t ind_no_signal[1]    = { (T38_IND_NO_SIGNAL << 1) };
+
+#define ITERATIONS 200000
+
+static t38_gateway_state_t *gw;
+static t38_core_state_t *core;
+
+/* Audio leg: exactly what t38_gateway_on_consume_media does. */
+static void *audio_thread(void *arg)
+{
+    (void) arg;
+    int16_t amp[160];
+    int i;
+    /* Non-silent input keeps the V.21 receiver alive so it generates the
+     * status-change callbacks that read hdlc_rx.frame_user_data. */
+    for (i = 0; i < 160; i++)
+        amp[i] = (int16_t) ((i * 1373) ^ (i << 7));
+
+    for (i = 0; i < ITERATIONS; i++) {
+        t38_gateway_rx(gw, amp, 160);
+        int16_t out[160];
+        t38_gateway_tx(gw, out, 160);
+    }
+    return NULL;
+}
+
+/* T.38 leg: exactly what t38_gateway_on_soft_execute does via udptl_rx_packet. */
+static void *t38_thread(void *arg)
+{
+    (void) arg;
+    uint8_t cfr[32];
+    int cfr_len = build_cfr_ifp(cfr);
+    uint16_t seq = 0;
+    int i;
+
+    for (i = 0; i < ITERATIONS; i++) {
+        /* Alternate carrier indicators and a CFR control frame; both drive
+         * concurrent mutation of the gateway's rx-modem state. */
+        t38_core_rx_ifp_packet(core, ind_v21_preamble, 1, seq++);
+        t38_core_rx_ifp_packet(core, cfr, cfr_len, seq++);
+        t38_core_rx_ifp_packet(core, ind_no_signal, 1, seq++);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t a, b;
+
+    gw = t38_gateway_init(NULL, tx_packet_handler, NULL);
+    if (gw == NULL) {
+        fprintf(stderr, "t38_gateway_init failed\n");
+        return 2;
+    }
+    core = t38_gateway_get_t38_core_state(gw);
+    t38_gateway_set_supported_modems(gw, T30_SUPPORT_V17 | T30_SUPPORT_V29 | T30_SUPPORT_V27TER);
+    t38_gateway_set_ecm_capability(gw, true);
+    t38_set_t38_version(core, 0);
+    t38_set_sequence_number_handling(core, false);
+
+    span_log_set_message_handler(t38_gateway_get_logging_state(gw), log_message, NULL);
+    span_log_set_message_handler(t38_core_get_logging_state(core), log_message, NULL);
+    span_log_set_level(t38_gateway_get_logging_state(gw),
+                       SPAN_LOG_SHOW_SEVERITY | SPAN_LOG_SHOW_PROTOCOL | SPAN_LOG_FLOW);
+    span_log_set_level(t38_core_get_logging_state(core),
+                       SPAN_LOG_SHOW_SEVERITY | SPAN_LOG_SHOW_PROTOCOL | SPAN_LOG_FLOW);
+
+    fprintf(stderr, "Driving one t38_gateway_state from 2 threads (%d iters each)...\n", ITERATIONS);
+
+    pthread_create(&a, NULL, audio_thread, NULL);
+    pthread_create(&b, NULL, t38_thread, NULL);
+    pthread_join(a, NULL);
+    pthread_join(b, NULL);
+
+    fprintf(stderr, "Done. restart_rx_modem/CFR path exercised: %s\n",
+            g_saw_restart ? "yes" : "no");
+    return 0;
+}

--- a/tests/test_t38_gateway_race/tsan-report.txt
+++ b/tests/test_t38_gateway_race/tsan-report.txt
@@ -1,0 +1,136 @@
+TELCORE-226 ThreadSanitizer evidence
+Generated from tests/test_t38_gateway_race/t38_gateway_race.c
+spandsp built with -fsanitize=thread; run under 'setarch -R'.
+
+===== Race on hdlc_rx.frame_user_data (the crash field) =====
+WARNING: ThreadSanitizer: data race (pid=3041989)
+  Write of size 8 at 0x72c800000328 by thread T2:
+    #0 hdlc_rx_init /home/damir/work/fs_docker_deps/spandsp/src/hdlc.c:389 (gwrace_tsan+0x1664d) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #1 restart_rx_modem /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:2077 (gwrace_tsan+0x733b) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #2 monitor_control_messages /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:644 (gwrace_tsan+0x762b) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #3 process_rx_data /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:1110 (gwrace_tsan+0x7ee7) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #4 t38_core_rx_ifp_stream /home/damir/work/fs_docker_deps/spandsp/src/t38_core.c:652 (gwrace_tsan+0x4687) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #5 t38_core_rx_ifp_packet /home/damir/work/fs_docker_deps/spandsp/src/t38_core.c:750 (gwrace_tsan+0x490f) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #6 t38_thread tests/test_t38_gateway_race/t38_gateway_race.c:143 (gwrace_tsan+0x2653) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+
+  Previous read of size 8 at 0x72c800000328 by thread T1:
+    #0 hdlc_rx_status /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:1722 (gwrace_tsan+0x917f) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #1 t38_hdlc_rx_put_bit /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:1945 (gwrace_tsan+0x917f)
+    #2 report_status_change /home/damir/work/fs_docker_deps/spandsp/src/fsk.c:380 (gwrace_tsan+0x14599) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #3 fsk_rx /home/damir/work/fs_docker_deps/spandsp/src/fsk.c:467 (gwrace_tsan+0x14fe2) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #4 t38_gateway_rx /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:2169 (gwrace_tsan+0xa614) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #5 audio_thread tests/test_t38_gateway_race/t38_gateway_race.c:123 (gwrace_tsan+0x2740) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+
+  Location is heap block of size 98288 at 0x72c800000000 allocated by main thread:
+    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
+    #1 span_alloc /home/damir/work/fs_docker_deps/spandsp/src/alloc.c:114 (gwrace_tsan+0x1169f) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #2 t38_gateway_init /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:2384 (gwrace_tsan+0xad53) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #3 main tests/test_t38_gateway_race/t38_gateway_race.c:153 (gwrace_tsan+0x2834) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+
+  Thread T2 (tid=3041992, running) created by main thread at:
+    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
+    #1 main tests/test_t38_gateway_race/t38_gateway_race.c:174 (gwrace_tsan+0x29d8) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+
+  Thread T1 (tid=3041991, running) created by main thread at:
+    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
+    #1 main tests/test_t38_gateway_race/t38_gateway_race.c:173 (gwrace_tsan+0x29bb) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+
+SUMMARY: ThreadSanitizer: data race /home/damir/work/fs_docker_deps/spandsp/src/hdlc.c:389 in hdlc_rx_init
+
+===== TSan-caught SEGV at the production crash line =====
+==3041989==ERROR: ThreadSanitizer: SEGV on unknown address 0x000000000018 (pc 0x55555555d180 bp 0x7ffff2ffd2b0 sp 0x7ffff2ffd260 T3041991)
+==3041989==The signal is caused by a READ memory access.
+==3041989==Hint: address points to the zero page.
+    #0 hdlc_rx_status /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:1722 (gwrace_tsan+0x9180) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #1 t38_hdlc_rx_put_bit /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:1945 (gwrace_tsan+0x9180)
+    #2 report_status_change /home/damir/work/fs_docker_deps/spandsp/src/fsk.c:380 (gwrace_tsan+0x14599) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #3 fsk_rx /home/damir/work/fs_docker_deps/spandsp/src/fsk.c:467 (gwrace_tsan+0x14fe2) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #4 t38_gateway_rx /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:2169 (gwrace_tsan+0xa614) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #5 audio_thread tests/test_t38_gateway_race/t38_gateway_race.c:123 (gwrace_tsan+0x2740) (BuildId: fce97da4b38950c6ba7824ef22bef2ceefb1d408)
+    #6 __tsan_thread_start_func ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1012 (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
+    #7 start_thread nptl/pthread_create.c:447 (libc.so.6+0x9caa3) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
+    #8 clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78 (libc.so.6+0x129c6b) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
+
+ThreadSanitizer can not provide additional info.
+SUMMARY: ThreadSanitizer: SEGV /home/damir/work/fs_docker_deps/spandsp/src/t38_gateway.c:1722 in hdlc_rx_status
+==3041989==ABORTING
+
+===== Distinct race sites (122 reports total) =====
+      6 SUMMARY: ThreadSanitizer: data race src/fsk.c:328 in fsk_rx_restart
+      4 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:290 in set_next_tx_type
+      4 SUMMARY: ThreadSanitizer: data race src/fsk.c:310 in fsk_rx_restart
+      3 SUMMARY: ThreadSanitizer: data race src/fsk.c:318 in fsk_rx_restart
+      3 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:536 in fax_modems_set_rx_handler
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:966 in process_hdlc_data
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:960 in process_hdlc_data
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:911 in process_rx_indicator
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:476 in finalise_hdlc_frame
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:475 in finalise_hdlc_frame
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:343 in set_next_tx_type
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:222 in hdlc_underflow_handler
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2052 in restart_rx_modem
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:1597 in to_t38_buffer_init
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:1596 in to_t38_buffer_init
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:1594 in to_t38_buffer_init
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:1593 in to_t38_buffer_init
+      2 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:1592 in to_t38_buffer_init
+      2 SUMMARY: ThreadSanitizer: data race src/power_meter.c:65 in power_meter_init
+      2 SUMMARY: ThreadSanitizer: data race src/hdlc.c:392 in hdlc_rx_init
+      2 SUMMARY: ThreadSanitizer: data race src/hdlc.c:389 in hdlc_rx_init
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:356 in fsk_rx_init
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:355 in fsk_rx_init
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:335 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:330 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:329 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:307 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:305 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:303 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:294 in fsk_rx_restart
+      2 SUMMARY: ThreadSanitizer: data race src/fsk.c:265 in fsk_rx_signal_cutoff
+      2 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:559 in fax_modems_set_rx_active
+      2 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:558 in fax_modems_set_rx_active
+      2 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:551 in fax_modems_set_rx_handler
+      2 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:541 in fax_modems_set_rx_handler
+      1 SUMMARY: ThreadSanitizer: SEGV src/t38_gateway.c:1722 in hdlc_rx_status
+      1 SUMMARY: ThreadSanitizer: data race tests/test_t38_gateway_race/t38_gateway_race.c:54 in log_message
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:912 in process_rx_indicator
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:634 in monitor_control_messages
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:301 in set_next_tx_type
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:297 in set_next_tx_type
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:294 in set_next_tx_type
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:229 in hdlc_underflow_handler
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:224 in hdlc_underflow_handler
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2103 in restart_rx_modem
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2096 in restart_rx_modem
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2095 in restart_rx_modem
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2074 in restart_rx_modem
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2072 in restart_rx_modem
+      1 SUMMARY: ThreadSanitizer: data race src/t38_gateway.c:2071 in restart_rx_modem
+      1 SUMMARY: ThreadSanitizer: data race src/silence_gen.c:107 in silence_gen_remainder
+      1 SUMMARY: ThreadSanitizer: data race src/power_meter.c:94 in power_meter_update
+      1 SUMMARY: ThreadSanitizer: data race src/power_meter.c:66 in power_meter_init
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:474 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:470 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:465 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:464 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:448 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:445 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:441 in hdlc_tx_frame
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:393 in hdlc_rx_init
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:391 in hdlc_rx_init
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:390 in hdlc_rx_init
+      1 SUMMARY: ThreadSanitizer: data race src/hdlc.c:388 in hdlc_rx_init
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:487 in fsk_rx
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:466 in fsk_rx
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:463 in fsk_rx
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:331 in fsk_rx_restart
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:306 in fsk_rx_restart
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:304 in fsk_rx_restart
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:295 in fsk_rx_restart
+      1 SUMMARY: ThreadSanitizer: data race src/fsk.c:266 in fsk_rx_signal_cutoff
+      1 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:552 in fax_modems_set_rx_handler
+      1 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:543 in fax_modems_set_rx_handler
+      1 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:538 in fax_modems_set_rx_handler
+      1 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:515 in fax_modems_set_put_bit
+      1 SUMMARY: ThreadSanitizer: data race src/fax_modems.c:514 in fax_modems_set_put_bit
+      1 SUMMARY: ThreadSanitizer: data race src/dds_int.c:399 in dds_complexi


### PR DESCRIPTION
## Problem

B2BUA segfaults in `span_log_test()` during T.38 gateway processing (TELCORE-226):

```
0 span_log_test       libspandsp
1 span_log            libspandsp
2 hdlc_rx_status      t38_gateway.c
3 t38_hdlc_rx_put_bit t38_gateway.c
4 report_status_change fsk.c
5 fsk_rx              libspandsp
6 t38_gateway_rx      libspandsp
7 t38_gateway_on_consume_media  mod_spandsp_fax.c:2235
```

`span_log_test()` is NULL-safe, so the faulting `s` is **non-NULL garbage** — a torn pointer read, not a NULL deref and not a freed-memory UAF.

## Root cause

In gateway mode a single `t38_gateway_state` is driven by **two session threads with no synchronization**:

- **audio leg** (`t38_gateway_on_consume_media`): `t38_gateway_rx`/`rx_fillin`/`tx`
- **T.38 leg** (`t38_gateway_on_soft_execute`): `udptl_rx_packet` → `t38_core_rx_ifp_packet`

When an incoming T.38 control message (e.g. CFR) on the T.38 leg drives `restart_rx_modem()` → `hdlc_rx_init()`, it `memset`s the `hdlc_rx` struct and restores `frame_user_data` a few instructions later. Meanwhile the audio leg is inside `hdlc_rx_status()` reading that same `frame_user_data` and dereferencing it in `span_log(&s->logging, …)`. A torn read yields a non-NULL garbage pointer → SIGSEGV in `span_log_test()`.

## Fix

Take the existing per-`pvt` mutex (`pvt->mutex`, already used to serialize terminal mode against the timer thread) around every spandsp call that touches the shared gateway state, on both legs. The lock is held only around the non-blocking spandsp calls and released across the blocking session read/write, so there is no added blocking under the lock and — with a single mutex — no lock-ordering deadlock.

Both legs share the same `pvt`: the T.38 leg creates it (`pvt_init`, which initialises `pvt->mutex`) and publishes it as `_t38_pvt`; the audio leg picks it up from the other channel while holding a read-lock on that session, so the `pvt` and its mutex stay alive for the whole loop. The timer thread never touches the gateway state (`add_pvt` is terminal-only), so the two legs are the only accessors.

## Validation

Standalone ThreadSanitizer reproducer added under `tests/test_t38_gateway_race/` (links libspandsp only, drives one `t38_gateway_state` from two threads exactly like the two handlers):

- `./run.sh crash` — links the shipping `libspandsp.so` → SIGSEGV with the exact production stack.
- `./run.sh tsan` — TSan-instrumented spandsp → data race on `hdlc_rx.frame_user_data` (write at `hdlc.c:389` in `hdlc_rx_init` from the T.38 leg vs. read at `t38_gateway.c:1722` in `hdlc_rx_status` from the audio leg), plus the resulting SEGV at the exact crash line; 122 distinct race sites on the shared state.
- `./run.sh fixed` — same workload compiled with `-DSERIALIZE` (models this lock) → **0 race reports, clean exit**.

Other checks: `mod_spandsp` builds + installs clean; `switch_core_codec` unit test (the only mod_spandsp-dependent test) passes 5/5.

Linear: https://linear.app/telnyx/issue/TELCORE-226