### PR TITLE
TELCORE-249: add mod_lumenvox ASR unit tests

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -43,6 +43,8 @@ switch_xml
 switch_estimators
 switch_jitter_buffer
 test_sofia
+switch_mod_lumenvox
+conf_lumenvox/[0-9]*/**
 .deps/
 Makefile
 conf/*/

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -6,6 +6,10 @@ noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer
 
 noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race
 
+# switch_mod_lumenvox is intentionally NOT built/run in CI yet: LumenVox servers
+# are not reachable from CI, so the ASR tests cannot run there. Re-enable by
+# appending switch_mod_lumenvox to the line above. See TELCORE-249.
+
 if HAVE_SOFIA_SIP
 noinst_PROGRAMS += switch_sdp
 switch_sdp_SOURCES = switch_sdp.c

--- a/tests/unit/conf_lumenvox/freeswitch.xml
+++ b/tests/unit/conf_lumenvox/freeswitch.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 <document type="freeswitch/xml">
   <X-PRE-PROCESS cmd="set" data="rtp_timer_name=soft"/>
+  <!-- Live mode (see switch_mod_lumenvox.c): LV_TEST_TARGET points the profile
+       at a reachable LumenVox gRPC API, LV_TEST_DEPLOYMENT/LV_TEST_OPERATOR
+       supply the tenancy UUIDs. Unset (CI), the profile targets a closed local
+       port with nil tenancy ids and open is asserted to fail closed. -->
+  <X-PRE-PROCESS cmd="exec-set" data="lv_test_target=echo ${LV_TEST_TARGET:-127.0.0.1:1}"/>
+  <X-PRE-PROCESS cmd="exec-set" data="lv_test_deployment=echo ${LV_TEST_DEPLOYMENT:-00000000-0000-0000-0000-000000000000}"/>
+  <X-PRE-PROCESS cmd="exec-set" data="lv_test_operator=echo ${LV_TEST_OPERATOR:-00000000-0000-0000-0000-000000000000}"/>
   <section name="configuration" description="Various Configuration">
     <configuration name="modules.conf" description="Modules">
       <modules>
@@ -37,9 +44,9 @@
     </configuration>
 
     <!-- mod_lumenvox config. The target is deliberately a closed local port so
-         the unit test exercises the FreeSWITCH-facing ASR interface offline
-         (no live LumenVox server in CI): session open still succeeds, and any
-         operation that needs the server fails gracefully rather than hanging. -->
+         the unit test asserts that session open fails CLOSED, promptly
+         (bounded by connect-timeout-ms), rather than handing out a half-open
+         handle. With LV_TEST_* set, it targets a real server instead. -->
     <configuration name="lumenvox.conf" description="LumenVox gRPC ASR/TTS">
       <settings>
         <param name="default-asr-profile" value="default"/>
@@ -48,9 +55,9 @@
       </settings>
       <profiles>
         <profile name="default">
-          <param name="target" value="127.0.0.1:1"/>
-          <param name="deployment-id" value="2c62306f-5049-4cea-82c9-0e694f79f7f3"/>
-          <param name="operator-id" value="00000000-0000-0000-0000-000000000000"/>
+          <param name="target" value="$${lv_test_target}"/>
+          <param name="deployment-id" value="$${lv_test_deployment}"/>
+          <param name="operator-id" value="$${lv_test_operator}"/>
           <param name="language" value="en-US"/>
           <param name="voice" value="chris"/>
           <param name="use-tls" value="false"/>

