### PR TITLE
TELCORE-184: stop XML-RPC batch on API errors

### DIFF
--- a/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
+++ b/src/mod/xml_int/mod_xml_rpc/mod_xml_rpc.c
@@ -1313,6 +1313,7 @@ static xmlrpc_value *freeswitch_batch(xmlrpc_env * const envP, xmlrpc_value * co
 	for (i = 0; i < commandSize; i++) {
 		xmlrpc_value *command = NULL;
 		xmlrpc_value *value = NULL;
+		char *response = NULL;
 		
 		xmlrpc_array_read_item(envP, commands, i, &command);
 		if (envP->fault_occurred) {
@@ -1328,6 +1329,46 @@ static xmlrpc_value *freeswitch_batch(xmlrpc_env * const envP, xmlrpc_value * co
 		}
 
 		xmlrpc_array_append_item(envP, commandResults, value);
+		if (envP->fault_occurred) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to append command result to array!\n");
+			xmlrpc_DECREF(command);
+			xmlrpc_DECREF(value);
+			break;
+		}
+
+		xmlrpc_read_string(envP, value, &response);
+		if (envP->fault_occurred) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to read command response!\n");
+			xmlrpc_DECREF(command);
+			xmlrpc_DECREF(value);
+			break;
+		}
+
+		if (is_api_response_error(response)) {
+			unsigned int j = 0;
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Stopping XML-RPC batch after failed command response: [%s].\n", response);
+			for (j = i + 1; j < commandSize; j++) {
+				xmlrpc_value *not_completed = xmlrpc_build_value(envP, "s", "-ERR: Not Completed");
+				if (envP->fault_occurred) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to build skipped command response!\n");
+					break;
+				}
+
+				xmlrpc_array_append_item(envP, commandResults, not_completed);
+				xmlrpc_DECREF(not_completed);
+				if (envP->fault_occurred) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to append skipped command response!\n");
+					break;
+				}
+			}
+			switch_safe_free(response);
+			xmlrpc_DECREF(command);
+			xmlrpc_DECREF(value);
+			break;
+		}
+
+		switch_safe_free(response);
 		xmlrpc_DECREF(command);
 		xmlrpc_DECREF(value);
 	}

--- a/src/mod/xml_int/mod_xml_rpc/rpc_helper.cpp
+++ b/src/mod/xml_int/mod_xml_rpc/rpc_helper.cpp
@@ -1,3 +1,5 @@
+#include <cctype>
+#include <cstring>
 #include <string>
 #include <set>
 #include <vector>
@@ -30,6 +32,25 @@ static std::string first_token(const std::string& s)
 	if (pos == std::string::npos) return std::string();
 	const std::string::size_type end = s.find_first_of(" \t\r\n", pos);
 	return s.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+}
+
+switch_bool_t is_api_response_error(const char* response)
+{
+	if (zstr(response)) return SWITCH_FALSE;
+
+	while (*response && std::isspace(static_cast<unsigned char>(*response))) {
+		++response;
+	}
+
+	if (!std::strncmp(response, "-ERR", 4) || !std::strncmp(response, "-USAGE", 6)) {
+		return SWITCH_TRUE;
+	}
+
+	if (!std::strcmp(response, "ERROR!") || !std::strcmp(response, "UNAUTHORIZED!")) {
+		return SWITCH_TRUE;
+	}
+
+	return SWITCH_FALSE;
 }
 
 void set_min_idle_cpu_watermark(const char* idle_cpu)

--- a/src/mod/xml_int/mod_xml_rpc/rpc_helper.h
+++ b/src/mod/xml_int/mod_xml_rpc/rpc_helper.h
@@ -6,9 +6,9 @@
 SWITCH_BEGIN_EXTERN_C
 
 switch_bool_t is_resource_available(const char* comman, const char* api_str);
+switch_bool_t is_api_response_error(const char* response);
 void set_min_idle_cpu_watermark(const char* idle_cpu);
 void set_throttled_api_calls(const char* api);
 SWITCH_END_EXTERN_C
 
 #endif /* RPC_HELPER_H */
-

--- a/src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp
+++ b/src/mod/xml_int/mod_xml_rpc/test/test_rpc_helper.cpp
@@ -32,6 +32,7 @@ static inline double switch_core_idle_cpu(void) { return g_idle_cpu; }
 #define RPC_HELPER_H
 extern "C" {
 	switch_bool_t is_resource_available(const char *command, const char *api_str);
+	switch_bool_t is_api_response_error(const char *response);
 	void set_min_idle_cpu_watermark(const char *idle_cpu);
 	void set_throttled_api_calls(const char *api);
 }
@@ -262,6 +263,26 @@ static void test_null_or_empty_cmd(void)
 		"empty cmd: not throttled");
 }
 
+static void test_api_response_error_detection(void)
+{
+	CHECK(is_api_response_error("-ERR: Not Completed") == SWITCH_TRUE,
+		"api_response: -ERR marks failure");
+	CHECK(is_api_response_error("  \r\n-ERR invalid argument") == SWITCH_TRUE,
+		"api_response: leading whitespace before -ERR marks failure");
+	CHECK(is_api_response_error("-USAGE: uuid_media <uuid> [off|on]") == SWITCH_TRUE,
+		"api_response: -USAGE marks failure");
+	CHECK(is_api_response_error("ERROR!") == SWITCH_TRUE,
+		"api_response: switch_api_execute failure marks failure");
+	CHECK(is_api_response_error("UNAUTHORIZED!") == SWITCH_TRUE,
+		"api_response: authorization failure marks failure");
+	CHECK(is_api_response_error("+OK queued") == SWITCH_FALSE,
+		"api_response: +OK is success");
+	CHECK(is_api_response_error("OK") == SWITCH_FALSE,
+		"api_response: plain OK is success");
+	CHECK(is_api_response_error(NULL) == SWITCH_FALSE,
+		"api_response: NULL response is not classified as API failure");
+}
+
 int main(void)
 {
 	struct { const char *name; void (*fn)(void); } tests[] = {
@@ -277,6 +298,7 @@ int main(void)
 		{"whitespace_tokenization",                    test_whitespace_tokenization},
 		{"idle_exactly_at_watermark_allowed",          test_idle_exactly_at_watermark_allowed},
 		{"null_or_empty_cmd",                          test_null_or_empty_cmd},
+		{"api_response_error_detection",               test_api_response_error_detection},
 	};
 	for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
 		printf("[%s]\n", tests[i].name);


### PR DESCRIPTION
Summary:
- Stop freeswitch_batch after freeswitch_api returns an error response.
- Preserve response array length by marking skipped commands as -ERR: Not Completed.
- Treat -ERR, -USAGE, ERROR!, and UNAUTHORIZED! responses as batch-stopping API errors.

Verification:
- git diff --cached --check
- Docker build: make -C src/mod/xml_int/mod_xml_rpc test/test_rpc_helper mod_xml_rpc.la
- helper test: 37/37 passed