### PR TITLE
TELCORE-250: fix video-bridge engine-function use-after-free crash in kill_channel

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -9731,17 +9731,22 @@ static void *SWITCH_THREAD_FUNC text_helper_thread(switch_thread_t *thread, void
 	while (switch_channel_up_nosig(channel)) {
 
 		if (t_engine->engine_function) {
-			int run = 0;
+			switch_engine_function_t run_fn = NULL;
+			void *run_data = NULL;
 
 			switch_mutex_lock(smh->control_mutex);
-			if (t_engine->engine_function_running == 0) {
+			/* Latch the job under the lock and re-check engine_function: it may
+			 * have been cancelled by end_engine_function() since the unlocked
+			 * test above. */
+			if (t_engine->engine_function && t_engine->engine_function_running == 0) {
 				t_engine->engine_function_running = 1;
-				run = 1;
+				run_fn = t_engine->engine_function;
+				run_data = t_engine->engine_user_data;
 			}
 			switch_mutex_unlock(smh->control_mutex);
 
-			if (run) {
-				t_engine->engine_function(session, t_engine->engine_user_data);
+			if (run_fn) {
+				run_fn(session, run_data);
 				switch_mutex_lock(smh->control_mutex);
 				t_engine->engine_function = NULL;
 				t_engine->engine_user_data = NULL;
@@ -9939,17 +9944,22 @@ static void *SWITCH_THREAD_FUNC video_helper_thread(switch_thread_t *thread, voi
 		}
 
 		if (v_engine->engine_function) {
-			int run = 0;
+			switch_engine_function_t run_fn = NULL;
+			void *run_data = NULL;
 
 			switch_mutex_lock(smh->control_mutex);
-			if (v_engine->engine_function_running == 0) {
+			/* Latch the job under the lock and re-check engine_function: it may
+			 * have been cancelled by end_engine_function() since the unlocked
+			 * test above. */
+			if (v_engine->engine_function && v_engine->engine_function_running == 0) {
 				v_engine->engine_function_running = 1;
-				run = 1;
+				run_fn = v_engine->engine_function;
+				run_data = v_engine->engine_user_data;
 			}
 			switch_mutex_unlock(smh->control_mutex);
 
-			if (run) {
-				v_engine->engine_function(session, v_engine->engine_user_data);
+			if (run_fn) {
+				run_fn(session, run_data);
 				switch_mutex_lock(smh->control_mutex);
 				v_engine->engine_function = NULL;
 				v_engine->engine_user_data = NULL;
@@ -10096,7 +10106,14 @@ SWITCH_DECLARE(int) switch_core_media_check_engine_function(switch_core_session_
 	engine = &smh->engines[type];
 
 	switch_mutex_lock(smh->control_mutex);
-	r = (engine->engine_function_running > 0);
+	/* An outstanding job exists as soon as it has been submitted (engine_function
+	 * set), not only once the media thread has actually started running it
+	 * (engine_function_running > 0). Reporting only the "running" state opened a
+	 * window where a caller (the bridge) that submitted a job pointing at a
+	 * stack-allocated context would skip switch_core_media_end_engine_function()
+	 * and let that stack go out of scope while the job was still pending, so the
+	 * media thread later invoked it with a dangling user_data. */
+	r = (engine->engine_function_running > 0 || engine->engine_function != NULL);
 	switch_mutex_unlock(smh->control_mutex);
 
 	return r;
@@ -10115,7 +10132,16 @@ SWITCH_DECLARE(void) switch_core_media_end_engine_function(switch_core_session_t
 
 	switch_mutex_lock(smh->control_mutex);
 	if (engine->engine_function_running > 0) {
+		/* Already running: ask it to stop and wait below for the media thread
+		 * to clear engine_function_running back to 0 when the job returns. */
 		engine->engine_function_running = -1;
+	} else if (engine->engine_function) {
+		/* Submitted but the media thread has not picked it up yet. Cancel it in
+		 * place so the thread never runs it against a user_data whose lifetime is
+		 * ending. The media thread's pickup re-checks engine_function under the
+		 * control_mutex, so clearing it here is safe against a concurrent start. */
+		engine->engine_function = NULL;
+		engine->engine_user_data = NULL;
 	}
 	switch_mutex_unlock(smh->control_mutex);
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 			   switch_ivr_play_say switch_core_codec switch_rtp switch_xml
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log switch_stun switch_trickle_ice
 
-noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec
+noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race
 
 if HAVE_SOFIA_SIP
 noinst_PROGRAMS += switch_sdp

--- a/tests/unit/test_video_bridge_engine_race.c
+++ b/tests/unit/test_video_bridge_engine_race.c
@@ -1,0 +1,252 @@
+/*
+ * Regression test for the video-bridge engine-function use-after-free crash.
+ *
+ * Production stack (release build line numbers):
+ *   switch_core_session_perform_kill_channel()  switch_core_io.c:1165   <-- crash
+ *   video_bridge_thread()                        switch_ivr_bridge.c:293
+ *   video_helper_thread()                        switch_core_media.c:9953
+ *   dummy_worker() / start_thread() / clone3()
+ *
+ * Root cause
+ * ----------
+ * A bridge runs on the audio bridge thread and, for video, hands a
+ * *stack-allocated* context (`struct vid_helper vh`) to another thread via:
+ *
+ *      switch_core_media_start_engine_function(session_a, VIDEO,
+ *                                              video_bridge_thread, &vh);
+ *
+ * start_engine_function() only publishes the job:
+ *      engine->engine_function      = video_bridge_thread;   // set
+ *      engine->engine_user_data     = &vh;                   // set (stack ptr!)
+ *      engine->engine_function_running = 0;                  // NOT yet started
+ *
+ * The media thread (video_helper_thread) flips engine_function_running to 1
+ * only later, when it actually picks the job up.
+ *
+ * At bridge teardown the audio thread decides whether it must wait for that job
+ * with:
+ *      if (switch_core_media_check_engine_function(session_a, VIDEO)) {
+ *          ...
+ *          switch_core_media_end_engine_function(session_a, VIDEO);   // waits
+ *      }
+ *
+ * but check_engine_function() reported only `engine_function_running > 0`. In
+ * the window between "job submitted" and "job picked up", that is 0, so the
+ * bridge SKIPS end_engine_function(), returns, and its stack frame (holding
+ * `vh`) is destroyed. The media thread then finally runs the job with
+ * user_data == &vh pointing at a dead stack frame -> video_bridge_thread()
+ * dereferences a dangling `vh->session_b` and kill_channel() faults on its
+ * garbage endpoint_interface.
+ *
+ * The fix
+ * -------
+ *  - check_engine_function() reports an outstanding job as soon as it is
+ *    submitted (engine_function != NULL), not only once it is running.
+ *  - end_engine_function() cancels a submitted-but-not-started job in place.
+ *  - the media-thread pickup latches the job under control_mutex and re-checks
+ *    engine_function, so a concurrent cancel is race-free.
+ *
+ * What this test does
+ * -------------------
+ * It drives the exact public contract the bridge relies on, deterministically,
+ * with no reliance on real video media:
+ *
+ *   1. Originate an answered "null" session and give it a media handle.
+ *   2. Submit an engine function to the VIDEO engine while CF_VIDEO is OFF, so
+ *      start_video_thread() is a no-op and NOBODY can pick the job up: it stays
+ *      pending forever. This freezes the exact race window deterministically.
+ *   3. Assert check_engine_function() == true.  <-- the crux.
+ *          BUGGY tree: returns 0  -> assertion FAILS (this is the bug: the
+ *                      bridge would skip the wait and free the stack context).
+ *          FIXED tree: returns 1.
+ *   4. Run the bridge's teardown guard verbatim
+ *          if (check_engine_function()) end_engine_function();
+ *      and assert the pending job is gone afterwards (check == false), i.e. it
+ *      is now safe to free the context. On a buggy tree the guard is skipped
+ *      and the job would still be live.
+ *   5. Free the heap context that stood in for `vh`, then start a REAL video
+ *      helper thread and give it time to pick up anything left behind. On a
+ *      fixed tree nothing is left (job cancelled) so the helper never touches
+ *      the freed context; on a buggy tree the stale job fires and reads the
+ *      freed context (SIGSEGV / ASan use-after-free), exactly as in production.
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+
+/* Stand-in for the bridge's stack-allocated `struct vid_helper vh`. Heap so we
+ * can free it (modelling the stack frame going out of scope) and hand the media
+ * thread a dangling pointer, exactly like the production bug. */
+typedef struct {
+	uint32_t canary;
+	switch_core_session_t *session_b; /* like vh->session_b */
+	volatile int *fn_ran;
+} engine_ctx_t;
+
+#define ENGINE_CTX_CANARY 0xC0FFEEu
+
+static volatile int g_fn_ran = 0;
+
+/* Stands in for video_bridge_thread(): the media thread invokes this with the
+ * user_data captured at submit time. Its final act mirrors
+ * video_bridge_thread()'s: switch_core_session_kill_channel(vh->session_b, ...).
+ * When the context is dangling, session_b is garbage and kill_channel() faults
+ * on its endpoint_interface exactly like switch_core_io.c:1165 in production. */
+static void test_engine_function(switch_core_session_t *session, void *user_data)
+{
+	engine_ctx_t *ctx = (engine_ctx_t *) user_data;
+
+	(void) session;
+	g_fn_ran = 1;
+	/* video_bridge_thread()'s final act (switch_ivr_bridge.c:292). On a dangling
+	 * context session_b is a wild pointer and this faults in
+	 * switch_core_session_perform_kill_channel(), the production frame 0. */
+	switch_core_session_kill_channel(ctx->session_b, SWITCH_SIG_BREAK);
+}
+
+static switch_core_session_t *originate_null_session(void)
+{
+	switch_core_session_t *session = NULL;
+	switch_call_cause_t cause = SWITCH_CAUSE_NONE;
+	switch_status_t status;
+
+	status = switch_ivr_originate(NULL, &session, &cause,
+								  "null/+15553334444",
+								  0, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+
+	if (status != SWITCH_STATUS_SUCCESS || !session) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "[TEST] originate failed: status=%d cause=%d\n", status, cause);
+		return NULL;
+	}
+	return session;
+}
+
+/* Give the session a media handle so the engine-function API (which needs
+ * smh->control_mutex) is usable. */
+static switch_status_t attach_media_handle(switch_core_session_t *session)
+{
+	switch_media_handle_t *media_handle = NULL;
+	switch_core_media_params_t *mparams;
+
+	mparams = switch_core_session_alloc(session, sizeof(*mparams));
+	mparams->num_codecs = 1;
+	mparams->inbound_codec_string = switch_core_session_strdup(session, "PCMU");
+	mparams->outbound_codec_string = switch_core_session_strdup(session, "PCMU");
+	mparams->rtpip = switch_core_session_strdup(session, "127.0.0.1");
+
+	return switch_media_handle_create(&media_handle, session, mparams);
+}
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(video_bridge_engine_race)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_loopback");
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		/*
+		 * The deterministic contract test. Fails on a buggy tree at step 3,
+		 * passes on a fixed tree.
+		 */
+		FST_TEST_BEGIN(test_pending_engine_function_is_waited_on)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			engine_ctx_t *ctx = NULL;
+			int fn_ran_flag = 0;
+			int outstanding;
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "===== VIDEO-BRIDGE ENGINE-FUNCTION RACE TEST =====\n");
+
+			session = originate_null_session();
+			fst_requires(session);
+			channel = switch_core_session_get_channel(session);
+			fst_requires(channel);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+
+			/* Heap context standing in for the bridge's stack `vh`. */
+			ctx = malloc(sizeof(*ctx));
+			fst_requires(ctx);
+			ctx->canary = ENGINE_CTX_CANARY;
+			ctx->session_b = session; /* stands in for vh->session_b */
+			ctx->fn_ran = &fn_ran_flag;
+			g_fn_ran = 0;
+
+			/* CF_VIDEO is OFF: start_video_thread() is a no-op, so no media
+			 * thread exists to pick the job up. The job is pinned "pending",
+			 * freezing the production race window deterministically. */
+			fst_requires(!switch_channel_test_flag(channel, CF_VIDEO));
+
+			switch_core_media_start_engine_function(session, SWITCH_MEDIA_TYPE_VIDEO,
+													test_engine_function, ctx);
+
+			/* THE CRUX: a job was submitted, so the bridge's teardown guard must
+			 * see an outstanding job and wait for it. */
+			outstanding = switch_core_media_check_engine_function(session, SWITCH_MEDIA_TYPE_VIDEO);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] check_engine_function after submit = %d (expect 1)\n", outstanding);
+			fst_check(outstanding == 1);
+
+			/* Bridge teardown guard, verbatim (switch_ivr_bridge.c:1221). */
+			if (switch_core_media_check_engine_function(session, SWITCH_MEDIA_TYPE_VIDEO)) {
+				switch_core_media_end_engine_function(session, SWITCH_MEDIA_TYPE_VIDEO);
+			}
+
+			/* After the guard the job must be resolved, so freeing the context
+			 * is safe. */
+			outstanding = switch_core_media_check_engine_function(session, SWITCH_MEDIA_TYPE_VIDEO);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] check_engine_function after teardown guard = %d (expect 0)\n", outstanding);
+			fst_check(outstanding == 0);
+
+			/* Free the stand-in for the stack context, then overwrite the freed
+			 * slot with garbage - modelling the bridge's stack frame going out
+			 * of scope and being reused. glibc hands the just-freed block back
+			 * to the next same-size malloc, so ctx->session_b now reads as a
+			 * wild pointer, exactly like a dangling vh->session_b. */
+			free(ctx);
+			{
+				int i;
+				for (i = 0; i < 8; i++) {
+					void *p = malloc(sizeof(engine_ctx_t));
+					memset(p, 0xAB, sizeof(engine_ctx_t));
+				}
+			}
+			/* ctx is intentionally left pointing at the freed/overwritten slot. */
+
+			/* Now let a REAL video helper thread run and pick up anything that
+			 * was (incorrectly) left pending. On a fixed tree the job was
+			 * cancelled, so it must never fire against the freed context; on a
+			 * buggy tree it invokes test_engine_function() -> kill_channel() on
+			 * the wild session_b and SIGSEGVs, reproducing the production stack. */
+			switch_channel_set_flag(channel, CF_VIDEO);
+			switch_core_session_start_video_thread(session);
+
+			switch_yield(500000); /* 0.5s for the helper to loop a few times */
+
+			fst_check(g_fn_ran == 0);
+			fst_check(fn_ran_flag == 0);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] stale engine function ran = %d (expect 0)\n", g_fn_ran);
+
+			switch_channel_hangup(channel, SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "===== TEST COMPLETED =====\n\n");
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()


### PR DESCRIPTION
## Summary

Fixes the b2bua crash reported in [TELCORE-250](https://linear.app/telnyx/issue/TELCORE-250):

```
0 [switch_core_session_perform_kill_channel()] src/switch_core_io.c:1165
1 [video_bridge_thread()]                       src/switch_ivr_bridge.c:293
2 [video_helper_thread()]                       src/switch_core_media.c:9953
3 [dummy_worker()] / start_thread() / clone3()
```

## Root cause

The audio bridge thread hands `video_bridge_thread` to the media thread as an engine
function whose `user_data` points at its **stack-allocated** `struct vid_helper vh`:

```c
switch_core_media_start_engine_function(session_a, VIDEO, video_bridge_thread, &vh);
```

`start_engine_function()` only publishes the job (`engine_function` + `engine_user_data`
set, `engine_function_running` still `0`). The media thread flips
`engine_function_running` to `1` only later, when it actually picks the job up.

At teardown the bridge decides whether it must wait for the job with:

```c
if (switch_core_media_check_engine_function(session_a, VIDEO)) {
    switch_core_media_end_engine_function(session_a, VIDEO);
}
```

but `check_engine_function()` reported only `engine_function_running > 0`. In the window
between "submitted" and "picked up" that is `0`, so the bridge **skips**
`end_engine_function()`, returns, and its stack frame holding `vh` goes out of scope. The
media thread then finally runs `video_bridge_thread(&dead_vh)`, which dereferences a
dangling `vh->session_b`, and `kill_channel()` faults on its garbage `endpoint_interface`
at `switch_core_io.c:1165`.

## Fix

Close the gap in the engine-function lifecycle (`src/switch_core_media.c`):

- `check_engine_function()` reports an outstanding job as soon as it is submitted
  (`engine_function != NULL`), not only once it is running — so the bridge always waits.
- `end_engine_function()` cancels a submitted-but-not-started job in place, so the media
  thread never runs it against a `user_data` whose lifetime is ending.
- The text/video media-thread pickups latch the job under `control_mutex` and re-check
  `engine_function`, making a concurrent cancel race-free.

Blast radius is small: `check_engine_function()` is consumed only by the bridge, and only
the text/video helpers run engine functions.

## Test

`tests/unit/test_video_bridge_engine_race.c` freezes the race window deterministically
(submits the job with `CF_VIDEO` off so no media thread can pick it up) and:

1. asserts `check_engine_function()` reports the outstanding job — the crux;
2. runs the bridge's teardown guard verbatim and asserts the job is resolved afterwards;
3. frees the stand-in for `vh`, starts a real video helper, and asserts the stale job is
   never invoked.

- **Unpatched tree:** assertion fails (`check == 0`) and the real video helper invokes the
  stale job on the freed context, SIGSEGV'ing in `switch_core_session_perform_kill_channel`
  with `session=0xabababababababab` — the production stack.
- **This branch:** `check == 1` after submit, `0` after the teardown guard, stale job never
  runs. Test passes.