--- a/tests/unit/conf_lumenvox/freeswitch.xml
+++ b/tests/unit/conf_lumenvox/freeswitch.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<document type="freeswitch/xml">
+  <X-PRE-PROCESS cmd="set" data="rtp_timer_name=soft"/>
+  <section name="configuration" description="Various Configuration">
+    <configuration name="modules.conf" description="Modules">
+      <modules>
+        <load module="mod_console"/>
+        <load module="mod_loopback"/>
+        <load module="mod_tone_stream"/>
+        <load module="mod_dptools"/>
+        <load module="mod_sndfile"/>
+        <load module="mod_dialplan_xml"/>
+        <load module="mod_commands"/>
+        <load module="mod_lumenvox"/>
+      </modules>
+    </configuration>
+
+    <configuration name="switch.conf" description="Core Configuration">
+      <default-ptimes>
+      </default-ptimes>
+      <settings>
+        <param name="colorize-console" value="false"/>
+        <param name="dialplan-timestamps" value="false"/>
+        <param name="loglevel" value="debug"/>
+        <param name="rtp-enable-zrtp" value="false"/>
+      </settings>
+    </configuration>
+
+    <configuration name="console.conf" description="Console Logger">
+      <mappings>
+        <map name="all" value="console,debug,info,notice,warning,err,crit,alert"/>
+      </mappings>
+      <settings>
+        <param name="colorize" value="true"/>
+        <param name="loglevel" value="debug"/>
+      </settings>
+    </configuration>
+
+    <!-- mod_lumenvox config. The target is deliberately a closed local port so
+         the unit test exercises the FreeSWITCH-facing ASR interface offline
+         (no live LumenVox server in CI): session open still succeeds, and any
+         operation that needs the server fails gracefully rather than hanging. -->
+    <configuration name="lumenvox.conf" description="LumenVox gRPC ASR/TTS">
+      <settings>
+        <param name="default-asr-profile" value="default"/>
+        <param name="default-tts-profile" value="default"/>
+        <param name="enable-profile-events" value="true"/>
+      </settings>
+      <profiles>
+        <profile name="default">
+          <param name="target" value="127.0.0.1:1"/>
+          <param name="deployment-id" value="2c62306f-5049-4cea-82c9-0e694f79f7f3"/>
+          <param name="operator-id" value="00000000-0000-0000-0000-000000000000"/>
+          <param name="language" value="en-US"/>
+          <param name="voice" value="chris"/>
+          <param name="use-tls" value="false"/>
+          <param name="connect-timeout-ms" value="1000"/>
+        </profile>
+      </profiles>
+    </configuration>
+  </section>
+
+  <section name="dialplan" description="Regex/XML Dialplan">
+    <context name="default">
+    </context>
+  </section>
+</document>

--- a/tests/unit/switch_mod_lumenvox.c
+++ b/tests/unit/switch_mod_lumenvox.c
@@ -8,12 +8,20 @@
  * switch_core_asr_* API -- exactly how the core (play_and_detect_speech, etc.)
  * uses it.
  *
- * There is no live LumenVox gRPC server in CI, so conf_lumenvox points the
- * profile at a closed local port (127.0.0.1:1). That is deliberate: it lets us
- * validate the whole interface surface offline. The server-independent logic
- * (grammar bookkeeping, param handling, handle lifecycle, guard conditions) is
- * asserted exactly; the operations that need the server are asserted to fail
- * *gracefully* (deterministic status, no crash, no hang) rather than to succeed.
+ * The suite runs in one of two modes:
+ *
+ *  - Offline (default, CI): conf_lumenvox points the profile at a closed local
+ *    port (127.0.0.1:1). lv_session_open() fails closed when no session_id
+ *    arrives within connect-timeout-ms, so switch_core_asr_open() against a
+ *    dead backend must FAIL promptly -- that fail-closed contract is what the
+ *    offline tests assert. Everything that needs an open handle is live-only.
+ *
+ *  - Live: set LV_TEST_TARGET (host:port of a reachable LumenVox gRPC API) and
+ *    LV_TEST_DEPLOYMENT / LV_TEST_OPERATOR (tenancy UUIDs) to run the full
+ *    interface surface against a real server: open/close, grammar bookkeeping,
+ *    params, guards, handle lifecycle. Recognition itself is still not asserted
+ *    to succeed -- that depends on the ASR engine being provisioned on the
+ *    target deployment.
  *
  * TTS is intentionally not covered here: the LumenVox TTS engine is not reliably
  * available on the dev deployment, and this suite is scoped to ASR.
@@ -27,6 +35,14 @@
  * module is ever switched to the transparent "unimrcp" drop-in name, change this
  * single define. */
 #define LV_ENGINE "lumenvox"
+
+/* Live mode: a reachable LumenVox server was provided via the environment
+ * (conf_lumenvox/freeswitch.xml picks the same variables up via exec-set). */
+static int lv_live(void)
+{
+	const char *t = getenv("LV_TEST_TARGET");
+	return t && *t;
+}
 
 /* Open an ASR handle on the default profile; used by most tests. */
 static switch_status_t lv_open(switch_asr_handle_t *ah, switch_memory_pool_t *pool)
