### PR TITLE
TELCORE-57: Add switch_telnyx_track_session dispatch function

### DIFF
--- a/src/include/switch_telnyx.h
+++ b/src/include/switch_telnyx.h
@@ -10,6 +10,7 @@ typedef void (*switch_telnyx_sofia_on_hangup_func)(switch_core_session_t *);
 typedef switch_bool_t (*switch_telnyx_sofia_on_init_func)(switch_core_session_t *);
 typedef void (*switch_telnyx_channel_on_answer_func)(switch_core_session_t *);
 typedef void (*switch_telnyx_on_set_variable_func)(switch_channel_t*, const char*, const char*);
+typedef void (*switch_telnyx_track_session_func)(const char* uuid, switch_time_t base_time);
 typedef int (*switch_telnyx_recover_func)(switch_core_session_t *);
 typedef void (*switch_telnyx_on_channel_recover_func)(switch_channel_t*);
 typedef void (*switch_telnyx_on_populate_event_func)(switch_event_t *);
@@ -79,6 +80,7 @@ typedef struct switch_telnyx_event_dispatch_s {
 	switch_telnyx_sofia_on_hangup_func switch_telnyx_sofia_on_hangup;
 	switch_telnyx_channel_on_answer_func switch_telnyx_channel_on_answer;
 	switch_telnyx_on_set_variable_func switch_telnyx_on_set_variable;
+	switch_telnyx_track_session_func switch_telnyx_track_session;
 	switch_telnyx_recover_func switch_telnyx_call_recover;
 	switch_telnyx_on_channel_recover_func switch_telnyx_on_channel_recover;
 	switch_telnyx_publish_json_event_func switch_telnyx_publish_json_event;
@@ -106,6 +108,7 @@ SWITCH_DECLARE(void) switch_telnyx_sofia_on_hangup(switch_core_session_t *sessio
 SWITCH_DECLARE(void) switch_telnyx_channel_on_answer(switch_core_session_t *session);
 SWITCH_DECLARE(switch_telnyx_event_dispatch_t*) switch_telnyx_event_dispatch(void);
 SWITCH_DECLARE(void) switch_telnyx_on_set_variable(switch_channel_t* channel, const char* name, const char* value);
+SWITCH_DECLARE(void) switch_telnyx_track_session(const char* uuid, switch_time_t base_time);
 SWITCH_DECLARE(int) switch_telnyx_call_recover(switch_core_session_t* session);
 SWITCH_DECLARE(void) switch_telnyx_on_channel_recover(switch_channel_t* channel);
 SWITCH_DECLARE(void) switch_telnyx_on_populate_event(switch_event_t* event);

--- a/src/switch_telnyx.cpp
+++ b/src/switch_telnyx.cpp
@@ -83,6 +83,13 @@ void switch_telnyx_on_set_variable(switch_channel_t* channel, const char* name, 
 	}
 }
 
+void switch_telnyx_track_session(const char* uuid, switch_time_t base_time)
+{
+	if (_event_dispatch.switch_telnyx_track_session) {
+		_event_dispatch.switch_telnyx_track_session(uuid, base_time);
+	}
+}
+
 int switch_telnyx_call_recover(switch_core_session_t* session)
 {
 	if (_event_dispatch.switch_telnyx_call_recover) {


### PR DESCRIPTION
## TELCORE-57: ZMQ event timeline not populated for recovered inbound calls

### Problem
Recovered inbound calls with `call_control=true` were missing the ZMQ event timeline. The variable-change hook that triggers session tracking in the event tracker may not fire during XML CDR restoration, so the session never gets tracked and `zmq_event_timeline` is never populated on hangup.

### Changes
- Added `switch_telnyx_track_session` to the event dispatch table
- Added typedef, dispatch field, and NULL-guarded implementation in `switch_telnyx.cpp`

### Related PRs
- mod_call_recovery: calls `switch_telnyx_track_session` after successful recovery
- mod_telnyx: wires the dispatch function to the event tracker + adds CHANNEL_CREATE to ZMQ config

### Testing
- Build verification in progress
- Scenario analysis covers 14 edge cases (idempotency, thread safety, failed recovery, NULL UUIDs, disabled tracker, etc.)
