### PR TITLE
TELCORE-249: add HAVE_GOOGLEAPIS_SO conditional for gRPC modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,11 @@ have_openal=no
 AC_CHECK_LIB(openal, alcLoopbackOpenDeviceSOFT, [have_openal="yes"])
 AM_CONDITIONAL([HAVE_OPENAL],[test "${have_openal}" = "yes"])
 
+# Shared googleapis library (fs_docker_grpc >= 1.1.1); gRPC modules must link
+# it instead of embedding googleapis protos (duplicate descriptor registration
+# aborts at dlopen).
+AM_CONDITIONAL([HAVE_GOOGLEAPIS_SO],[test -f /usr/local/lib/libgoogleapis.so])
+
 PA_LIBS=
 
 PKG_CHECK_MODULES(JACK, jack, have_jack=yes, have_jack=no)


### PR DESCRIPTION
Generated protobuf code may register a given .proto file's descriptors into the shared libprotobuf pool only once per process; two modules embedding the same googleapis file (mod_gstt via `libgoogleapis.a` and mod_lumenvox's vendored `google/rpc/status.pb`) abort FreeSWITCH at dlopen:

```
[libprotobuf ERROR] File already exists in database: google/rpc/status.proto
[libprotobuf FATAL] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
```

The conditional lets gRPC modules link the shared googleapis library (freeswitch-docker-grpc >= 1.1.1, team-telnyx/fs_docker_grpc#6) instead of embedding copies, with a vendored fallback on hosts without it. Used by team-telnyx/mod_lumenvox#2.

Follow-up to the merged #624 (this hunk landed on the old branch after the merge).