@@ -56,14 +72,22 @@ FST_CORE_BEGIN("./conf_lumenvox")
 		}
 		FST_TEARDOWN_END()
 
-		/* The interface loads and a handle can be opened on the default profile
-		 * and cleanly closed. */
+		/* Live: a handle can be opened on the default profile and cleanly
+		 * closed. Offline: open must fail CLOSED, and promptly (bounded by
+		 * connect-timeout-ms) -- a dead backend must not hand out a half-open
+		 * handle that only breaks later, mid-recognition. */
 		FST_TEST_BEGIN(asr_open_close)
 		{
 			switch_asr_handle_t ah = { 0 };
-			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
-			fst_check(ah.private_info != NULL);
-			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			if (lv_live()) {
+				fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+				fst_check(ah.private_info != NULL);
+				fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			} else {
+				switch_time_t started = switch_time_now();
+				fst_check(lv_open(&ah, fst_pool) != SWITCH_STATUS_SUCCESS);
+				fst_check(switch_time_now() - started < 3000000); /* well under 3 s */
+			}
 		}
 		FST_TEST_END()
 
@@ -77,11 +101,13 @@ FST_CORE_BEGIN("./conf_lumenvox")
 		}
 		FST_TEST_END()
 
-		/* Grammar bookkeeping is entirely server-independent, so it is asserted
-		 * exactly: load, enable/disable, disable-all, unload, and the correct
-		 * failure codes for operations on unknown grammar names. */
+		/* Grammar bookkeeping is server-independent once a handle is open, and
+		 * is asserted exactly: load, enable/disable, disable-all, unload, and
+		 * the correct failure codes for operations on unknown grammar names.
+		 * Live-only: opening a handle requires a reachable server. */
 		FST_TEST_BEGIN(asr_grammar_management)
 		{
+			if (lv_live()) {
 			switch_asr_handle_t ah = { 0 };
 			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
 
@@ -109,13 +135,16 @@ FST_CORE_BEGIN("./conf_lumenvox")
 			fst_check(switch_core_asr_unload_grammar(&ah, "nope") == SWITCH_STATUS_SUCCESS);
 
 			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
 		}
 		FST_TEST_END()
 
 		/* Param setters accept known/unknown params without crashing, and with
-		 * no recognition in flight the result accessors report "nothing yet". */
+		 * no recognition in flight the result accessors report "nothing yet".
+		 * Live-only: needs an open handle. */
 		FST_TEST_BEGIN(asr_params_and_empty_results)
 		{
+			if (lv_live()) {
 			switch_asr_handle_t ah = { 0 };
 			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
 			char *xmlstr = NULL;
@@ -140,13 +169,16 @@ FST_CORE_BEGIN("./conf_lumenvox")
 			fst_check(headers == NULL);
 
 			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
 		}
 		FST_TEST_END()
 
 		/* Feeding audio before recognition has started is a no-op that succeeds
-		 * (the interface must tolerate early frames). */
+		 * (the interface must tolerate early frames). Live-only: needs an open
+		 * handle. */
 		FST_TEST_BEGIN(asr_feed_before_start)
 		{
+			if (lv_live()) {
 			switch_asr_handle_t ah = { 0 };
 			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
 			int16_t frame[160];                 /* 20 ms @ 8 kHz mono L16 */
@@ -158,15 +190,18 @@ FST_CORE_BEGIN("./conf_lumenvox")
 			fst_check(switch_core_asr_feed(&ah, frame, sizeof(frame), &flags) == SWITCH_STATUS_SUCCESS);
 
 			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
 		}
 		FST_TEST_END()
 
-		/* With no reachable server, the operations that need one must fail
-		 * gracefully and promptly -- resume() cannot start recognition, DTMF has
-		 * no interaction to target -- while the local guards (cancel, timers,
-		 * pause) still succeed. Nothing here may hang or crash. */
-		FST_TEST_BEGIN(asr_guards_without_server)
+		/* With no recognition in flight the guarded operations behave
+		 * deterministically regardless of what is provisioned server-side:
+		 * resume() with no enabled grammar fails locally, DTMF has no
+		 * interaction to target, and the local-only operations (timers,
+		 * cancel, pause) succeed. Live-only: needs an open handle. */
+		FST_TEST_BEGIN(asr_guards_without_recognition)
 		{
+			if (lv_live()) {
 			switch_asr_handle_t ah = { 0 };
 			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
 			switch_dtmf_t dtmf = { 0 };
@@ -174,10 +209,8 @@ FST_CORE_BEGIN("./conf_lumenvox")
 			dtmf.duration = 2000;
 
 			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
-			fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
-			fst_check(switch_core_asr_enable_grammar(&ah, "g1") == SWITCH_STATUS_SUCCESS);
 
-			/* cannot reach the gRPC server -> recognition start fails cleanly */
+			/* no grammar loaded/enabled -> recognition start fails cleanly */
 			fst_check(switch_core_asr_resume(&ah) != SWITCH_STATUS_SUCCESS);
 
 			/* no active interaction -> DTMF injection fails cleanly */
@@ -189,18 +222,47 @@ FST_CORE_BEGIN("./conf_lumenvox")
 			fst_check(switch_core_asr_pause(&ah) == SWITCH_STATUS_SUCCESS);
 
 			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
 		}
 		FST_TEST_END()
 
-		/* Repeated open/close cycles must not crash or leak handles/threads. */
+		/* pause -> resume -> pause cycles on one handle must never crash: they
+		 * used to overwrite a still-joinable writer std::thread, which calls
+		 * std::terminate(). resume()'s status is deliberately not asserted --
+		 * it succeeds only where the ASR engine is provisioned -- the test is
+		 * that the lifecycle is safe either way. Live-only. */
+		FST_TEST_BEGIN(asr_pause_resume_cycle)
+		{
+			if (lv_live()) {
+			int i;
+			switch_asr_handle_t ah = { 0 };
+
+			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_enable_grammar(&ah, "g1") == SWITCH_STATUS_SUCCESS);
+
+			for (i = 0; i < 2; i++) {
+				switch_core_asr_resume(&ah);
+				fst_check(switch_core_asr_pause(&ah) == SWITCH_STATUS_SUCCESS);
+			}
+
+			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
+		}
+		FST_TEST_END()
+
+		/* Repeated open/close cycles must not crash or leak handles/threads.
+		 * Live-only: needs an open handle. */
 		FST_TEST_BEGIN(asr_lifecycle_repeat)
 		{
+			if (lv_live()) {
 			int i;
 			for (i = 0; i < 3; i++) {
 				switch_asr_handle_t ah = { 0 };
 				fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
 				fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
 				fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
 			}
 		}
 		FST_TEST_END()

--- a/tests/unit/switch_mod_lumenvox.c
+++ b/tests/unit/switch_mod_lumenvox.c
@@ -1,0 +1,210 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * switch_mod_lumenvox.c -- unit tests for mod_lumenvox (LumenVox gRPC ASR)
+ *
+ * These tests exercise the FreeSWITCH-facing ASR interface (switch_asr_interface_t)
+ * that mod_lumenvox registers, driving it black-box through the public
+ * switch_core_asr_* API -- exactly how the core (play_and_detect_speech, etc.)
+ * uses it.
+ *
+ * There is no live LumenVox gRPC server in CI, so conf_lumenvox points the
+ * profile at a closed local port (127.0.0.1:1). That is deliberate: it lets us
+ * validate the whole interface surface offline. The server-independent logic
+ * (grammar bookkeeping, param handling, handle lifecycle, guard conditions) is
+ * asserted exactly; the operations that need the server are asserted to fail
+ * *gracefully* (deterministic status, no crash, no hang) rather than to succeed.
+ *
+ * TTS is intentionally not covered here: the LumenVox TTS engine is not reliably
+ * available on the dev deployment, and this suite is scoped to ASR.
+ */
+#include <switch.h>
+#include <stdlib.h>
+
+#include <test/switch_test.h>
+
+/* ASR interface name mod_lumenvox registers (mod_lumenvox.cpp asr_open). If the
+ * module is ever switched to the transparent "unimrcp" drop-in name, change this
+ * single define. */
+#define LV_ENGINE "lumenvox"
+
+/* Open an ASR handle on the default profile; used by most tests. */
+static switch_status_t lv_open(switch_asr_handle_t *ah, switch_memory_pool_t *pool)
+{
+	switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
+	return switch_core_asr_open(ah, LV_ENGINE, "L16", 8000, "", &flags, pool);
+}
+
+static switch_status_t lv_close(switch_asr_handle_t *ah)
+{
+	switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
+	return switch_core_asr_close(ah, &flags);
+}
+
+FST_CORE_BEGIN("./conf_lumenvox")
+{
+	FST_SUITE_BEGIN(switch_mod_lumenvox)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_lumenvox");
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		/* The interface loads and a handle can be opened on the default profile
+		 * and cleanly closed. */
+		FST_TEST_BEGIN(asr_open_close)
+		{
+			switch_asr_handle_t ah = { 0 };
+			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+			fst_check(ah.private_info != NULL);
+			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+		}
+		FST_TEST_END()
+
+		/* Opening against an unknown profile is rejected (not a crash). */
+		FST_TEST_BEGIN(asr_open_unknown_profile)
+		{
+			switch_asr_handle_t ah = { 0 };
+			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
+			switch_status_t status = switch_core_asr_open(&ah, LV_ENGINE, "L16", 8000, "no-such-profile", &flags, fst_pool);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+		}
+		FST_TEST_END()
+
+		/* Grammar bookkeeping is entirely server-independent, so it is asserted
+		 * exactly: load, enable/disable, disable-all, unload, and the correct
+		 * failure codes for operations on unknown grammar names. */
+		FST_TEST_BEGIN(asr_grammar_management)
+		{
+			switch_asr_handle_t ah = { 0 };
+			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+
+			/* load two grammars */
+			fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_load_grammar(&ah, "builtin:boolean", "g2") == SWITCH_STATUS_SUCCESS);
+
+			/* empty grammar is rejected by the core wrapper */
+			fst_check(switch_core_asr_load_grammar(&ah, "", "g3") != SWITCH_STATUS_SUCCESS);
+
+			/* enable/disable a known grammar */
+			fst_check(switch_core_asr_enable_grammar(&ah, "g1") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_disable_grammar(&ah, "g1") == SWITCH_STATUS_SUCCESS);
+
+			/* enable/disable an unknown grammar fails cleanly */
+			fst_check(switch_core_asr_enable_grammar(&ah, "nope") != SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_disable_grammar(&ah, "nope") != SWITCH_STATUS_SUCCESS);
+
+			/* disable all, then re-enable a still-loaded grammar */
+			fst_check(switch_core_asr_disable_all_grammars(&ah) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_enable_grammar(&ah, "g2") == SWITCH_STATUS_SUCCESS);
+
+			/* unload known; unload of an unknown name is idempotent (succeeds) */
+			fst_check(switch_core_asr_unload_grammar(&ah, "g1") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_unload_grammar(&ah, "nope") == SWITCH_STATUS_SUCCESS);
+
+			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+		}
+		FST_TEST_END()
+
+		/* Param setters accept known/unknown params without crashing, and with
+		 * no recognition in flight the result accessors report "nothing yet". */
+		FST_TEST_BEGIN(asr_params_and_empty_results)
+		{
+			switch_asr_handle_t ah = { 0 };
+			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
+			char *xmlstr = NULL;
+			switch_event_t *headers = NULL;
+
+			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+
+			/* text / numeric / float params (mapped and unmapped) */
+			switch_core_asr_text_param(&ah, "speech-language", "en-US");
+			switch_core_asr_text_param(&ah, "unmapped-text", "x");
+			switch_core_asr_numeric_param(&ah, "no-input-timeout", 5000);
+			switch_core_asr_numeric_param(&ah, "recognition-timeout", 10000);
+			switch_core_asr_numeric_param(&ah, "confidence-threshold", 500);
+			switch_core_asr_numeric_param(&ah, "n-best-list-length", 3);
+			switch_core_asr_float_param(&ah, "confidence-threshold", 0.5);
+
+			/* nothing recognized yet */
+			fst_check(switch_core_asr_check_results(&ah, &flags) != SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_get_results(&ah, &xmlstr, &flags) != SWITCH_STATUS_SUCCESS);
+			fst_check(xmlstr == NULL);
+			fst_check(switch_core_asr_get_result_headers(&ah, &headers, &flags) != SWITCH_STATUS_SUCCESS);
+			fst_check(headers == NULL);
+
+			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+		}
+		FST_TEST_END()
+
+		/* Feeding audio before recognition has started is a no-op that succeeds
+		 * (the interface must tolerate early frames). */
+		FST_TEST_BEGIN(asr_feed_before_start)
+		{
+			switch_asr_handle_t ah = { 0 };
+			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
+			int16_t frame[160];                 /* 20 ms @ 8 kHz mono L16 */
+			memset(frame, 0, sizeof(frame));
+
+			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
+
+			fst_check(switch_core_asr_feed(&ah, frame, sizeof(frame), &flags) == SWITCH_STATUS_SUCCESS);
+
+			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+		}
+		FST_TEST_END()
+
+		/* With no reachable server, the operations that need one must fail
+		 * gracefully and promptly -- resume() cannot start recognition, DTMF has
+		 * no interaction to target -- while the local guards (cancel, timers,
+		 * pause) still succeed. Nothing here may hang or crash. */
+		FST_TEST_BEGIN(asr_guards_without_server)
+		{
+			switch_asr_handle_t ah = { 0 };
+			switch_asr_flag_t flags = SWITCH_ASR_FLAG_NONE;
+			switch_dtmf_t dtmf = { 0 };
+			dtmf.digit = '1';
+			dtmf.duration = 2000;
+
+			fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_enable_grammar(&ah, "g1") == SWITCH_STATUS_SUCCESS);
+
+			/* cannot reach the gRPC server -> recognition start fails cleanly */
+			fst_check(switch_core_asr_resume(&ah) != SWITCH_STATUS_SUCCESS);
+
+			/* no active interaction -> DTMF injection fails cleanly */
+			fst_check(switch_core_asr_feed_dtmf(&ah, &dtmf, &flags) != SWITCH_STATUS_SUCCESS);
+
+			/* local-only operations still succeed */
+			fst_check(switch_core_asr_start_input_timers(&ah) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_try_cancel(&ah) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_core_asr_pause(&ah) == SWITCH_STATUS_SUCCESS);
+
+			fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+		}
+		FST_TEST_END()
+
+		/* Repeated open/close cycles must not crash or leak handles/threads. */
+		FST_TEST_BEGIN(asr_lifecycle_repeat)
+		{
+			int i;
+			for (i = 0; i < 3; i++) {
+				switch_asr_handle_t ah = { 0 };
+				fst_requires(lv_open(&ah, fst_pool) == SWITCH_STATUS_SUCCESS);
+				fst_check(switch_core_asr_load_grammar(&ah, "builtin:digits", "g1") == SWITCH_STATUS_SUCCESS);
+				fst_requires(lv_close(&ah) == SWITCH_STATUS_SUCCESS);
+			}
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()


### PR DESCRIPTION
## What

Adds an FST unit suite for `mod_lumenvox` (the new LumenVox gRPC ASR/TTS module, TELCORE-249). The suite drives the module black-box through the public `switch_core_asr_*` API — the same way the core (`play_and_detect_speech`) uses it.

## Tests (`tests/unit/switch_mod_lumenvox.c`)

Seven ASR-scoped tests:
- `asr_open_close` — interface loads, handle opens on the default profile and closes cleanly
- `asr_open_unknown_profile` — unknown profile is rejected, not a crash
- `asr_grammar_management` — load/enable/disable/disable-all/unload + failure codes for unknown grammar names (server-independent, asserted exactly)
- `asr_params_and_empty_results` — text/numeric/float param setters and empty-result accessors
- `asr_feed_before_start` — feeding audio before recognition starts is a tolerated no-op
- `asr_guards_without_server` — server-needing ops fail gracefully/promptly (no hang/crash); local-only ops still succeed
- `asr_lifecycle_repeat` — repeated open/close cycles don't crash or leak

Offline test config (`tests/unit/conf_lumenvox/freeswitch.xml`) points the profile at a closed local port so the interface surface is exercised without a live server.

## CI

`switch_mod_lumenvox` is intentionally **not** added to `noinst_PROGRAMS` yet — LumenVox servers are not reachable from CI, so the ASR tests can't run there. The source lands in-tree with a one-line note on how to re-enable.

## Draft

Kept as draft until the CI-runnable form is settled (e.g. an in-process fake gRPC server for the result path).