### PR TITLE
TELCORE-263: harden ICE nomination, peer-reflexive bootstrap, and recovery

### DIFF
--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -45,7 +45,8 @@ typedef struct {
 
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
-	char *ice_user, switch_size_t ice_user_len, switch_bool_t *has_addr);
+	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
+	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -16,6 +16,7 @@ typedef struct {
 		uint8_t sending;
 		uint8_t ready;
 		uint8_t rready;
+		uint8_t remote_eoc_received;
 		uint8_t initializing;
 		int missed_count;
 		char last_sent_id[13];

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -46,12 +46,23 @@ typedef struct {
 		switch_time_t restart_provisional_us;
 } switch_rtp_ice_t;
 
+typedef enum {
+	SWITCH_RTP_RECOVERY_NOMINATION_NONE = 0,
+	SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED,
+	SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT
+} switch_rtp_recovery_nomination_proof_t;
+
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
 	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
 	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(switch_sockaddr_t *current_addr,
 	switch_sockaddr_t *handshake_peer_addr, dtls_state_t dtls_state, switch_bool_t handshake_peer_set, switch_bool_t is_rtcp);
+SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_dtls_nomination_proof(
+	switch_bool_t authenticated_vanilla_use_candidate, switch_bool_t direct_username_match);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_guard_recovery_dtls_tuple(switch_sockaddr_t *current_addr,
+	switch_sockaddr_t *packet_addr, dtls_state_t dtls_state, switch_bool_t is_rtcp,
+	switch_bool_t recovering, switch_rtp_recovery_nomination_proof_t nomination_proof);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ice_t *ice, dtls_state_t dtls_state,
 	switch_bool_t provisional_ice, switch_bool_t direct_username_match, switch_bool_t stun_auth_valid,
 	switch_bool_t got_message_integrity, switch_bool_t got_fingerprint, switch_bool_t got_use_candidate,

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -33,6 +33,8 @@ typedef struct {
 		uint32_t mid_call_failover_ms;
 		int mid_call_nominated_idx;
 		switch_time_t mid_call_nominated_us;
+		int inbound_media_idx;
+		switch_time_t inbound_media_us;
 		uint8_t prflx_bootstrap_cached;
 		uint8_t prflx_bootstrap_enabled;
 		uint8_t prflx_bootstrap_require_use_candidate;

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -63,6 +63,10 @@ SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_d
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_guard_recovery_dtls_tuple(switch_sockaddr_t *current_addr,
 	switch_sockaddr_t *packet_addr, dtls_state_t dtls_state, switch_bool_t is_rtcp,
 	switch_bool_t recovering, switch_rtp_recovery_nomination_proof_t nomination_proof);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_sync_authenticated_recovery_ice_addr(switch_sockaddr_t **ice_addr,
+	switch_sockaddr_t *remote_addr, switch_sockaddr_t *nominated_addr, dtls_state_t dtls_state,
+	switch_bool_t is_rtcp, switch_bool_t rtcp_mux, switch_bool_t recovering,
+	switch_rtp_recovery_nomination_proof_t nomination_proof);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ice_t *ice, dtls_state_t dtls_state,
 	switch_bool_t provisional_ice, switch_bool_t direct_username_match, switch_bool_t stun_auth_valid,
 	switch_bool_t got_message_integrity, switch_bool_t got_fingerprint, switch_bool_t got_use_candidate,

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -41,12 +41,22 @@ typedef struct {
 		uint32_t prflx_bootstrap_ms;
 		int prflx_bootstrap_idx;
 		switch_time_t prflx_bootstrap_us;
+		uint8_t restart_pending;
+		uint8_t restart_provisional;
+		switch_time_t restart_provisional_us;
 } switch_rtp_ice_t;
 
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
 	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
 	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(switch_sockaddr_t *current_addr,
+	switch_sockaddr_t *handshake_peer_addr, dtls_state_t dtls_state, switch_bool_t handshake_peer_set, switch_bool_t is_rtcp);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ice_t *ice, dtls_state_t dtls_state,
+	switch_bool_t provisional_ice, switch_bool_t direct_username_match, switch_bool_t stun_auth_valid,
+	switch_bool_t got_message_integrity, switch_bool_t got_fingerprint, switch_bool_t got_use_candidate,
+	switch_bool_t got_use_candidate_covered, switch_bool_t has_priority, switch_bool_t within_bootstrap_window,
+	uint32_t bootstrap_ms, switch_time_t now);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -44,6 +44,8 @@ typedef struct {
 } switch_rtp_ice_t;
 
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
+	char *ice_user, switch_size_t ice_user_len, switch_bool_t *has_addr);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -1,6 +1,21 @@
 #ifndef __SWITCH_RTP_PVT_H__
 #define __SWITCH_RTP_PVT_H__
 
+typedef enum {
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE = 0,
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING,
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING,
+	SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING
+} switch_rtp_ice_controlling_failover_state_t;
+
+typedef enum {
+	SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE = 0,
+	SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT,
+	SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE
+} switch_rtp_ice_controlling_timer_action_t;
+
+#define SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY 4
+
 typedef struct {
 		char *ice_user;
 		char *user_ice;
@@ -33,6 +48,29 @@ typedef struct {
 		uint32_t mid_call_failover_ms;
 		int mid_call_nominated_idx;
 		switch_time_t mid_call_nominated_us;
+		uint8_t controlling_failover_cached;
+		uint8_t controlling_failover_enabled;
+		uint32_t controlling_failover_ms;
+		switch_rtp_ice_controlling_failover_state_t controlling_failover_state;
+		int controlling_failover_idx;
+		switch_time_t controlling_failover_candidate_us;
+		switch_time_t controlling_failover_started_us;
+		switch_time_t controlling_failover_sent_us;
+		uint8_t controlling_failover_attempts;
+		char controlling_failover_probe_id[13];
+		char controlling_failover_nomination_id[13];
+		switch_socket_t *controlling_failover_socket;
+		switch_port_t controlling_failover_local_port;
+		int controlling_failover_local_family;
+		char selected_pair_check_ids[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY][13];
+		uint8_t selected_pair_check_controlling[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY];
+		switch_sockaddr_t *selected_pair_check_remote_addr[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY];
+		uint8_t selected_pair_check_pos;
+		uint8_t selected_pair_check_count;
+		switch_socket_t *selected_pair_check_socket;
+		switch_port_t selected_pair_check_local_port;
+		int selected_pair_check_local_family;
+		switch_time_t selected_pair_last_response_us;
 		int inbound_media_idx;
 		switch_time_t inbound_media_us;
 		uint8_t prflx_bootstrap_cached;
@@ -72,6 +110,21 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ic
 	switch_bool_t got_message_integrity, switch_bool_t got_fingerprint, switch_bool_t got_use_candidate,
 	switch_bool_t got_use_candidate_covered, switch_bool_t has_priority, switch_bool_t within_bootstrap_window,
 	uint32_t bootstrap_ms, switch_time_t now);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_matches(switch_rtp_ice_t *ice,
+	switch_rtp_ice_controlling_failover_state_t expected_state, int candidate_idx, const char *transaction_id,
+	switch_bool_t authenticated, switch_socket_t *local_socket, switch_port_t local_port, int local_family);
+SWITCH_DECLARE(switch_rtp_ice_controlling_timer_action_t) switch_rtp_pvt_controlling_failover_timer_action(
+	switch_rtp_ice_controlling_failover_state_t state, switch_time_t started_us, switch_time_t sent_us,
+	uint8_t attempts, switch_time_t now);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_role_conflict_response_matches(switch_rtp_ice_t *ice,
+	switch_sockaddr_t *from_addr, int candidate_idx, const char *transaction_id, switch_bool_t authenticated,
+	switch_socket_t *local_socket, switch_port_t local_port, int local_family, switch_bool_t *sent_controlling);
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_apply(switch_rtp_ice_t *ice, switch_bool_t sent_controlling);
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_cancel(switch_rtp_ice_t *ice);
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(char tie_breaker[8]);
+SWITCH_DECLARE(uint32_t) switch_rtp_pvt_ice_local_prflx_priority(switch_bool_t is_rtcp, switch_bool_t rtcp_mux);
+SWITCH_DECLARE(int) switch_rtp_pvt_reuse_pending_startup_prflx_candidate(switch_rtp_t *rtp_session,
+	switch_rtp_ice_t *ice, const char *host, switch_port_t port, uint32_t priority);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -519,6 +519,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_sync_stats(switch_rtp_t *rtp_session)
   \brief Acvite ICE on an RTP session
   \return SWITCH_STATUS_SUCCESS
 */
+SWITCH_DECLARE(void) switch_rtp_prepare_ice_restart(switch_rtp_t *rtp_session, ice_proto_t proto, switch_bool_t explicit_restart);
 SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_session, char *login, char *rlogin,
 														const char *password, const char *rpassword, ice_proto_t proto,
 														switch_core_media_ice_type_t type, ice_t *ice_params);

--- a/src/include/switch_stun.h
+++ b/src/include/switch_stun.h
@@ -253,6 +253,8 @@ SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_fingerprint(switch_stun
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_use_candidate(switch_stun_packet_t *packet);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling(switch_stun_packet_t *packet);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled(switch_stun_packet_t *packet);
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling_value(switch_stun_packet_t *packet, const char *tie_breaker);
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled_value(switch_stun_packet_t *packet, const char *tie_breaker);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_priority(switch_stun_packet_t *packet, uint32_t priority);
 
 /*!

--- a/src/include/switch_stun.h
+++ b/src/include/switch_stun.h
@@ -247,6 +247,7 @@ SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_software(switch_stun_pa
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_binded_address(switch_stun_packet_t *packet, char *ipstr, uint16_t port, int family);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_xor_binded_address(switch_stun_packet_t *packet, char *ipstr, uint16_t port, int family);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_integrity(switch_stun_packet_t *packet, const char *pass);
+SWITCH_DECLARE(uint8_t) switch_stun_packet_validate_auth(const void *data, uint32_t len, const char *pass);
 SWITCH_DECLARE(uint32_t) switch_crc32_8bytes(const void* data, size_t length);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_fingerprint(switch_stun_packet_t *packet);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_use_candidate(switch_stun_packet_t *packet);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11652,7 +11652,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 			a_engine->ice_restart_remote_pwd = NULL;
 		}
 		provisional_audio_ice = !candidate_ready && switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
-		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice && !a_engine->new_dtls &&
+		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice &&
+			!(a_engine->new_dtls && switch_channel_test_flag(session->channel, CF_RECOVERING)) &&
 			(candidate_ready || provisional_audio_ice);
 
 		if (remote_host && remote_port && !strcmp(remote_host, a_engine->cur_payload_map->remote_sdp_ip) &&
@@ -12483,7 +12484,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				provisional_video_ice = !candidate_ready &&
 					switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
 				reactivate_video_ice = v_engine->ice_restart_pending && !v_engine->bundled_with_audio &&
-					has_remote_ice && !v_engine->new_dtls && (candidate_ready || provisional_video_ice);
+					has_remote_ice && !(v_engine->new_dtls && switch_channel_test_flag(session->channel, CF_RECOVERING)) &&
+					(candidate_ready || provisional_video_ice);
 
 				if (remote_host && remote_port && !strcmp(remote_host, v_engine->cur_payload_map->remote_sdp_ip) && remote_port == v_engine->cur_payload_map->remote_sdp_port) {
 					if (reactivate_video_ice) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -210,6 +210,8 @@ struct switch_rtp_engine_s {
 	switch_thread_id_t thread_write_lock;
 	uint8_t new_ice;
 	uint8_t ice_restart_pending;
+	char *ice_restart_remote_ufrag;
+	char *ice_restart_remote_pwd;
 	uint8_t new_dtls;
 	uint32_t sdp_bw;
 	uint32_t orig_bitrate;
@@ -4871,6 +4873,8 @@ static void clear_ice(switch_core_session_t *session, switch_media_type_t type)
 	engine->ice_in.is_chosen[1] = 0;
 	engine->ice_in.cand_idx[0] = 0;
 	engine->ice_in.cand_idx[1] = 0;
+	engine->ice_restart_remote_ufrag = engine->ice_in.ufrag;
+	engine->ice_restart_remote_pwd = engine->ice_in.pwd;
 	memset(&engine->ice_in, 0, sizeof(engine->ice_in));
 	engine->remote_rtcp_port = 0;
 
@@ -5404,6 +5408,12 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 				} else if (engine->ice_in.ufrag && !strcmp(engine->ice_in.ufrag, attr->a_value)) {
 					engine->new_ice = 0;
 				} else {
+					if (engine->ice_restart_pending &&
+						(!engine->ice_restart_remote_ufrag || strcmp(engine->ice_restart_remote_ufrag, attr->a_value))) {
+						/* Both peers need fresh credentials for a new ICE generation. */
+						engine->ice_out.ufrag = NULL;
+						engine->ice_out.pwd = NULL;
+					}
 					engine->ice_in.ufrag = switch_core_session_strdup(smh->session, attr->a_value);
 					engine->new_ice = 1;
 				}
@@ -5413,6 +5423,11 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG,
 						"ice-pwd: skipping update during trickle recheck\n");
 				} else if (!engine->ice_in.pwd || strcmp(engine->ice_in.pwd, attr->a_value)) {
+					if (engine->ice_restart_pending &&
+						(!engine->ice_restart_remote_pwd || strcmp(engine->ice_restart_remote_pwd, attr->a_value))) {
+						engine->ice_out.ufrag = NULL;
+						engine->ice_out.pwd = NULL;
+					}
 					engine->ice_in.pwd = switch_core_session_strdup(smh->session, attr->a_value);
 				}
 			} else if (!strcasecmp(attr->a_name, "ice-options") && !zstr(attr->a_value)) {
@@ -11345,6 +11360,8 @@ static switch_status_t activate_audio_ice(switch_core_session_t *session, switch
 
 	if (status == SWITCH_STATUS_SUCCESS) {
 		engine->ice_restart_pending = 0;
+		engine->ice_restart_remote_ufrag = NULL;
+		engine->ice_restart_remote_pwd = NULL;
 		if (provisional) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
 							  "Armed Audio ICE for peer-reflexive bootstrap\n");
@@ -11574,6 +11591,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 		has_remote_ice = !zstr(a_engine->ice_in.ufrag) && !zstr(a_engine->ice_in.pwd) ? SWITCH_TRUE : SWITCH_FALSE;
 		if (!has_remote_ice) {
 			a_engine->ice_restart_pending = 0;
+			a_engine->ice_restart_remote_ufrag = NULL;
+			a_engine->ice_restart_remote_pwd = NULL;
 		}
 		provisional_audio_ice = !candidate_ready && switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
 		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice &&

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11643,6 +11643,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 		switch_port_t remote_port = switch_rtp_get_remote_port(a_engine->rtp_session);
 		switch_bool_t candidate_ready;
 		switch_bool_t has_remote_ice;
+		switch_bool_t skip_recovery_audio_ice;
 
 		candidate_ready = a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready ? SWITCH_TRUE : SWITCH_FALSE;
 		has_remote_ice = !zstr(a_engine->ice_in.ufrag) && !zstr(a_engine->ice_in.pwd) ? SWITCH_TRUE : SWITCH_FALSE;
@@ -11652,8 +11653,16 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 			a_engine->ice_restart_remote_pwd = NULL;
 		}
 		provisional_audio_ice = !candidate_ready && switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
+		/* Avoid duplicate ICE activation while recovery restarts DTLS. */
+		skip_recovery_audio_ice = a_engine->new_dtls && candidate_ready &&
+			switch_channel_test_flag(session->channel, CF_RECOVERING);
+		if (skip_recovery_audio_ice && a_engine->ice_restart_pending) {
+			a_engine->ice_restart_pending = 0;
+			a_engine->ice_restart_remote_ufrag = NULL;
+			a_engine->ice_restart_remote_pwd = NULL;
+		}
 		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice &&
-			!(a_engine->new_dtls && switch_channel_test_flag(session->channel, CF_RECOVERING)) &&
+			!skip_recovery_audio_ice &&
 			(candidate_ready || provisional_audio_ice);
 
 		if (remote_host && remote_port && !strcmp(remote_host, a_engine->cur_payload_map->remote_sdp_ip) &&
@@ -12473,6 +12482,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				switch_port_t remote_port = switch_rtp_get_remote_port(v_engine->rtp_session);
 				switch_bool_t candidate_ready;
 				switch_bool_t has_remote_ice;
+				switch_bool_t skip_recovery_video_ice;
 
 				candidate_ready = v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].ready ? SWITCH_TRUE : SWITCH_FALSE;
 				has_remote_ice = !zstr(v_engine->ice_in.ufrag) && !zstr(v_engine->ice_in.pwd) ? SWITCH_TRUE : SWITCH_FALSE;
@@ -12483,8 +12493,16 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				}
 				provisional_video_ice = !candidate_ready &&
 					switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
+				/* Avoid duplicate ICE activation while recovery restarts DTLS. */
+				skip_recovery_video_ice = v_engine->new_dtls && candidate_ready &&
+					switch_channel_test_flag(session->channel, CF_RECOVERING);
+				if (skip_recovery_video_ice && v_engine->ice_restart_pending) {
+					v_engine->ice_restart_pending = 0;
+					v_engine->ice_restart_remote_ufrag = NULL;
+					v_engine->ice_restart_remote_pwd = NULL;
+				}
 				reactivate_video_ice = v_engine->ice_restart_pending && !v_engine->bundled_with_audio &&
-					has_remote_ice && !(v_engine->new_dtls && switch_channel_test_flag(session->channel, CF_RECOVERING)) &&
+					has_remote_ice && !skip_recovery_video_ice &&
 					(candidate_ready || provisional_video_ice);
 
 				if (remote_host && remote_port && !strcmp(remote_host, v_engine->cur_payload_map->remote_sdp_ip) && remote_port == v_engine->cur_payload_map->remote_sdp_port) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -209,6 +209,7 @@ struct switch_rtp_engine_s {
 	switch_thread_id_t thread_id;
 	switch_thread_id_t thread_write_lock;
 	uint8_t new_ice;
+	uint8_t ice_restart_pending;
 	uint8_t new_dtls;
 	uint32_t sdp_bw;
 	uint32_t orig_bitrate;
@@ -4874,7 +4875,10 @@ static void clear_ice(switch_core_session_t *session, switch_media_type_t type)
 	engine->remote_rtcp_port = 0;
 
 	if (engine->rtp_session) {
+		engine->ice_restart_pending = type == SWITCH_MEDIA_TYPE_AUDIO;
 		switch_rtp_reset(engine->rtp_session);
+	} else {
+		engine->ice_restart_pending = 0;
 	}
 
 }
@@ -11307,6 +11311,51 @@ SWITCH_DECLARE(void) switch_core_session_wake_video_thread(switch_core_session_t
 	}
 }
 
+static switch_status_t activate_audio_ice(switch_core_session_t *session, switch_rtp_engine_t *engine, int provisional)
+{
+	switch_status_t status;
+
+	if (!session || !engine || !engine->rtp_session) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	gen_ice(session, SWITCH_MEDIA_TYPE_AUDIO, NULL, 0);
+
+	if (zstr(engine->ice_in.ufrag) || zstr(engine->ice_in.pwd) ||
+		zstr(engine->ice_out.ufrag) || zstr(engine->ice_out.pwd)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+						  "Cannot activate Audio ICE without complete credentials\n");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	status = switch_rtp_activate_ice(engine->rtp_session,
+								 engine->ice_in.ufrag,
+								 engine->ice_out.ufrag,
+								 engine->ice_out.pwd,
+								 engine->ice_in.pwd,
+								 IPR_RTP,
+#ifdef GOOGLE_ICE
+								 ICE_GOOGLE_JINGLE,
+								 NULL
+#else
+								 switch_determine_ice_type(engine, session),
+								 &engine->ice_in
+#endif
+								 );
+
+	if (status == SWITCH_STATUS_SUCCESS) {
+		engine->ice_restart_pending = 0;
+		if (provisional) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+							  "Armed Audio ICE for peer-reflexive bootstrap\n");
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating Audio ICE\n");
+		}
+	}
+
+	return status;
+}
+
 static void check_dtls_reinvite(switch_core_session_t *session, switch_rtp_engine_t *engine)
 {
 	if (switch_channel_test_flag(session->channel, CF_REINVITE) && engine->new_dtls) {
@@ -11359,6 +11408,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 	switch_media_handle_t *smh;
 	int is_reinvite = 0;
 	int provisional_audio_ice = 0;
+	int reactivate_audio_ice = 0;
 
 #ifdef HAVE_OPENSSL_DTLSv1_2_method
 			uint8_t want_DTLSv1_2 = 1;
@@ -11517,11 +11567,35 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 		//const char *port = switch_channel_get_variable(session->channel, SWITCH_LOCAL_MEDIA_PORT_VARIABLE);
 		char *remote_host = switch_rtp_get_remote_host(a_engine->rtp_session);
 		switch_port_t remote_port = switch_rtp_get_remote_port(a_engine->rtp_session);
+		switch_bool_t candidate_ready;
+		switch_bool_t has_remote_ice;
+
+		candidate_ready = a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready ? SWITCH_TRUE : SWITCH_FALSE;
+		has_remote_ice = !zstr(a_engine->ice_in.ufrag) && !zstr(a_engine->ice_in.pwd) ? SWITCH_TRUE : SWITCH_FALSE;
+		if (!has_remote_ice) {
+			a_engine->ice_restart_pending = 0;
+		}
+		provisional_audio_ice = !candidate_ready && switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
+		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice &&
+			(candidate_ready || provisional_audio_ice);
 
 		if (remote_host && remote_port && !strcmp(remote_host, a_engine->cur_payload_map->remote_sdp_ip) &&
 			remote_port == a_engine->cur_payload_map->remote_sdp_port) {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Audio params are unchanged for %s.\n",
-							  switch_channel_get_name(session->channel));
+			if (reactivate_audio_ice) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+								  "Audio params are unchanged for %s; reactivating ICE.\n",
+								  switch_channel_get_name(session->channel));
+				audio_ice_status = activate_audio_ice(session, a_engine, provisional_audio_ice);
+				if (audio_ice_status == SWITCH_STATUS_SUCCESS) {
+					a_engine->new_ice = 0;
+				} else {
+					status = audio_ice_status;
+					goto end;
+				}
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Audio params are unchanged for %s.\n",
+								  switch_channel_get_name(session->channel));
+			}
 			a_engine->cur_payload_map->negotiated = 1;
 
 			if (session && a_engine) {
@@ -11786,35 +11860,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 			switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
 
 		if (a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready || provisional_audio_ice) {
-
-			gen_ice(session, SWITCH_MEDIA_TYPE_AUDIO, NULL, 0);
-
-
-			audio_ice_status = switch_rtp_activate_ice(a_engine->rtp_session,
-									a_engine->ice_in.ufrag,
-									a_engine->ice_out.ufrag,
-									a_engine->ice_out.pwd,
-									a_engine->ice_in.pwd,
-									IPR_RTP,
-#ifdef GOOGLE_ICE
-									ICE_GOOGLE_JINGLE,
-									NULL
-#else
-									switch_determine_ice_type(a_engine, session),
-									&a_engine->ice_in
-#endif
-									);
-			if (audio_ice_status == SWITCH_STATUS_SUCCESS) {
-				if (a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating Audio ICE\n");
-				} else {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
-						"Armed Audio ICE for peer-reflexive bootstrap\n");
-				}
-			}
-
-
-
+			audio_ice_status = activate_audio_ice(session, a_engine, provisional_audio_ice);
 		}
 
 		if ((val = switch_channel_get_variable(session->channel, "rtcp_audio_interval_msec")) || (val = smh->mparams->rtcp_audio_interval_msec)) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11351,12 +11351,14 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 	const char *val = NULL;
 	switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = {0};
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
+	switch_status_t audio_ice_status = SWITCH_STATUS_SUCCESS;
 	char tmp[50];
 	char *timer_name = NULL;
 	const char *var;
 	switch_rtp_engine_t *a_engine, *v_engine, *t_engine;
 	switch_media_handle_t *smh;
 	int is_reinvite = 0;
+	int provisional_audio_ice = 0;
 
 #ifdef HAVE_OPENSSL_DTLSv1_2_method
 			uint8_t want_DTLSv1_2 = 1;
@@ -11780,13 +11782,15 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 								switch_channel_get_name(switch_core_session_get_channel(session)));
 		}
 
-		if (a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready) {
+		provisional_audio_ice = !a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready &&
+			switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
+
+		if (a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready || provisional_audio_ice) {
 
 			gen_ice(session, SWITCH_MEDIA_TYPE_AUDIO, NULL, 0);
 
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating Audio ICE\n");
 
-			switch_rtp_activate_ice(a_engine->rtp_session,
+			audio_ice_status = switch_rtp_activate_ice(a_engine->rtp_session,
 									a_engine->ice_in.ufrag,
 									a_engine->ice_out.ufrag,
 									a_engine->ice_out.pwd,
@@ -11800,6 +11804,14 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 									&a_engine->ice_in
 #endif
 									);
+			if (audio_ice_status == SWITCH_STATUS_SUCCESS) {
+				if (a_engine->ice_in.cands[a_engine->ice_in.chosen[0]][0].ready) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating Audio ICE\n");
+				} else {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+						"Armed Audio ICE for peer-reflexive bootstrap\n");
+				}
+			}
 
 
 
@@ -11882,7 +11894,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 
 		skip_audio_rtcp_ice:
 
-		if (!zstr(a_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session)) {
+		if (!zstr(a_engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(smh->session) &&
+			(!provisional_audio_ice || audio_ice_status == SWITCH_STATUS_SUCCESS)) {
 			dtls_type_t xtype, dtype = a_engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
 
 			//if (switch_channel_test_flag(smh->session->channel, CF_3PCC)) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4879,7 +4879,8 @@ static void clear_ice(switch_core_session_t *session, switch_media_type_t type)
 	engine->remote_rtcp_port = 0;
 
 	if (engine->rtp_session) {
-		engine->ice_restart_pending = type == SWITCH_MEDIA_TYPE_AUDIO;
+		engine->ice_restart_pending = type == SWITCH_MEDIA_TYPE_AUDIO ||
+			(type == SWITCH_MEDIA_TYPE_VIDEO && !engine->bundled_with_audio);
 		switch_rtp_reset(engine->rtp_session);
 	} else {
 		engine->ice_restart_pending = 0;
@@ -5408,7 +5409,7 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 				} else if (engine->ice_in.ufrag && !strcmp(engine->ice_in.ufrag, attr->a_value)) {
 					engine->new_ice = 0;
 				} else {
-					if (engine->ice_restart_pending &&
+					if (sdp_type == SDP_OFFER && engine->ice_restart_pending &&
 						(!engine->ice_restart_remote_ufrag || strcmp(engine->ice_restart_remote_ufrag, attr->a_value))) {
 						/* Both peers need fresh credentials for a new ICE generation. */
 						engine->ice_out.ufrag = NULL;
@@ -5423,7 +5424,7 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG,
 						"ice-pwd: skipping update during trickle recheck\n");
 				} else if (!engine->ice_in.pwd || strcmp(engine->ice_in.pwd, attr->a_value)) {
-					if (engine->ice_restart_pending &&
+					if (sdp_type == SDP_OFFER && engine->ice_restart_pending &&
 						(!engine->ice_restart_remote_pwd || strcmp(engine->ice_restart_remote_pwd, attr->a_value))) {
 						engine->ice_out.ufrag = NULL;
 						engine->ice_out.pwd = NULL;
@@ -5972,7 +5973,8 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 		}
 
 
-		if (engine->rtp_session && ((val = switch_channel_get_variable(smh->session->channel,
+		if (engine->rtp_session && !switch_rtp_test_flag(engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP) &&
+			((val = switch_channel_get_variable(smh->session->channel,
 																	   type == SWITCH_MEDIA_TYPE_VIDEO ?
 																	   "rtcp_video_interval_msec" : "rtcp_audio_interval_msec"))
 									|| (val = type == SWITCH_MEDIA_TYPE_VIDEO ?
@@ -11326,20 +11328,25 @@ SWITCH_DECLARE(void) switch_core_session_wake_video_thread(switch_core_session_t
 	}
 }
 
-static switch_status_t activate_audio_ice(switch_core_session_t *session, switch_rtp_engine_t *engine, int provisional)
+static switch_status_t activate_media_ice(switch_core_session_t *session, switch_rtp_engine_t *engine,
+                                         switch_media_type_t type, int provisional)
 {
+	const char *media_name;
 	switch_status_t status;
+	switch_bool_t activate_rtcp_ice;
 
-	if (!session || !engine || !engine->rtp_session) {
+	if (!session || !engine || !engine->rtp_session ||
+		(type != SWITCH_MEDIA_TYPE_AUDIO && type != SWITCH_MEDIA_TYPE_VIDEO)) {
 		return SWITCH_STATUS_FALSE;
 	}
 
-	gen_ice(session, SWITCH_MEDIA_TYPE_AUDIO, NULL, 0);
+	media_name = type == SWITCH_MEDIA_TYPE_AUDIO ? "Audio" : "Video";
+	gen_ice(session, type, NULL, 0);
 
 	if (zstr(engine->ice_in.ufrag) || zstr(engine->ice_in.pwd) ||
 		zstr(engine->ice_out.ufrag) || zstr(engine->ice_out.pwd)) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
-						  "Cannot activate Audio ICE without complete credentials\n");
+						  "Cannot activate %s ICE without complete credentials\n", media_name);
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -11357,20 +11364,56 @@ static switch_status_t activate_audio_ice(switch_core_session_t *session, switch
 								 &engine->ice_in
 #endif
 								 );
+	if (status != SWITCH_STATUS_SUCCESS) {
+		return status;
+	}
 
-	if (status == SWITCH_STATUS_SUCCESS) {
-		engine->ice_restart_pending = 0;
-		engine->ice_restart_remote_ufrag = NULL;
-		engine->ice_restart_remote_pwd = NULL;
-		if (provisional) {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
-							  "Armed Audio ICE for peer-reflexive bootstrap\n");
-		} else {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Activating Audio ICE\n");
+	activate_rtcp_ice = engine->rtcp_mux < 1 &&
+		switch_rtp_test_flag(engine->rtp_session, SWITCH_RTP_FLAG_ENABLE_RTCP) &&
+		(engine->ice_in.cands[engine->ice_in.chosen[1]][1].ready ||
+		 switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap"));
+	if (activate_rtcp_ice) {
+		status = switch_rtp_activate_ice(engine->rtp_session,
+									 engine->ice_in.ufrag,
+									 engine->ice_out.ufrag,
+									 engine->ice_out.pwd,
+									 engine->ice_in.pwd,
+									 IPR_RTCP,
+#ifdef GOOGLE_ICE
+									 ICE_GOOGLE_JINGLE,
+									 NULL
+#else
+									 switch_determine_ice_type(engine, session),
+									 &engine->ice_in
+#endif
+									 );
+		if (status != SWITCH_STATUS_SUCCESS) {
+			return status;
 		}
 	}
 
-	return status;
+	engine->ice_restart_pending = 0;
+	engine->ice_restart_remote_ufrag = NULL;
+	engine->ice_restart_remote_pwd = NULL;
+	if (provisional) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+						  "Armed %s ICE for peer-reflexive bootstrap\n", media_name);
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+						  "Activating %s ICE\n", media_name);
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t activate_audio_ice(switch_core_session_t *session, switch_rtp_engine_t *engine, int provisional)
+{
+	return activate_media_ice(session, engine, SWITCH_MEDIA_TYPE_AUDIO, provisional);
+}
+
+static switch_status_t activate_video_ice(switch_core_session_t *session, switch_rtp_engine_t *engine, int provisional)
+{
+	return activate_media_ice(session, engine, SWITCH_MEDIA_TYPE_VIDEO, provisional);
 }
 
 static void check_dtls_reinvite(switch_core_session_t *session, switch_rtp_engine_t *engine)
@@ -11426,6 +11469,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 	int is_reinvite = 0;
 	int provisional_audio_ice = 0;
 	int reactivate_audio_ice = 0;
+	int provisional_video_ice = 0;
+	int reactivate_video_ice = 0;
 
 #ifdef HAVE_OPENSSL_DTLSv1_2_method
 			uint8_t want_DTLSv1_2 = 1;
@@ -12413,10 +12458,29 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				//const char *port = switch_channel_get_variable(session->channel, SWITCH_LOCAL_MEDIA_PORT_VARIABLE);
 				char *remote_host = switch_rtp_get_remote_host(v_engine->rtp_session);
 				switch_port_t remote_port = switch_rtp_get_remote_port(v_engine->rtp_session);
+				switch_bool_t candidate_ready;
+				switch_bool_t has_remote_ice;
 
-
+				candidate_ready = v_engine->ice_in.cands[v_engine->ice_in.chosen[0]][0].ready ? SWITCH_TRUE : SWITCH_FALSE;
+				has_remote_ice = !zstr(v_engine->ice_in.ufrag) && !zstr(v_engine->ice_in.pwd) ? SWITCH_TRUE : SWITCH_FALSE;
+				if (!has_remote_ice) {
+					v_engine->ice_restart_pending = 0;
+					v_engine->ice_restart_remote_ufrag = NULL;
+					v_engine->ice_restart_remote_pwd = NULL;
+				}
+				provisional_video_ice = !candidate_ready &&
+					switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
+				reactivate_video_ice = v_engine->ice_restart_pending && !v_engine->bundled_with_audio &&
+					has_remote_ice && (candidate_ready || provisional_video_ice);
 
 				if (remote_host && remote_port && !strcmp(remote_host, v_engine->cur_payload_map->remote_sdp_ip) && remote_port == v_engine->cur_payload_map->remote_sdp_port) {
+					if (reactivate_video_ice) {
+						status = activate_video_ice(session, v_engine, provisional_video_ice);
+						if (status != SWITCH_STATUS_SUCCESS) {
+							goto end;
+						}
+						v_engine->new_ice = 0;
+					}
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Video params are unchanged for %s.\n",
 									  switch_channel_get_name(session->channel));
 					v_engine->cur_payload_map->negotiated = 1;
@@ -12468,6 +12532,13 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 						switch_rtp_set_flag(v_engine->rtp_session, SWITCH_RTP_FLAG_AUTOADJ);
 					}
 
+				}
+				if (reactivate_video_ice) {
+					status = activate_video_ice(session, v_engine, provisional_video_ice);
+					if (status != SWITCH_STATUS_SUCCESS) {
+						goto end;
+					}
+					v_engine->new_ice = 0;
 				}
 				goto video_up;
 			}

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11334,6 +11334,7 @@ static switch_status_t activate_media_ice(switch_core_session_t *session, switch
 	const char *media_name;
 	switch_status_t status;
 	switch_bool_t activate_rtcp_ice;
+	switch_bool_t explicit_restart;
 
 	if (!session || !engine || !engine->rtp_session ||
 		(type != SWITCH_MEDIA_TYPE_AUDIO && type != SWITCH_MEDIA_TYPE_VIDEO)) {
@@ -11341,15 +11342,19 @@ static switch_status_t activate_media_ice(switch_core_session_t *session, switch
 	}
 
 	media_name = type == SWITCH_MEDIA_TYPE_AUDIO ? "Audio" : "Video";
+	explicit_restart = engine->ice_restart_pending ? SWITCH_TRUE : SWITCH_FALSE;
 	gen_ice(session, type, NULL, 0);
 
 	if (zstr(engine->ice_in.ufrag) || zstr(engine->ice_in.pwd) ||
 		zstr(engine->ice_out.ufrag) || zstr(engine->ice_out.pwd)) {
+		switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTP, SWITCH_FALSE);
+		switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTCP, SWITCH_FALSE);
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
 						  "Cannot activate %s ICE without complete credentials\n", media_name);
 		return SWITCH_STATUS_FALSE;
 	}
 
+	switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTP, explicit_restart);
 	status = switch_rtp_activate_ice(engine->rtp_session,
 								 engine->ice_in.ufrag,
 								 engine->ice_out.ufrag,
@@ -11365,6 +11370,8 @@ static switch_status_t activate_media_ice(switch_core_session_t *session, switch
 #endif
 								 );
 	if (status != SWITCH_STATUS_SUCCESS) {
+		switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTP, SWITCH_FALSE);
+		switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTCP, SWITCH_FALSE);
 		return status;
 	}
 
@@ -11373,6 +11380,7 @@ static switch_status_t activate_media_ice(switch_core_session_t *session, switch
 		(engine->ice_in.cands[engine->ice_in.chosen[1]][1].ready ||
 		 switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap"));
 	if (activate_rtcp_ice) {
+		switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTCP, explicit_restart);
 		status = switch_rtp_activate_ice(engine->rtp_session,
 									 engine->ice_in.ufrag,
 									 engine->ice_out.ufrag,
@@ -11388,8 +11396,12 @@ static switch_status_t activate_media_ice(switch_core_session_t *session, switch
 #endif
 									 );
 		if (status != SWITCH_STATUS_SUCCESS) {
+			switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTP, SWITCH_FALSE);
+			switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTCP, SWITCH_FALSE);
 			return status;
 		}
+	} else {
+		switch_rtp_prepare_ice_restart(engine->rtp_session, IPR_RTCP, SWITCH_FALSE);
 	}
 
 	engine->ice_restart_pending = 0;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11652,7 +11652,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 			a_engine->ice_restart_remote_pwd = NULL;
 		}
 		provisional_audio_ice = !candidate_ready && switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
-		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice &&
+		reactivate_audio_ice = a_engine->ice_restart_pending && has_remote_ice && !a_engine->new_dtls &&
 			(candidate_ready || provisional_audio_ice);
 
 		if (remote_host && remote_port && !strcmp(remote_host, a_engine->cur_payload_map->remote_sdp_ip) &&
@@ -12483,7 +12483,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				provisional_video_ice = !candidate_ready &&
 					switch_channel_var_true(session->channel, "rtp_ice_prflx_bootstrap");
 				reactivate_video_ice = v_engine->ice_restart_pending && !v_engine->bundled_with_audio &&
-					has_remote_ice && (candidate_ready || provisional_video_ice);
+					has_remote_ice && !v_engine->new_dtls && (candidate_ready || provisional_video_ice);
 
 				if (remote_host && remote_port && !strcmp(remote_host, v_engine->cur_payload_map->remote_sdp_ip) && remote_port == v_engine->cur_payload_map->remote_sdp_port) {
 					if (reactivate_video_ice) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -783,6 +783,28 @@ static const char *ice_candidate_type_safe(const icand_t *cand)
 	return (cand && cand->cand_type) ? cand->cand_type : "(unknown)";
 }
 
+static switch_bool_t ice_should_preserve_peer_nominated_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
+{
+	int idx;
+	char cur_buf[80] = "";
+	const char *cur_host;
+	switch_port_t cur_port;
+
+	if (is_rtcp || !rtp_session || !ice || !ice->ice_params || !ice->addr || !dtls || dtls->state >= DS_READY || !rtp_session->ice.dtls_handshake) {
+		return SWITCH_FALSE;
+	}
+
+	idx = ice->mid_call_nominated_idx;
+	if (idx < 0 || idx >= ice->ice_params->cand_idx[ice->proto]) {
+		return SWITCH_FALSE;
+	}
+
+	cur_host = switch_get_addr(cur_buf, sizeof(cur_buf), ice->addr);
+	cur_port = switch_sockaddr_get_port(ice->addr);
+
+	return ice_candidate_matches_addr(&ice->ice_params->cands[idx][ice->proto], cur_host, cur_port) ? SWITCH_TRUE : SWITCH_FALSE;
+}
+
 static uint32_t ice_prflx_bootstrap_ms(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
 {
 	if (!ice->prflx_bootstrap_cached) {
@@ -1556,7 +1578,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Marked %s ICE candidate %s:%d as responsive (is_relay: %d)\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port, is_relay);
 
-						if (!ice->cand_responsive && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) && (!is_relay || rtp_session->elapsed_stun >= 1000)) {
+						if (!ice->cand_responsive && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) && (!is_relay || rtp_session->elapsed_stun >= 1000) &&
+							!ice_should_preserve_peer_nominated_dtls_tuple(rtp_session, ice, is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls, is_rtcp)) {
 							switch_channel_t *channel = NULL;
 							char ice_cur_buf[80] = "";
 							const char *ice_cur_host = switch_get_addr(ice_cur_buf, sizeof(ice_cur_buf), ice->addr);
@@ -1809,7 +1832,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					prior_current_nomination = SWITCH_TRUE;
 				}
 
-				if (peer_candidate_idx > -1) {
+				dtls_ready = dtls && dtls->state >= DS_READY && ice->ready;
+				preserve_dtls_tuple = !is_rtcp && peer_candidate && prior_current_nomination && peer_candidate_idx != prior_nominated_idx &&
+					!dtls_ready && rtp_session->ice.dtls_handshake && ice->cand_responsive ? SWITCH_TRUE : SWITCH_FALSE;
+
+				if (peer_candidate_idx > -1 && !preserve_dtls_tuple) {
 					for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
 						ice->ice_params->cands[i][ice->proto].use_candidate = 0;
 					}
@@ -1827,7 +1854,6 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						"%s late peer USE-CANDIDATE after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
 				}
 
-				dtls_ready = dtls && dtls->state >= DS_READY && ice->ready;
 				if (!is_rtcp && rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && dtls_ready && (ice->type & ICE_CONTROLLED)) {
 					mid_call_failover_ms = ice_mid_call_failover_ms(rtp_session, ice);
 					if (mid_call_failover_ms > 0) {
@@ -1845,12 +1871,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 				pre_dtls_prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
 				defer_to_prflx_bootstrap = pre_dtls_prflx_bootstrap_ms > 0 && pri && rtp_session->elapsed_stun <= pre_dtls_prflx_bootstrap_ms &&
-					ice->initializing && !rtp_session->ice.dtls_handshake && (!dtls || dtls->state < DS_READY) &&
+					ice->initializing && !ice->cand_responsive && (!dtls || dtls->state < DS_READY) &&
 					got_message_integrity && got_fingerprint &&
 					(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) ? SWITCH_TRUE : SWITCH_FALSE;
-				preserve_dtls_tuple = !is_rtcp && peer_candidate && prior_current_nomination && peer_candidate_idx != prior_nominated_idx &&
-					!dtls_ready && rtp_session->ice.dtls_handshake && ice->cand_responsive ? SWITCH_TRUE : SWITCH_FALSE;
-
 				if (ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE)) {
 					if (dtls_ready) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), allow_mid_call_failover ? SWITCH_LOG_DEBUG : SWITCH_LOG_DEBUG5,
@@ -1917,7 +1940,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							  "%s %s STUN from %s:%d %s is_relay: %d is_responsive: %d use_candidate: %d ready: %d, rready: %d dtls_handshake: %d\n", switch_channel_get_name(channel), rtp_type(rtp_session), from_host, from_port, cmp ? "EXPECTED" : "IGNORED", is_relay, is_responsive, use_candidate, ice->ready, ice->rready, rtp_session->ice.dtls_handshake);
 
-			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !cmp && !rtp_session->ice.dtls_handshake &&
+			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp &&
 				(!dtls || dtls->state < DS_READY) && got_message_integrity && got_fingerprint &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
@@ -2074,6 +2097,14 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						}
 					}
 				}
+			}
+
+			if ((ice->type & ICE_VANILLA) && ice->ice_params && do_adj &&
+				ice_should_preserve_peer_nominated_dtls_tuple(rtp_session, ice, dtls, is_rtcp)) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"ICE preserving peer-nominated %s DTLS tuple during handshake, ignoring auto-adjust from %s:%d (idx:%d)\n",
+					rtp_type(rtp_session), from_host, from_port, cur_idx);
+				do_adj = 0;
 			}
 
 			if ((ice->type & ICE_VANILLA) && ice->ice_params && do_adj) {
@@ -3956,6 +3987,9 @@ SWITCH_DECLARE(void) switch_rtp_reset(switch_rtp_t *rtp_session)
 	switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_PAUSE);
 	switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_MUTE);
 	rtcp_stats_init(rtp_session);
+
+	rtp_session->ice.remote_eoc_received = 0;
+	rtp_session->rtcp_ice.remote_eoc_received = 0;
 
 	if (rtp_session->ice.ready) {
 		switch_rtp_reset_vb(rtp_session);
@@ -6482,12 +6516,14 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 		switch_snprintf(user_ice, sizeof(user_ice), "%s:%s", rlogin, login);
 		switch_snprintf(luser_ice, sizeof(luser_ice), "%s%s", rlogin, login);
 		ice->ready = ice->rready = 0;
+		ice->remote_eoc_received = 0;
 		ice->cand_responsive = 0;
 	} else {
 		switch_snprintf(ice_user, sizeof(ice_user), "%s%s", login, rlogin);
 		switch_snprintf(user_ice, sizeof(user_ice), "%s%s", rlogin, login);
 		switch_snprintf(luser_ice, sizeof(luser_ice), "");
 		ice->ready = ice->rready = 1;
+		ice->remote_eoc_received = 0;
 		ice->cand_responsive = 0;
 	}
 	ice->first_responsive_us = 0;
@@ -11958,15 +11994,6 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 		}
 	}
 
-	/* RFC 8838: ignore late trickled candidates after end-of-candidates */
-	if ((ice == &rtp_session->ice && rtp_session->ice.rready) ||
-	    (ice == &rtp_session->rtcp_ice && rtp_session->rtcp_ice.rready)) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
-					"Trickle ICE: ignoring late remote candidate after end-of-candidates (mid=%s idx=%d, comp=%d)",
-					mid ? mid : "(null)", mline_index, cand->component_id);
-		return SWITCH_STATUS_SUCCESS;
-	}
-	
 	switch_mutex_lock(rtp_session->ice_mutex);
 
 	/* Re-check ice_params under lock — may have been freed during teardown */
@@ -11976,6 +12003,15 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 					"Trickle ICE: ice_params gone after lock (mid=%s idx=%d comp=%d)\n",
 					mid ? mid : "(null)", mline_index, cand->component_id);
 		return SWITCH_STATUS_FALSE;
+	}
+
+	/* RFC 8838: ignore late trickled candidates after explicit end-of-candidates. */
+	if (ice->remote_eoc_received) {
+		switch_mutex_unlock(rtp_session->ice_mutex);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+					"Trickle ICE: ignoring late remote candidate after end-of-candidates (mid=%s idx=%d, comp=%d)",
+					mid ? mid : "(null)", mline_index, cand->component_id);
+		return SWITCH_STATUS_SUCCESS;
 	}
 
 	{
@@ -12029,6 +12065,14 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 			if (ice->ice_params->chosen[ice->proto] >= (int)insert_at) {
 				ice->ice_params->chosen[ice->proto]++;
 			}
+
+			if (ice->mid_call_nominated_idx >= (int)insert_at) {
+				ice->mid_call_nominated_idx++;
+			}
+
+			if (ice->prflx_bootstrap_idx >= (int)insert_at) {
+				ice->prflx_bootstrap_idx++;
+			}
 		}
 	}
 
@@ -12078,14 +12122,25 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 static switch_status_t switch_rtp_internal_end_of_candidates(switch_rtp_t *rtp_session, int mline_index, const char *mid)
 {
 #ifdef SWITCH_HAVE_ICE
-	/* Mark that the remote finished listing candidates*/
-	if (rtp_session && rtp_session->ice.ice_params) {
-		rtp_session->ice.rready = 1;  /* RTP */
+	if (!rtp_session) {
+		return SWITCH_STATUS_FALSE;
 	}
 
-	if (rtp_session && !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && rtp_session->rtcp_ice.ice_params) {
-		rtp_session->rtcp_ice.rready = 1; /* RTCP */
+	switch_mutex_lock(rtp_session->ice_mutex);
+
+	/* Mark that the remote finished listing candidates. */
+	if (rtp_session->ice.ice_params) {
+		rtp_session->ice.rready = 1;  /* RTP */
+		rtp_session->ice.remote_eoc_received = 1;
 	}
+
+	if (!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && rtp_session->rtcp_ice.ice_params) {
+		rtp_session->rtcp_ice.rready = 1; /* RTCP */
+		rtp_session->rtcp_ice.remote_eoc_received = 1;
+	}
+
+	switch_mutex_unlock(rtp_session->ice_mutex);
+
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO, 
 			 "Trickle ICE: end-of-candidates (mid=%s idx=%d)\n", mid ? mid : "(null)", mline_index);
 	return SWITCH_STATUS_SUCCESS;
@@ -12094,6 +12149,7 @@ static switch_status_t switch_rtp_internal_end_of_candidates(switch_rtp_t *rtp_s
 	return SWITCH_STATUS_FALSE;
  #endif
 }
+
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_add_trickle_remote_candidate(switch_rtp_t *rtp_session, int mline_index, const char *mid, const char *cand_line)
 {
@@ -12367,6 +12423,7 @@ SWITCH_DECLARE(void) switch_rtp_prepare_trickle_ice(switch_rtp_t *rtp_session,  
 
 	ice->proto = proto;
 	ice->ice_params = ice_params;
+	ice->remote_eoc_received = 0;
 	switch_mutex_unlock(rtp_session->ice_mutex);
 }
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1454,6 +1454,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	uint16_t raw_packet_type = 0;
 	switch_bool_t provisional_ice = SWITCH_FALSE;
 	switch_bool_t stun_auth_valid = SWITCH_FALSE;
+	switch_bool_t trusted_use_candidate = SWITCH_FALSE;
 	switch_bool_t direct_username_match = SWITCH_FALSE;
 
 	if (is_rtcp) {
@@ -1486,11 +1487,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		memcpy(&raw_packet_type, data, sizeof(raw_packet_type));
 		raw_packet_type = ntohs(raw_packet_type);
 	}
+	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && (ice->type & ICE_VANILLA)) {
+		stun_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->pass) ? SWITCH_TRUE : SWITCH_FALSE;
+	}
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST) {
 		prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
-		if (prflx_bootstrap_ms > 0) {
-			stun_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->pass) ? SWITCH_TRUE : SWITCH_FALSE;
-		}
 	}
 	if (provisional_ice && (raw_packet_type != SWITCH_STUN_BINDING_REQUEST || !prflx_bootstrap_ms || !stun_auth_valid)) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
@@ -1608,6 +1609,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 		xlen += 4 + switch_stun_attribute_padded_length(attr);
 	} while (xlen <= packet->header.length);
+
+	if (got_use_candidate) {
+		trusted_use_candidate = (!(ice->type & ICE_VANILLA) ||
+			(got_message_integrity && got_fingerprint && stun_auth_valid)) ? SWITCH_TRUE : SWITCH_FALSE;
+	}
 
 	if ((ice->type & ICE_GOOGLE_JINGLE) && ok) {
 		ok = !strcmp(ice->user_ice, username);
@@ -1936,7 +1942,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						nominated_media_recent = ice->inbound_media_idx == peer_candidate_idx && ice->inbound_media_us &&
 							(uint32_t)((now - ice->inbound_media_us) / 1000) <= nomination_fresh_ms;
 					}
-					if (fresh_nomination && ((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent)) {
+					if (fresh_nomination && trusted_use_candidate &&
+						((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent || peer_candidate)) {
 						allow_mid_call_failover = SWITCH_TRUE;
 					}
 				}
@@ -1949,9 +1956,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				if (ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE)) {
 					if (dtls_ready) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), allow_mid_call_failover ? SWITCH_LOG_DEBUG : SWITCH_LOG_DEBUG5,
-							"USE-CANDIDATE: DTLS already READY, %s %s nomination from %s:%d (elapsed_stun=%u, elapsed_media=%u, mid_call_failover_ms=%u, controlled=%d, known_candidate=%d, fresh_nomination=%d, nomination_age_ms=%u, media_unhealthy=%d, nominated_media_recent=%d, rtcp_mux=%d)\n",
+							"USE-CANDIDATE: DTLS already READY, %s %s nomination from %s:%d (elapsed_stun=%u, elapsed_media=%u, mid_call_failover_ms=%u, controlled=%d, known_candidate=%d, fresh_nomination=%d, nomination_age_ms=%u, media_unhealthy=%d, nominated_media_recent=%d, trusted_use=%d, rtcp_mux=%d)\n",
 							allow_mid_call_failover ? "accepted" : "ignoring", rtp_type(rtp_session), from_host, from_port, rtp_session->elapsed_stun, rtp_session->elapsed_media, mid_call_failover_ms,
-							!!(ice->type & ICE_CONTROLLED), peer_candidate, fresh_nomination, nomination_age_ms, media_unhealthy, nominated_media_recent, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
+							!!(ice->type & ICE_CONTROLLED), peer_candidate, fresh_nomination, nomination_age_ms, media_unhealthy, nominated_media_recent,
+							trusted_use_candidate, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
 					} else if (preserve_dtls_tuple) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							"USE-CANDIDATE: preserving active %s DTLS tuple %s:%d during handshake, ignoring nomination from %s:%d\n",
@@ -2121,7 +2129,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 			if (!provisional_ice && cmp) {
 				ice->last_ok = now;
-			} else if (!provisional_ice && !do_adj && !is_rtcp && rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && dtls_ready && (ice->type & ICE_CONTROLLED) && use_candidate) {
+			} else if (!provisional_ice && !do_adj && !is_rtcp && rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && dtls_ready && (ice->type & ICE_CONTROLLED) && got_use_candidate && use_candidate) {
 				mid_call_failover_ms = ice_mid_call_failover_ms(rtp_session, ice);
 				if (mid_call_failover_ms > 0) {
 					media_unhealthy = rtp_session->elapsed_media >= mid_call_failover_ms || !ice->cand_responsive || !ice->rready;
@@ -2133,11 +2141,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					nominated_media_recent = ice->inbound_media_idx == cur_idx && ice->inbound_media_us &&
 						(uint32_t)((now - ice->inbound_media_us) / 1000) <= nomination_fresh_ms;
 				}
-				if (fresh_nomination && ((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent)) {
+				if (fresh_nomination && trusted_use_candidate &&
+					((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent || cur_idx > -1)) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
-						"%s %s %s ICE mid-call failover accepting freshly nominated %s:%d (elapsed_stun=%u, elapsed_media=%u, nomination_age_ms=%u, nominated_media_recent=%d, current: %s:%d typ: %s)\n",
+						"%s %s %s ICE mid-call failover accepting freshly nominated %s:%d (elapsed_stun=%u, elapsed_media=%u, nomination_age_ms=%u, nominated_media_recent=%d, trusted_use=%d, current: %s:%d typ: %s)\n",
 						switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, rtp_session->elapsed_stun,
-						rtp_session->elapsed_media, nomination_age_ms, nominated_media_recent,
+						rtp_session->elapsed_media, nomination_age_ms, nominated_media_recent, trusted_use_candidate,
 						ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]),
 						ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port,
 						ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1452,6 +1452,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	int got_message_integrity = 0;
 	int got_fingerprint = 0;
 	uint32_t prflx_bootstrap_ms = 0;
+	uint32_t stun_packet_len = 0;
 	uint16_t raw_packet_type = 0;
 	switch_bool_t provisional_ice = SWITCH_FALSE;
 	switch_bool_t stun_auth_valid = SWITCH_FALSE;
@@ -1518,7 +1519,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	calc_elapsed(rtp_session, ice);
 
-	end_buf = buf + ((sizeof(buf) > packet->header.length) ? packet->header.length : sizeof(buf));
+	stun_packet_len = sizeof(switch_stun_packet_header_t) + packet->header.length;
+	if (stun_packet_len > cpylen) {
+		stun_packet_len = (uint32_t)cpylen;
+	}
+	end_buf = buf + stun_packet_len;
 
 	switch_stun_packet_first_attribute(packet, attr);
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG8, "%s STUN PACKET TYPE: %s\n",

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -828,6 +828,26 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(s
 	return switch_cmp_addr(current_addr, handshake_peer_addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
+SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_dtls_nomination_proof(
+	switch_bool_t authenticated_vanilla_use_candidate, switch_bool_t direct_username_match)
+{
+	return authenticated_vanilla_use_candidate && direct_username_match ?
+		SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT : SWITCH_RTP_RECOVERY_NOMINATION_NONE;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_guard_recovery_dtls_tuple(switch_sockaddr_t *current_addr,
+	switch_sockaddr_t *packet_addr, dtls_state_t dtls_state, switch_bool_t is_rtcp,
+	switch_bool_t recovering, switch_rtp_recovery_nomination_proof_t nomination_proof)
+{
+	if (is_rtcp || !recovering || !current_addr || !packet_addr ||
+		(dtls_state != DS_HANDSHAKE && dtls_state != DS_SETUP) ||
+		switch_cmp_addr(packet_addr, current_addr, SWITCH_FALSE)) {
+		return SWITCH_FALSE;
+	}
+
+	return nomination_proof == SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT ? SWITCH_FALSE : SWITCH_TRUE;
+}
+
 static switch_bool_t ice_should_preserve_active_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
 {
 	if (!rtp_session || !ice || !dtls) {
@@ -1518,6 +1538,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_bool_t trusted_use_candidate = SWITCH_FALSE;
 	switch_bool_t authenticated_vanilla_use_candidate = SWITCH_FALSE;
 	switch_bool_t direct_username_match = SWITCH_FALSE;
+	switch_bool_t recovering = SWITCH_FALSE;
+	switch_rtp_recovery_nomination_proof_t nomination_proof = SWITCH_RTP_RECOVERY_NOMINATION_NONE;
 
 	if (is_rtcp) {
 		from_addr = rtp_session->rtcp_from_addr;
@@ -1544,6 +1566,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	}
 
 	channel = switch_core_session_get_channel(rtp_session->session);
+	recovering = channel && switch_channel_test_flag(channel, CF_RECOVERING) ? SWITCH_TRUE : SWITCH_FALSE;
 	provisional_ice = ice->addr ? SWITCH_FALSE : SWITCH_TRUE;
 	if (cpylen >= sizeof(switch_stun_packet_header_t)) {
 		memcpy(&raw_packet_type, data, sizeof(raw_packet_type));
@@ -1679,11 +1702,16 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		xlen += 4 + switch_stun_attribute_padded_length(attr);
 	} while (xlen <= packet->header.length);
 
-	if (got_use_candidate) {
+	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && got_use_candidate) {
 		authenticated_vanilla_use_candidate = ((ice->type & ICE_VANILLA) && got_use_candidate_covered &&
 			got_message_integrity && got_fingerprint && stun_auth_valid) ? SWITCH_TRUE : SWITCH_FALSE;
 		trusted_use_candidate = (!(ice->type & ICE_VANILLA) || authenticated_vanilla_use_candidate) ? SWITCH_TRUE : SWITCH_FALSE;
 	}
+
+	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && !zstr(username) && !icecmp(username, ice)) {
+		direct_username_match = SWITCH_TRUE;
+	}
+	nomination_proof = switch_rtp_pvt_recovery_dtls_nomination_proof(authenticated_vanilla_use_candidate, direct_username_match);
 
 	if ((ice->type & ICE_GOOGLE_JINGLE) && ok) {
 		ok = !strcmp(ice->user_ice, username);
@@ -1722,7 +1750,13 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Marked %s ICE candidate %s:%d as responsive (is_relay: %d)\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port, is_relay);
 
 						if (!ice->cand_responsive && ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) && (!is_relay || rtp_session->elapsed_stun >= 1000) &&
-							!ice_should_preserve_active_dtls_tuple(rtp_session, ice, is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls, is_rtcp)) {
+							!ice_should_preserve_active_dtls_tuple(rtp_session, ice, is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls, is_rtcp) &&
+							!switch_rtp_pvt_should_guard_recovery_dtls_tuple(ice->addr, from_addr,
+								is_rtcp ? (rtp_session->rtcp_dtls ? rtp_session->rtcp_dtls->state : DS_OFF) :
+									(rtp_session->dtls ? rtp_session->dtls->state : DS_OFF),
+								is_rtcp ? SWITCH_TRUE : SWITCH_FALSE, recovering,
+								ice->ice_params->cands[i][ice->proto].use_candidate ?
+									SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED : SWITCH_RTP_RECOVERY_NOMINATION_NONE)) {
 							switch_channel_t *channel = NULL;
 							char ice_cur_buf[80] = "";
 							const char *ice_cur_host = switch_get_addr(ice_cur_buf, sizeof(ice_cur_buf), ice->addr);
@@ -1772,8 +1806,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		}
 
 		if (!zstr(username)) {
-			if (!icecmp(username, ice)) {
-				direct_username_match = SWITCH_TRUE;
+			if (direct_username_match) {
 				ok = 1;
 			} else if(!provisional_ice && !zstr(rtp_session->rtcp_ice.user_ice) && !icecmp(username, &rtp_session->rtcp_ice)) {
 				ice = &rtp_session->rtcp_ice;
@@ -1814,6 +1847,17 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					}
 					for (i = 0; i < icep[j]->ice_params->cand_idx[icep[j]->proto]; i++) {
 						if (icep[j]->ice_params &&  icep[j]->ice_params->cands[i][icep[j]->proto].priority == *pri) {
+							if (j == IPR_RTP && switch_rtp_pvt_should_guard_recovery_dtls_tuple(icep[j]->addr, from_addr,
+								rtp_session->dtls ? rtp_session->dtls->state : DS_OFF, SWITCH_FALSE, recovering,
+								nomination_proof == SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT ? nomination_proof :
+									(icep[j]->ice_params->cands[i][icep[j]->proto].use_candidate ?
+										SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED : SWITCH_RTP_RECOVERY_NOMINATION_NONE))) {
+								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+									"ICE preserving recovery DTLS restart tuple, ignoring missed-candidate fallback from %s:%d\n",
+									from_host, from_port);
+								continue;
+							}
+
 							if (j == IPR_RTP) {
 								icep[j]->ice_params->chosen[j] = i;
 								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO, "Change candidate index to %d\n", i);
@@ -1915,6 +1959,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_bool_t prflx_addr_ok = SWITCH_FALSE;
 			switch_bool_t prflx_bootstrap_installed = SWITCH_FALSE;
 			switch_bool_t restart_prflx_allowed = SWITCH_FALSE;
+			switch_bool_t guard_recovery_dtls_tuple = SWITCH_FALSE;
+			switch_bool_t guard_recovery_nomination = SWITCH_FALSE;
 			switch_dtls_t *dtls = is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls;
 
 			if (is_rtcp) {
@@ -1945,7 +1991,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 			bytes = switch_stun_packet_length(rpacket);
 
-			if (got_use_candidate && !provisional_ice) {
+			guard_recovery_nomination = switch_rtp_pvt_should_guard_recovery_dtls_tuple(ice->addr, from_addr,
+				dtls ? dtls->state : DS_OFF, is_rtcp ? SWITCH_TRUE : SWITCH_FALSE, recovering, nomination_proof);
+
+			if (got_use_candidate && !provisional_ice && !guard_recovery_nomination) {
 				uint32_t mid_call_failover_ms = 0;
 				uint32_t nomination_age_ms = 0;
 				uint32_t nomination_fresh_ms = 0;
@@ -2057,6 +2106,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 							rtp_type(rtp_session), from_host, from_port);
 					}
 				}
+			} else if (got_use_candidate && !provisional_ice && guard_recovery_nomination) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"ICE preserving recovery DTLS restart tuple, ignoring untrusted USE-CANDIDATE from %s:%d\n",
+					from_host, from_port);
 			}
 
 			if (pri) {
@@ -2095,6 +2148,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							  "%s %s STUN from %s:%d %s is_relay: %d is_responsive: %d use_candidate: %d ready: %d, rready: %d dtls_handshake: %d\n", switch_channel_get_name(channel), rtp_type(rtp_session), from_host, from_port, cmp ? "EXPECTED" : "IGNORED", is_relay, is_responsive, use_candidate, ice->ready, ice->rready, rtp_session->ice.dtls_handshake);
 
+			guard_recovery_dtls_tuple = switch_rtp_pvt_should_guard_recovery_dtls_tuple(ice->addr, from_addr,
+				dtls ? dtls->state : DS_OFF, is_rtcp ? SWITCH_TRUE : SWITCH_FALSE, recovering,
+				nomination_proof == SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT ? nomination_proof :
+					(use_candidate ? SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED : SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+
 			restart_prflx_allowed = switch_rtp_pvt_restart_prflx_allowed(ice, dtls ? dtls->state : DS_OFF,
 				provisional_ice, direct_username_match, stun_auth_valid, got_message_integrity, got_fingerprint,
 				got_use_candidate, got_use_candidate_covered, pri ? SWITCH_TRUE : SWITCH_FALSE,
@@ -2102,7 +2160,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				 (!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) ? SWITCH_TRUE : SWITCH_FALSE,
 				prflx_bootstrap_ms, now);
 
-			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok &&
+			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok && !guard_recovery_dtls_tuple &&
 				(!dtls || dtls->state < DS_READY || restart_prflx_allowed) && stun_auth_valid &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
@@ -2163,7 +2221,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 			}
 
-			if (!provisional_ice && ice->initializing && !cmp && !rtp_session->ice.dtls_handshake) {
+			if (!guard_recovery_dtls_tuple && !provisional_ice && ice->initializing && !cmp && !rtp_session->ice.dtls_handshake) {
 				if (!rtp_session->adj_window && (!ice->ready || !ice->rready || (!rtp_session->dtls || rtp_session->dtls->state != DS_READY))) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE set ADJUST window to 10 seconds on binding request from %s:%d (is_relay: %d, is_responsivie: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 									switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
@@ -2239,6 +2297,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					do_adj++;
 					rtp_session->last_adj = now;
 				}
+			} else if (guard_recovery_dtls_tuple) {
+				do_adj = 0;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"ICE preserving recovery DTLS restart tuple, ignoring non-nominated auto-adjust from %s:%d\n",
+					from_host, from_port);
 			} else if (!provisional_ice && !do_adj && !rtp_session->ice.dtls_handshake) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE %d/%d dt:%d i:%d i2:%d cmp:%d\n", rtp_session->elapsed_stun, rtp_session->elapsed_media, (rtp_session->dtls && rtp_session->dtls->state != DS_READY), !ice->ready, !ice->rready, same_host);
 
@@ -4781,6 +4844,8 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 	uint8_t is_ice = rtp_session->ice.ice_user ? 1 : 0;
 	int ready = is_ice ? (rtp_session->ice.rready && rtp_session->ice.ready) : 1;
 	int pending;
+	switch_channel_t *channel = NULL;
+	switch_bool_t is_rtcp = SWITCH_FALSE;
 
 	if (!dtls->bytes && !ready) {
 		return 0;
@@ -4796,12 +4861,19 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 		return 0;
 	}
 
+	if (rtp_session->session) {
+		channel = switch_core_session_get_channel(rtp_session->session);
+	}
+
+	is_rtcp = (dtls == rtp_session->rtcp_dtls && rtp_session->dtls != rtp_session->rtcp_dtls) ? SWITCH_TRUE : SWITCH_FALSE;
+
 	if (is_ice && !switch_cmp_addr(rtp_session->from_addr, rtp_session->ice.addr, SWITCH_FALSE)) {
 		char tmp_buf1[80] = "";
 		char tmp_buf2[80] = "";
 		const char *host_from = switch_get_addr(tmp_buf1, sizeof(tmp_buf1), rtp_session->from_addr);
 		const char *host_ice_cur_addr = switch_get_addr(tmp_buf2, sizeof(tmp_buf2), rtp_session->ice.addr);
 		switch_port_t from_port = switch_sockaddr_get_port(rtp_session->from_addr);
+		switch_bool_t guard_recovery_dtls_tuple = SWITCH_FALSE;
 		int nominated = 0;
 
 		/* Accept DTLS from a USE-CANDIDATE nominated address (e.g. relay). */
@@ -4824,7 +4896,16 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 			}
 		}
 
-		if (!nominated && dtls->state < DS_READY) {
+		guard_recovery_dtls_tuple = switch_rtp_pvt_should_guard_recovery_dtls_tuple(rtp_session->ice.addr, rtp_session->from_addr,
+			dtls->state, is_rtcp, channel && switch_channel_test_flag(channel, CF_RECOVERING) ? SWITCH_TRUE : SWITCH_FALSE,
+			nominated ? SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED : SWITCH_RTP_RECOVERY_NOMINATION_NONE);
+
+		if (guard_recovery_dtls_tuple) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+				"Got DTLS packet from [%s:%d] during recovery DTLS restart while current ICE is [%s]. Ignored.\n",
+				host_from, from_port, host_ice_cur_addr);
+			return 0;
+		} else if (!nominated && dtls->state < DS_READY) {
 			/* Pre-READY: accept non-nominated DTLS for handshake (fingerprint auth) but don't switch dest. */
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 				"DTLS packet from [%s] (not nominated), processing for handshake (current ICE [%s]).\n",

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -848,6 +848,22 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_guard_recovery_dtls_tuple(sw
 	return nomination_proof == SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT ? SWITCH_FALSE : SWITCH_TRUE;
 }
 
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_sync_authenticated_recovery_ice_addr(switch_sockaddr_t **ice_addr,
+	switch_sockaddr_t *remote_addr, switch_sockaddr_t *nominated_addr, dtls_state_t dtls_state,
+	switch_bool_t is_rtcp, switch_bool_t rtcp_mux, switch_bool_t recovering,
+	switch_rtp_recovery_nomination_proof_t nomination_proof)
+{
+	if (!ice_addr || !remote_addr || !nominated_addr || is_rtcp || rtcp_mux || !recovering ||
+		(dtls_state != DS_HANDSHAKE && dtls_state != DS_SETUP) ||
+		nomination_proof != SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT ||
+		!switch_cmp_addr(remote_addr, nominated_addr, SWITCH_FALSE)) {
+		return SWITCH_FALSE;
+	}
+
+	*ice_addr = remote_addr;
+	return SWITCH_TRUE;
+}
+
 static switch_bool_t ice_should_preserve_active_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
 {
 	if (!rtp_session || !ice || !dtls) {
@@ -2089,6 +2105,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 							"USE-CANDIDATE: switching %s ice dest from current to nominated %s:%d\n",
 							rtp_type(rtp_session), from_host, from_port);
 						switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
+						switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice->addr, rtp_session->remote_addr, from_addr,
+							dtls ? dtls->state : DS_OFF, is_rtcp ? SWITCH_TRUE : SWITCH_FALSE,
+							rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ? SWITCH_TRUE : SWITCH_FALSE,
+							recovering, nomination_proof);
 
 						/* Update DTLS remote addr for future DTLS writes. */
 						if (dtls && dtls->remote_addr) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1600,7 +1600,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Marked %s ICE candidate %s:%d as responsive (is_relay: %d)\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port, is_relay);
 
-						if (!ice->cand_responsive && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) && (!is_relay || rtp_session->elapsed_stun >= 1000) &&
+						if (!ice->cand_responsive && ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) && (!is_relay || rtp_session->elapsed_stun >= 1000) &&
 							!ice_should_preserve_active_dtls_tuple(rtp_session, ice, is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls, is_rtcp)) {
 							switch_channel_t *channel = NULL;
 							char ice_cur_buf[80] = "";
@@ -1771,7 +1771,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_socket_t *sock_output = rtp_session->sock_output;
 			uint8_t do_adj = 0;
 			switch_time_t now = switch_micro_time_now();
+			switch_sockaddr_t *prflx_ice_addr = NULL;
+			switch_sockaddr_t *prflx_dtls_addr = NULL;
 			int cmp = 0;
+			int same_host = 0;
 			int cur_idx = -1, is_relay = 0, is_responsive = 0, use_candidate = 0;
 			uint32_t mid_call_failover_ms = 0;
 			uint32_t nomination_age_ms = 0;
@@ -1935,9 +1938,14 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				prflx_age_ms = (uint32_t)((now - ice->prflx_bootstrap_us) / 1000);
 			}
 
-			host2 = switch_get_addr(buf2, sizeof(buf2), ice->addr);
-			port2 = switch_sockaddr_get_port(ice->addr);
-			cmp = switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE);
+			if (ice->addr) {
+				host2 = switch_get_addr(buf2, sizeof(buf2), ice->addr);
+				port2 = switch_sockaddr_get_port(ice->addr);
+				cmp = switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE);
+				same_host = switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE);
+			} else {
+				host2 = "unselected";
+			}
 
 			for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; i++) {
 				if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
@@ -1968,7 +1976,13 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 				prflx_addr_ok = ice_remote_ip_is_acceptable(rtp_session, from_host, "udp", &prflx_family);
 				if (prflx_addr_ok) {
-					prflx_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, from_host, from_port, prflx_priority, got_use_candidate ? SWITCH_TRUE : SWITCH_FALSE);
+					if (switch_sockaddr_info_get(&prflx_ice_addr, from_host, SWITCH_UNSPEC, from_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !prflx_ice_addr ||
+						(dtls && (switch_sockaddr_info_get(&prflx_dtls_addr, from_host, SWITCH_UNSPEC, from_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !prflx_dtls_addr))) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+							"ICE peer-reflexive bootstrap: failed to resolve learned tuple %s:%d\n", from_host, from_port);
+					} else {
+						prflx_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, from_host, from_port, prflx_priority, got_use_candidate ? SWITCH_TRUE : SWITCH_FALSE);
+					}
 				}
 
 				if (prflx_idx > -1) {
@@ -2025,10 +2039,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE CHECK SAME IP DIFFT PORT %d %d on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
-								switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp",ice->initializing, switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE), from_host, from_port, is_relay, is_responsive, use_candidate,
+								switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp",ice->initializing, same_host, from_host, from_port, is_relay, is_responsive, use_candidate,
 								ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
-				if (!do_adj && (switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE) || (use_candidate && !is_relay))) {
+				if (!do_adj && (same_host || (use_candidate && !is_relay))) {
 					do_adj++;
 					rtp_session->last_adj = now;
 
@@ -2072,7 +2086,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					rtp_session->last_adj = now;
 				}
 			} else if (!do_adj && !rtp_session->ice.dtls_handshake) {
-				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE %d/%d dt:%d i:%d i2:%d cmp:%d\n", rtp_session->elapsed_stun, rtp_session->elapsed_media, (rtp_session->dtls && rtp_session->dtls->state != DS_READY), !ice->ready, !ice->rready, switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE));
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE %d/%d dt:%d i:%d i2:%d cmp:%d\n", rtp_session->elapsed_stun, rtp_session->elapsed_media, (rtp_session->dtls && rtp_session->dtls->state != DS_READY), !ice->ready, !ice->rready, same_host);
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST ELAPSED vs 1000 %d on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 								switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp" ,rtp_session->elapsed_adj, from_host, from_port, is_relay, is_responsive, use_candidate,
@@ -2085,7 +2099,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 									ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]), ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port, ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
 
 					if (!is_relay && ((rtp_session->dtls && rtp_session->dtls->state != DS_READY) ||
-						((!ice->ready || !ice->rready) && (rtp_session->elapsed_stun >= 3000 || switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE))))) {
+						((!ice->ready || !ice->rready) && (rtp_session->elapsed_stun >= 3000 || same_host)))) {
 
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST HIT 3 on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 										switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
@@ -2151,13 +2165,14 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				switch_core_media_gen_key_frame(rtp_session->session);
 
 				switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
-				if (prflx_bootstrap && dtls && dtls->remote_addr) {
-					if (switch_sockaddr_info_get(&dtls->remote_addr, from_host, SWITCH_UNSPEC, from_port, 0, rtp_session->pool) == SWITCH_STATUS_SUCCESS) {
+				if (prflx_bootstrap) {
+					if (!ice->addr && prflx_ice_addr) {
+						ice->addr = prflx_ice_addr;
+					}
+					if (dtls && prflx_dtls_addr) {
+						dtls->remote_addr = prflx_dtls_addr;
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
 							"ICE peer-reflexive bootstrap: updated DTLS remote addr to %s:%d\n", from_host, from_port);
-					} else {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
-							"ICE peer-reflexive bootstrap: failed to resolve DTLS remote addr %s:%d\n", from_host, from_port);
 					}
 				}
 				if (mid_call_failover && !is_rtcp && dtls && dtls->remote_addr) {
@@ -4621,6 +4636,10 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 		return 0;
 	}
 
+	if (is_ice && !rtp_session->ice.addr) {
+		return 0;
+	}
+
 	if (is_ice && !(rtp_session->ice.type & ICE_LITE) && !rtp_session->ice.cand_responsive) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG6, "Got DTLS packet but candidate is not responsive\n");
 
@@ -6516,6 +6535,8 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	char *host = NULL;
 	switch_port_t port = 0;
 	char bufc[50];
+	int provisional = 0;
+	icand_t *candidate = NULL;
 
 
 	switch_mutex_lock(rtp_session->ice_mutex);
@@ -6599,10 +6620,20 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	}
 
 	if ((ice->type & ICE_VANILLA) && ice->ice_params) {
-		host = ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_addr;
-		port = ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port;
+		candidate = &ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto];
+		host = candidate->con_addr;
+		port = candidate->con_port;
 
-		if (!host || !port || switch_sockaddr_info_get(&ice->addr, host, SWITCH_UNSPEC, port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !ice->addr) {
+		if (!candidate->ready) {
+			if (ice_prflx_bootstrap_ms(rtp_session, ice) > 0) {
+				ice->addr = NULL;
+				provisional = 1;
+			} else {
+				switch_mutex_unlock(rtp_session->ice_mutex);
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Cannot activate ICE with an unready remote candidate\n");
+				return SWITCH_STATUS_FALSE;
+			}
+		} else if (!host || !port || switch_sockaddr_info_get(&ice->addr, host, SWITCH_UNSPEC, port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !ice->addr) {
 			switch_mutex_unlock(rtp_session->ice_mutex);
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_ERROR, "Error setting remote host!\n");
 			return SWITCH_STATUS_FALSE;
@@ -6622,8 +6653,14 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 		switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED);
 	}
 
-	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE, "Activating %s %s ICE: %s %s:%d\n",
+	if (provisional) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+			"Armed %s %s ICE for peer-reflexive bootstrap: %s\n",
+			proto == IPR_RTP ? "RTP" : "RTCP", rtp_type(rtp_session), ice_user);
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE, "Activating %s %s ICE: %s %s:%d\n",
 					  proto == IPR_RTP ? "RTP" : "RTCP", rtp_type(rtp_session), ice_user, host, port);
+	}
 
 
 	rtp_session->rtp_bugs |= RTP_BUG_ACCEPT_ANY_PACKETS;
@@ -10296,7 +10333,7 @@ static int rtp_write_ready(switch_rtp_t *rtp_session, uint32_t bytes, int line)
 {
 	if (!rtp_session) return 0;
 
-	if (rtp_session->ice.ice_user && !(rtp_session->ice.rready || rtp_session->ice.ready)) {
+	if (rtp_session->ice.ice_user && (!rtp_session->ice.addr || !(rtp_session->ice.rready || rtp_session->ice.ready))) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG3, "Skip sending %s packet %ld bytes (ice not ready @ line %d!)\n",
 						  rtp_type(rtp_session), (long)bytes, line);
 		return 0;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1431,6 +1431,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	uint16_t raw_packet_type = 0;
 	switch_bool_t provisional_ice = SWITCH_FALSE;
 	switch_bool_t stun_auth_valid = SWITCH_FALSE;
+	switch_bool_t direct_username_match = SWITCH_FALSE;
 
 	if (is_rtcp) {
 		from_addr = rtp_session->rtcp_from_addr;
@@ -1673,14 +1674,18 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 		if (!zstr(username)) {
 			if (!icecmp(username, ice)) {
+				direct_username_match = SWITCH_TRUE;
 				ok = 1;
 			} else if(!provisional_ice && !zstr(rtp_session->rtcp_ice.user_ice) && !icecmp(username, &rtp_session->rtcp_ice)) {
 				ice = &rtp_session->rtcp_ice;
 				ok = 1;
 			}
 		}
+		if (provisional_ice) {
+			ok = direct_username_match;
+		}
 
-		if (ok) {
+		if (ok && !provisional_ice) {
 			ice->missed_count = 0;
 		} else if (!provisional_ice) {
 			switch_rtp_ice_t *icep[2] = { &rtp_session->ice, &rtp_session->rtcp_ice };
@@ -1987,7 +1992,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							  "%s %s STUN from %s:%d %s is_relay: %d is_responsive: %d use_candidate: %d ready: %d, rready: %d dtls_handshake: %d\n", switch_channel_get_name(channel), rtp_type(rtp_session), from_host, from_port, cmp ? "EXPECTED" : "IGNORED", is_relay, is_responsive, use_candidate, ice->ready, ice->rready, rtp_session->ice.dtls_handshake);
 
-			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp &&
+			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok &&
 				(!dtls || dtls->state < DS_READY) && stun_auth_valid &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -79,6 +79,11 @@
 #define RTP_STUN_FREQ 1000000
 #define DEFAULT_ICE_NOMINATION_FALLBACK_MS 10000
 #define DEFAULT_ICE_MID_CALL_FAILOVER_MS 5000
+#define DEFAULT_ICE_CONTROLLING_FAILOVER_MS 5000
+#define ICE_CONTROLLING_FAILOVER_TRANSACTION_MS 5000
+#define ICE_CONTROLLING_FAILOVER_RTO_MS 1000
+#define ICE_CONTROLLING_FAILOVER_MAX_ATTEMPTS 4
+#define ICE_LOCAL_PRFLX_PRIORITY 0x6effffffU
 #define DEFAULT_ICE_PRFLX_BOOTSTRAP_MS 10000
 #define rtp_header_len 12
 #define RTP_START_PORT 16384
@@ -441,6 +446,7 @@ struct switch_rtp {
 	switch_port_t rx_port;
 	switch_rtp_ice_t ice;
 	switch_rtp_ice_t rtcp_ice;
+	char ice_tie_breaker[8];
 	char *timer_name;
 	char *local_host_str;
 	char *remote_host_str;
@@ -919,7 +925,8 @@ static int switch_rtp_find_prflx_candidate(switch_rtp_ice_t *ice)
 	return -1;
 }
 
-static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, const char *host, switch_port_t port, uint32_t priority, switch_bool_t use_candidate)
+static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, const char *host,
+	switch_port_t port, uint32_t priority, switch_bool_t use_candidate, switch_bool_t mark_ready)
 {
 	icand_t *cand;
 	int idx;
@@ -931,6 +938,14 @@ static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_
 
 	for (idx = 0; idx < ice->ice_params->cand_idx[ice->proto]; ++idx) {
 		if (ice_candidate_matches_addr(&ice->ice_params->cands[idx][ice->proto], host, port)) {
+			cand = &ice->ice_params->cands[idx][ice->proto];
+			if (mark_ready) {
+				cand->responsive = 1;
+				cand->ready = 1;
+			}
+			if (use_candidate) {
+				cand->use_candidate = 1;
+			}
 			return idx;
 		}
 	}
@@ -954,8 +969,8 @@ static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_
 	cand->con_addr = switch_core_strdup(rtp_session->pool, host);
 	cand->con_port = port;
 	cand->cand_type = switch_core_strdup(rtp_session->pool, "prflx");
-	cand->responsive = 1;
-	cand->ready = 1;
+	cand->responsive = mark_ready ? 1 : 0;
+	cand->ready = mark_ready ? 1 : 0;
 	cand->use_candidate = use_candidate ? 1 : 0;
 
 	return idx;
@@ -1305,6 +1320,471 @@ static uint32_t ice_mid_call_failover_ms(switch_rtp_t *rtp_session, switch_rtp_i
 	return ice->mid_call_failover_enabled ? ice->mid_call_failover_ms : 0;
 }
 
+static void ice_controlling_failover_reset(switch_rtp_ice_t *ice, switch_bool_t clear_candidate)
+{
+	if (!ice) {
+		return;
+	}
+
+	ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE;
+	ice->controlling_failover_started_us = 0;
+	ice->controlling_failover_sent_us = 0;
+	ice->controlling_failover_attempts = 0;
+	ice->controlling_failover_socket = NULL;
+	ice->controlling_failover_local_port = 0;
+	ice->controlling_failover_local_family = SWITCH_UNSPEC;
+	memset(ice->controlling_failover_probe_id, 0, sizeof(ice->controlling_failover_probe_id));
+	memset(ice->controlling_failover_nomination_id, 0, sizeof(ice->controlling_failover_nomination_id));
+
+	if (clear_candidate) {
+		ice->controlling_failover_idx = -1;
+		ice->controlling_failover_candidate_us = 0;
+	}
+}
+
+static void ice_selected_pair_check_reset(switch_rtp_ice_t *ice)
+{
+	if (!ice) {
+		return;
+	}
+
+	memset(ice->selected_pair_check_ids, 0, sizeof(ice->selected_pair_check_ids));
+	memset(ice->selected_pair_check_controlling, 0, sizeof(ice->selected_pair_check_controlling));
+	memset(ice->selected_pair_check_remote_addr, 0, sizeof(ice->selected_pair_check_remote_addr));
+	ice->selected_pair_check_pos = 0;
+	ice->selected_pair_check_count = 0;
+	ice->selected_pair_check_socket = NULL;
+	ice->selected_pair_check_local_port = 0;
+	ice->selected_pair_check_local_family = SWITCH_UNSPEC;
+}
+
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_cancel(switch_rtp_ice_t *ice)
+{
+	if (!ice) {
+		return;
+	}
+
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+	ice_selected_pair_check_reset(ice);
+	memset(ice->last_sent_id, 0, sizeof(ice->last_sent_id));
+}
+
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_apply(switch_rtp_ice_t *ice, switch_bool_t sent_controlling)
+{
+	if (!ice || !(ice->type & ICE_VANILLA)) {
+		return;
+	}
+
+	if (sent_controlling) {
+		ice->type |= ICE_CONTROLLED;
+		if (ice->promoted_to_controlling) {
+			ice->nomination_fallback_enabled = 0;
+		}
+	} else {
+		ice->type &= ~ICE_CONTROLLED;
+	}
+	ice->promoted_to_controlling = 0;
+}
+
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(char tie_breaker[8])
+{
+	if (tie_breaker) {
+		switch_stun_random_string(tie_breaker, 8, NULL);
+	}
+}
+
+SWITCH_DECLARE(uint32_t) switch_rtp_pvt_ice_local_prflx_priority(switch_bool_t is_rtcp, switch_bool_t rtcp_mux)
+{
+	return is_rtcp && !rtcp_mux ? ICE_LOCAL_PRFLX_PRIORITY - 1 : ICE_LOCAL_PRFLX_PRIORITY;
+}
+
+static uint32_t ice_controlling_failover_ms(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
+{
+	if (!ice->controlling_failover_cached) {
+		switch_channel_t *channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+
+		if (channel) {
+			const char *failover_var = switch_channel_get_variable(channel, "rtp_ice_controlling_mid_call_failover");
+			int raw = switch_safe_atoi(
+				switch_channel_get_variable(channel, "rtp_ice_controlling_mid_call_failover_ms"),
+				DEFAULT_ICE_CONTROLLING_FAILOVER_MS);
+
+			ice->controlling_failover_enabled = failover_var && switch_true(failover_var);
+			ice->controlling_failover_ms = (raw > 0) ? (uint32_t)raw : 0;
+		} else {
+			ice->controlling_failover_enabled = 0;
+			ice->controlling_failover_ms = 0;
+		}
+
+		ice->controlling_failover_cached = 1;
+	}
+
+	return ice->controlling_failover_enabled ? ice->controlling_failover_ms : 0;
+}
+
+static switch_bool_t ice_controlling_failover_ready(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
+{
+	switch_channel_t *channel;
+
+	if (!rtp_session || !ice || ice != &rtp_session->ice || !ice->ice_params || !ice->addr ||
+		!(ice->type & ICE_VANILLA) || (ice->type & (ICE_CONTROLLED | ICE_LITE | ICE_LITE_INBOUND)) ||
+		ice->initializing || !ice->ready || !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ||
+		!rtp_session->dtls || rtp_session->dtls->state != DS_READY ||
+		!ice_controlling_failover_ms(rtp_session, ice)) {
+		return SWITCH_FALSE;
+	}
+
+	channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+	if (channel && switch_channel_test_flag(channel, CF_RECOVERING)) {
+		return SWITCH_FALSE;
+	}
+
+	return SWITCH_TRUE;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_matches(switch_rtp_ice_t *ice,
+	switch_rtp_ice_controlling_failover_state_t expected_state, int candidate_idx, const char *transaction_id,
+	switch_bool_t authenticated, switch_socket_t *local_socket, switch_port_t local_port, int local_family)
+{
+	const char *expected_id;
+
+	if (!ice || !transaction_id || !authenticated || candidate_idx < 0 ||
+		ice->controlling_failover_state != expected_state || ice->controlling_failover_idx != candidate_idx ||
+		!local_socket || ice->controlling_failover_socket != local_socket ||
+		!ice->controlling_failover_local_port || ice->controlling_failover_local_port != local_port ||
+		ice->controlling_failover_local_family == SWITCH_UNSPEC ||
+		ice->controlling_failover_local_family != local_family) {
+		return SWITCH_FALSE;
+	}
+
+	if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING) {
+		expected_id = ice->controlling_failover_probe_id;
+	} else if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING ||
+		expected_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
+		expected_id = ice->controlling_failover_nomination_id;
+	} else {
+		return SWITCH_FALSE;
+	}
+
+	return memcmp(transaction_id, expected_id, 12) ? SWITCH_FALSE : SWITCH_TRUE;
+}
+
+SWITCH_DECLARE(switch_rtp_ice_controlling_timer_action_t) switch_rtp_pvt_controlling_failover_timer_action(
+	switch_rtp_ice_controlling_failover_state_t state, switch_time_t started_us, switch_time_t sent_us,
+	uint8_t attempts, switch_time_t now)
+{
+	uint64_t elapsed_ms;
+	uint64_t sent_elapsed_ms;
+
+	if ((state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING &&
+		 state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING &&
+		 state != SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) ||
+		!started_us || !sent_us || now < started_us || now < sent_us) {
+		return state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE ?
+			SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE : SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE;
+	}
+
+	elapsed_ms = (uint64_t)(now - started_us) / 1000;
+	sent_elapsed_ms = (uint64_t)(now - sent_us) / 1000;
+	if (elapsed_ms >= ICE_CONTROLLING_FAILOVER_TRANSACTION_MS ||
+		(attempts >= ICE_CONTROLLING_FAILOVER_MAX_ATTEMPTS && sent_elapsed_ms >= ICE_CONTROLLING_FAILOVER_RTO_MS)) {
+		return SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE;
+	}
+
+	if (attempts < ICE_CONTROLLING_FAILOVER_MAX_ATTEMPTS && sent_elapsed_ms >= ICE_CONTROLLING_FAILOVER_RTO_MS) {
+		return SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT;
+	}
+
+	return SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE;
+}
+
+static void ice_selected_pair_check_record(switch_rtp_ice_t *ice, const char *transaction_id,
+	switch_bool_t sent_controlling, switch_socket_t *local_socket, switch_sockaddr_t *local_addr,
+	switch_sockaddr_t *remote_addr)
+{
+	uint8_t pos;
+
+	if (!ice || !transaction_id || !local_socket || !local_addr || !remote_addr) {
+		return;
+	}
+
+	if (ice->selected_pair_check_socket != local_socket ||
+		ice->selected_pair_check_local_port != switch_sockaddr_get_port(local_addr) ||
+		ice->selected_pair_check_local_family != switch_sockaddr_get_family(local_addr)) {
+		ice_selected_pair_check_reset(ice);
+	}
+	ice->selected_pair_check_socket = local_socket;
+	ice->selected_pair_check_local_port = switch_sockaddr_get_port(local_addr);
+	ice->selected_pair_check_local_family = switch_sockaddr_get_family(local_addr);
+
+	pos = ice->selected_pair_check_pos % SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY;
+	memcpy(ice->selected_pair_check_ids[pos], transaction_id, 12);
+	ice->selected_pair_check_ids[pos][12] = '\0';
+	ice->selected_pair_check_controlling[pos] = sent_controlling ? 1 : 0;
+	ice->selected_pair_check_remote_addr[pos] = remote_addr;
+	ice->selected_pair_check_pos = (uint8_t)((pos + 1) % SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY);
+	if (ice->selected_pair_check_count < SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY) {
+		ice->selected_pair_check_count++;
+	}
+}
+
+static switch_bool_t ice_selected_pair_response_matches(switch_rtp_ice_t *ice, const char *transaction_id,
+	switch_sockaddr_t *from_addr, switch_socket_t *local_socket, switch_port_t local_port, int local_family,
+	switch_bool_t consume, switch_bool_t *sent_controlling)
+{
+	int i;
+
+	if (!ice || !transaction_id || !from_addr || !local_socket || ice->selected_pair_check_socket != local_socket ||
+		ice->selected_pair_check_local_port != local_port ||
+		ice->selected_pair_check_local_family != local_family) {
+		return SWITCH_FALSE;
+	}
+
+	for (i = 0; i < ice->selected_pair_check_count; ++i) {
+		if (!memcmp(transaction_id, ice->selected_pair_check_ids[i], 12) &&
+			ice->selected_pair_check_remote_addr[i] &&
+			switch_cmp_addr(from_addr, ice->selected_pair_check_remote_addr[i], SWITCH_FALSE)) {
+			if (sent_controlling) {
+				*sent_controlling = ice->selected_pair_check_controlling[i] ? SWITCH_TRUE : SWITCH_FALSE;
+			}
+			if (consume) {
+				memset(ice->selected_pair_check_ids[i], 0, sizeof(ice->selected_pair_check_ids[i]));
+				ice->selected_pair_check_controlling[i] = 0;
+				ice->selected_pair_check_remote_addr[i] = NULL;
+			}
+			return SWITCH_TRUE;
+		}
+	}
+
+	return SWITCH_FALSE;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_role_conflict_response_matches(switch_rtp_ice_t *ice,
+	switch_sockaddr_t *from_addr,
+	int candidate_idx, const char *transaction_id, switch_bool_t authenticated,
+	switch_socket_t *local_socket, switch_port_t local_port, int local_family, switch_bool_t *sent_controlling)
+{
+	char *matched_id;
+
+	if (!ice || !from_addr || !transaction_id || !authenticated || !sent_controlling) {
+		return SWITCH_FALSE;
+	}
+
+	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING ||
+		ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING ||
+		ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
+		if (!switch_rtp_pvt_controlling_failover_response_matches(ice,
+			ice->controlling_failover_state, candidate_idx, transaction_id, authenticated,
+			local_socket, local_port, local_family)) {
+			return SWITCH_FALSE;
+		}
+
+		*sent_controlling = SWITCH_TRUE;
+		matched_id = ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING ?
+			ice->controlling_failover_probe_id : ice->controlling_failover_nomination_id;
+		memset(matched_id, 0, 13);
+		return SWITCH_TRUE;
+	}
+
+	return ice_selected_pair_response_matches(ice, transaction_id, from_addr,
+		local_socket, local_port, local_family,
+			SWITCH_TRUE, sent_controlling) ?
+		SWITCH_TRUE : SWITCH_FALSE;
+}
+
+static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	int candidate_idx, switch_bool_t use_candidate, char *transaction_id, switch_bool_t new_transaction)
+{
+	uint8_t buf[256] = { 0 };
+	char sw[128] = "";
+	switch_stun_packet_t *packet;
+	switch_sockaddr_t *candidate_addr = NULL;
+	switch_sockaddr_t *local_addr;
+	switch_socket_t *sock_output;
+	switch_size_t bytes;
+	switch_status_t status;
+	icand_t *candidate;
+	const char *context;
+
+	if (!rtp_session || !ice || !ice->ice_params || candidate_idx < 0 ||
+		candidate_idx >= ice->ice_params->cand_idx[ice->proto] || !transaction_id) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	context = !ice->addr && ice->initializing ? "startup" : "failover";
+	if (zstr(candidate->con_addr) || !candidate->con_port ||
+		switch_sockaddr_info_get(&candidate_addr, candidate->con_addr, SWITCH_UNSPEC, candidate->con_port, 0,
+			rtp_session->pool) != SWITCH_STATUS_SUCCESS || !candidate_addr) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	sock_output = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output ?
+		rtp_session->rtcp_sock_output : rtp_session->sock_output;
+	local_addr = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_local_addr ?
+		rtp_session->rtcp_local_addr : rtp_session->local_addr;
+	if (!sock_output || !local_addr) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST,
+		new_transaction ? NULL : transaction_id, buf);
+	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
+	/* RFC 8445 PRIORITY describes the local peer-reflexive candidate that this
+	 * check could create at the peer, not the remote candidate being checked. */
+	switch_stun_packet_attribute_add_priority(packet,
+		switch_rtp_pvt_ice_local_prflx_priority(ice == &rtp_session->rtcp_ice,
+			rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ? SWITCH_TRUE : SWITCH_FALSE));
+	switch_snprintf(sw, sizeof(sw), "FreeSWITCH (%s)", switch_version_revision_human());
+	switch_stun_packet_attribute_add_software(packet, sw, (uint16_t)strlen(sw));
+	switch_stun_packet_attribute_add_controlling_value(packet, rtp_session->ice_tie_breaker);
+	if (use_candidate) {
+		switch_stun_packet_attribute_add_use_candidate(packet);
+	}
+	switch_stun_packet_attribute_add_integrity(packet, ice->rpass);
+	switch_stun_packet_attribute_add_fingerprint(packet);
+	bytes = switch_stun_packet_length(packet);
+	if (new_transaction) {
+		memcpy(transaction_id, packet->header.id, 12);
+		transaction_id[12] = '\0';
+		ice->controlling_failover_local_port = switch_sockaddr_get_port(local_addr);
+		ice->controlling_failover_local_family = switch_sockaddr_get_family(local_addr);
+		ice->controlling_failover_socket = sock_output;
+	}
+
+	switch_mutex_lock(rtp_session->ice_mutex);
+	status = switch_socket_sendto(sock_output, candidate_addr, 0, (void *)packet, &bytes);
+	switch_mutex_unlock(rtp_session->ice_mutex);
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session),
+		status == SWITCH_STATUS_SUCCESS ? SWITCH_LOG_DEBUG : SWITCH_LOG_WARNING,
+		"ICE controlling %s: sent %s%s check to %s:%u idx:%d\n", context,
+		new_transaction ? "" : "retransmitted ", use_candidate ? "nomination" : "probe",
+		candidate->con_addr, candidate->con_port, candidate_idx);
+
+	return status;
+}
+
+static switch_bool_t ice_controlling_startup_ready(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
+{
+	if (!rtp_session || !ice || ice->proto != IPR_RTP || !ice->ice_params || ice->addr ||
+		!(ice->type & ICE_VANILLA) || (ice->type & (ICE_CONTROLLED | ICE_LITE | ICE_LITE_INBOUND)) ||
+		!ice->initializing || ice->ready || ice->cand_responsive ||
+		!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] || !ice_prflx_bootstrap_ms(rtp_session, ice)) {
+		return SWITCH_FALSE;
+	}
+
+	return SWITCH_TRUE;
+}
+
+static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_time_t now)
+{
+	uint32_t failover_ms;
+	uint64_t selected_age_ms;
+	uint64_t candidate_age_ms;
+	switch_rtp_ice_controlling_timer_action_t timer_action;
+	switch_sockaddr_t *local_addr;
+	switch_socket_t *local_socket;
+	char *transaction_id;
+	switch_bool_t use_candidate;
+
+	if (ice && ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
+		if (!ice_controlling_startup_ready(rtp_session, ice)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+
+		local_addr = rtp_session->local_addr;
+		local_socket = rtp_session->sock_output;
+		if (!local_addr || !local_socket || ice->controlling_failover_socket != local_socket ||
+			ice->controlling_failover_local_port != switch_sockaddr_get_port(local_addr) ||
+			ice->controlling_failover_local_family != switch_sockaddr_get_family(local_addr)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+
+		timer_action = switch_rtp_pvt_controlling_failover_timer_action(ice->controlling_failover_state,
+			ice->controlling_failover_started_us, ice->controlling_failover_sent_us,
+			ice->controlling_failover_attempts, now);
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT &&
+			ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx, SWITCH_TRUE,
+				ice->controlling_failover_nomination_id, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS) {
+			ice->controlling_failover_sent_us = now;
+			ice->controlling_failover_attempts++;
+		}
+		return;
+	}
+
+	if (!ice_controlling_failover_ready(rtp_session, ice)) {
+		if (ice && ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		}
+		return;
+	}
+
+	failover_ms = ice_controlling_failover_ms(rtp_session, ice);
+	if (!ice->selected_pair_last_response_us) {
+		ice->selected_pair_last_response_us = now;
+		return;
+	}
+
+	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		local_addr = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_local_addr ?
+			rtp_session->rtcp_local_addr : rtp_session->local_addr;
+		local_socket = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output ?
+			rtp_session->rtcp_sock_output : rtp_session->sock_output;
+		if (!local_addr || !local_socket || ice->controlling_failover_socket != local_socket ||
+			ice->controlling_failover_local_port != switch_sockaddr_get_port(local_addr) ||
+			ice->controlling_failover_local_family != switch_sockaddr_get_family(local_addr)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+
+		timer_action = switch_rtp_pvt_controlling_failover_timer_action(ice->controlling_failover_state,
+			ice->controlling_failover_started_us, ice->controlling_failover_sent_us,
+			ice->controlling_failover_attempts, now);
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT) {
+			use_candidate = ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING ?
+				SWITCH_TRUE : SWITCH_FALSE;
+			transaction_id = use_candidate ? ice->controlling_failover_nomination_id :
+				ice->controlling_failover_probe_id;
+			if (ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx,
+				use_candidate, transaction_id, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS) {
+				ice->controlling_failover_sent_us = now;
+				ice->controlling_failover_attempts++;
+			}
+		}
+		return;
+	}
+
+	if (ice->controlling_failover_idx < 0 || !ice->controlling_failover_candidate_us ||
+		now < ice->controlling_failover_candidate_us) {
+		return;
+	}
+
+	selected_age_ms = (uint64_t)(now - ice->selected_pair_last_response_us) / 1000;
+	candidate_age_ms = (uint64_t)(now - ice->controlling_failover_candidate_us) / 1000;
+	if (selected_age_ms < failover_ms || candidate_age_ms > ((uint64_t)failover_ms * 2)) {
+		return;
+	}
+
+	if (ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx, SWITCH_FALSE,
+		ice->controlling_failover_probe_id, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
+		ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice->controlling_failover_started_us = now;
+		ice->controlling_failover_sent_us = now;
+		ice->controlling_failover_attempts = 1;
+	}
+}
+
 static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_bool_t force)
 {
 	uint8_t buf[256] = { 0 };
@@ -1314,7 +1794,10 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	//switch_sockaddr_t *remote_addr = rtp_session->remote_addr;
 	switch_socket_t *sock_output = rtp_session->sock_output;
+	switch_sockaddr_t *local_addr = rtp_session->local_addr;
 	switch_time_t now = switch_micro_time_now();
+	switch_bool_t sent_controlling = SWITCH_FALSE;
+	char tie_breaker[8] = { 0 };
 
 	if (ice->type & ICE_LITE) {
 		// no connectivity checks for ICE-Lite
@@ -1326,6 +1809,15 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	}
 
 	ice->next_run = now + RTP_STUN_FREQ;
+	if (!force) {
+		/* RTP read, write, and ping paths can all drive the periodic ICE timer.
+		 * Serialize the controlling-side failover state machine independently of
+		 * the pre-existing next_run best-effort gate.  The mutex is nested because
+		 * the tick may send a probe through ice_send_controlling_check(). */
+		switch_mutex_lock(rtp_session->ice_mutex);
+		ice_controlling_failover_tick(rtp_session, ice, now);
+		switch_mutex_unlock(rtp_session->ice_mutex);
+	}
 
 	/* Non-DTLS ICE-CONTROLLED peers that never send USE-CANDIDATE hang media
 	 * forever. After the fallback window since first responsive STUN,
@@ -1374,9 +1866,10 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	if (ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output) {
 		sock_output = rtp_session->rtcp_sock_output;
+		local_addr = rtp_session->rtcp_local_addr;
 	}
 
-	if (!sock_output) {
+	if (!sock_output || !local_addr) {
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -1399,7 +1892,9 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
 	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
 
-	memcpy(ice->last_sent_id, packet->header.id, 12);
+	switch_mutex_lock(rtp_session->ice_mutex);
+	sent_controlling = ice->type & ICE_CONTROLLED ? SWITCH_FALSE : SWITCH_TRUE;
+	memcpy(tie_breaker, rtp_session->ice_tie_breaker, sizeof(tie_breaker));
 
 	//if (ice->pass && ice->type == ICE_GOOGLE_JINGLE) {
 	//	switch_stun_packet_attribute_add_password(packet, ice->pass, (uint16_t)strlen(ice->pass));
@@ -1408,15 +1903,19 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if ((ice->type & ICE_VANILLA)) {
 		char sw[128] = "";
 
-		switch_stun_packet_attribute_add_priority(packet, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].priority);
+		/* PRIORITY identifies the local peer-reflexive candidate that the check
+		 * could create at the peer, not the selected remote candidate. */
+		switch_stun_packet_attribute_add_priority(packet,
+			switch_rtp_pvt_ice_local_prflx_priority(ice == &rtp_session->rtcp_ice,
+				rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ? SWITCH_TRUE : SWITCH_FALSE));
 
 		switch_snprintf(sw, sizeof(sw), "FreeSWITCH (%s)", switch_version_revision_human());
 		switch_stun_packet_attribute_add_software(packet, sw, (uint16_t)strlen(sw));
 
-		if ((ice->type & ICE_CONTROLLED)) {
-			switch_stun_packet_attribute_add_controlled(packet);
+		if (!sent_controlling) {
+			switch_stun_packet_attribute_add_controlled_value(packet, tie_breaker);
 		} else {
-			switch_stun_packet_attribute_add_controlling(packet);
+			switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker);
 			switch_stun_packet_attribute_add_use_candidate(packet);
 		}
 
@@ -1427,10 +1926,12 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	bytes = switch_stun_packet_length(packet);
 
-	switch_mutex_lock(rtp_session->ice_mutex);
 	if (ice->addr) {
 		char buf_host[16];
 		const char *tx_host = switch_get_addr(buf_host, sizeof(buf_host), ice->addr);
+		memcpy(ice->last_sent_id, packet->header.id, 12);
+		ice_selected_pair_check_record(ice, packet->header.id, sent_controlling,
+			sock_output, local_addr, ice->addr);
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s send %s STUN to %s:%d\n", rtp_session_name(rtp_session), rtp_type(rtp_session), tx_host, switch_sockaddr_get_port(ice->addr));             
 		switch_socket_sendto(sock_output, ice->addr, 0, (void *) packet, &bytes);
 	}
@@ -1454,6 +1955,7 @@ SWITCH_DECLARE(void) switch_rtp_prepare_ice_restart(switch_rtp_t *rtp_session, i
 
 	switch_mutex_lock(rtp_session->ice_mutex);
 	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
+	switch_rtp_pvt_ice_role_conflict_cancel(ice);
 	ice->restart_pending = explicit_restart ? 1 : 0;
 	if (!explicit_restart) {
 		ice->restart_provisional = 0;
@@ -1524,6 +2026,370 @@ int icecmp(const char *them, switch_rtp_ice_t *ice)
 	return strcmp(them, ice->luser_ice);
 }
 
+static int ice_find_candidate_by_addr(switch_rtp_ice_t *ice, const char *host, switch_port_t port)
+{
+	int i;
+
+	if (!ice || !ice->ice_params || zstr(host) || !port) {
+		return -1;
+	}
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], host, port)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static int ice_note_authenticated_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
+	switch_bool_t mark_ready)
+{
+	int candidate_family = AF_UNSPEC;
+	int candidate_idx = -1;
+
+	if (!rtp_session || !ice || !ice->ice_params || !authenticated_current_request ||
+		zstr(host) || !port || !priority) {
+		return -1;
+	}
+
+	candidate_idx = ice_find_candidate_by_addr(ice, host, port);
+
+	if (candidate_idx < 0 && ice_remote_ip_is_acceptable(rtp_session, host, "udp", &candidate_family)) {
+		candidate_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, host, port, priority,
+			SWITCH_FALSE, mark_ready);
+		if (candidate_idx > -1) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+				"ICE learned authenticated peer-reflexive candidate %s:%u idx:%d\n",
+				host, port, candidate_idx);
+		}
+	}
+
+	return candidate_idx;
+}
+
+SWITCH_DECLARE(int) switch_rtp_pvt_reuse_pending_startup_prflx_candidate(switch_rtp_t *rtp_session,
+	switch_rtp_ice_t *ice, const char *host, switch_port_t port, uint32_t priority)
+{
+	icand_t *candidate;
+	int candidate_idx;
+
+	if (!rtp_session || !ice || !ice->ice_params || zstr(host) || !port || !priority ||
+		ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		return -1;
+	}
+
+	candidate_idx = ice->prflx_bootstrap_idx;
+	if (candidate_idx < 0 || candidate_idx >= ice->ice_params->cand_idx[ice->proto] ||
+		candidate_idx == ice->ice_params->chosen[ice->proto]) {
+		return -1;
+	}
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	if (zstr(candidate->cand_type) || strcasecmp(candidate->cand_type, "prflx") ||
+		candidate->use_candidate || candidate->responsive || candidate->ready) {
+		return -1;
+	}
+
+	candidate->con_addr = switch_core_strdup(rtp_session->pool, host);
+	candidate->con_port = port;
+	candidate->priority = priority;
+	return candidate_idx;
+}
+
+static int ice_controlling_failover_note_alternative(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
+	switch_time_t now)
+{
+	int candidate_idx = -1;
+
+	if (!authenticated_current_request || !ice_controlling_failover_ready(rtp_session, ice) || zstr(host) || !port) {
+		return -1;
+	}
+
+	if (ice->addr) {
+		char active_buf[80] = "";
+		const char *active_host = switch_get_addr(active_buf, sizeof(active_buf), ice->addr);
+
+		if (active_host && !strcmp(active_host, host) && switch_sockaddr_get_port(ice->addr) == port) {
+			return -1;
+		}
+	}
+
+	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		candidate_idx = ice_find_candidate_by_addr(ice, host, port);
+		if (candidate_idx == ice->controlling_failover_idx) {
+			ice->controlling_failover_candidate_us = now;
+			return candidate_idx;
+		}
+		return -1;
+	}
+
+	candidate_idx = ice_note_authenticated_prflx_candidate(rtp_session, ice, host, port, priority,
+		authenticated_current_request, SWITCH_TRUE);
+
+	if (candidate_idx < 0 || candidate_idx == ice->ice_params->chosen[ice->proto]) {
+		return -1;
+	}
+
+	ice->controlling_failover_idx = candidate_idx;
+	ice->controlling_failover_candidate_us = now;
+	return candidate_idx;
+}
+
+static int ice_controlling_startup_note_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
+	switch_time_t now)
+{
+	int candidate_family = AF_UNSPEC;
+	int candidate_idx;
+
+	if (!authenticated_current_request || !ice_controlling_startup_ready(rtp_session, ice) ||
+		!ice_remote_ip_is_acceptable(rtp_session, host, "udp", &candidate_family)) {
+		return -1;
+	}
+
+	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		candidate_idx = ice_find_candidate_by_addr(ice, host, port);
+		if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING &&
+			candidate_idx == ice->controlling_failover_idx) {
+			ice->controlling_failover_candidate_us = now;
+			return candidate_idx;
+		}
+		return -1;
+	}
+
+	candidate_idx = ice_note_authenticated_prflx_candidate(rtp_session, ice, host, port, priority,
+		authenticated_current_request, SWITCH_FALSE);
+	if (candidate_idx < 0) {
+		candidate_idx = switch_rtp_pvt_reuse_pending_startup_prflx_candidate(rtp_session, ice,
+			host, port, priority);
+	}
+	if (candidate_idx < 0) {
+		return -1;
+	}
+
+	ice->controlling_failover_idx = candidate_idx;
+	ice->controlling_failover_candidate_us = now;
+	ice->prflx_bootstrap_idx = candidate_idx;
+	ice->prflx_bootstrap_us = now;
+	return candidate_idx;
+}
+
+static void ice_controlling_failover_commit(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	int candidate_idx, switch_time_t now)
+{
+	char old_buf[80] = "";
+	const char *old_host;
+	icand_t *candidate;
+	int i;
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	old_host = switch_get_addr(old_buf, sizeof(old_buf), ice->addr);
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		ice->ice_params->cands[i][ice->proto].use_candidate = 0;
+	}
+	ice->ice_params->cands[candidate_idx][ice->proto].use_candidate = 1;
+	ice->ice_params->chosen[ice->proto] = candidate_idx;
+	ice->ice_params->is_chosen[ice->proto] = 1;
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+		"ICE controlling failover: nomination succeeded, switching %s from %s:%u to %s:%u idx:%d\n",
+		rtp_type(rtp_session), old_host, switch_sockaddr_get_port(ice->addr),
+		candidate->con_addr, candidate->con_port, candidate_idx);
+
+	switch_rtp_change_ice_dest(rtp_session, ice, candidate->con_addr, candidate->con_port);
+	if (rtp_session->dtls && rtp_session->dtls->remote_addr) {
+		if (switch_sockaddr_info_get(&rtp_session->dtls->remote_addr, candidate->con_addr, SWITCH_UNSPEC,
+			candidate->con_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"ICE controlling failover: failed to update DTLS remote addr to %s:%u\n",
+				candidate->con_addr, candidate->con_port);
+		}
+	}
+
+	ice->missed_count = 0;
+	ice->rready = 1;
+	ice->cand_responsive = 1;
+	ice->initializing = 0;
+	ice->last_ok = now;
+	ice->selected_pair_last_response_us = now;
+	ice_selected_pair_check_reset(ice);
+	rtp_session->last_adj = now;
+	if (rtp_session->session) {
+		switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+		switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
+		switch_core_media_gen_key_frame(rtp_session->session);
+	}
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+}
+
+static void ice_controlling_startup_commit(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	int candidate_idx, switch_time_t now)
+{
+	switch_sockaddr_t *candidate_addr = NULL;
+	switch_sockaddr_t *dtls_addr = NULL;
+	switch_channel_t *channel;
+	icand_t *candidate;
+	int i;
+
+	if (!rtp_session || !ice || !ice->ice_params || candidate_idx < 0 ||
+		candidate_idx >= ice->ice_params->cand_idx[ice->proto]) {
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return;
+	}
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	if (zstr(candidate->con_addr) || !candidate->con_port ||
+		switch_sockaddr_info_get(&candidate_addr, candidate->con_addr, SWITCH_UNSPEC,
+			candidate->con_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !candidate_addr ||
+		(rtp_session->dtls &&
+		 switch_sockaddr_info_get(&dtls_addr, candidate->con_addr, SWITCH_UNSPEC,
+			candidate->con_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+			"ICE controlling startup: failed to resolve nominated tuple %s:%u\n",
+			ice_candidate_addr_safe(candidate), candidate->con_port);
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return;
+	}
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		ice->ice_params->cands[i][ice->proto].use_candidate = 0;
+	}
+	candidate->use_candidate = 1;
+	candidate->responsive = 1;
+	candidate->ready = 1;
+	ice->ice_params->chosen[ice->proto] = candidate_idx;
+	ice->ice_params->is_chosen[ice->proto] = 1;
+
+	switch_rtp_change_ice_dest(rtp_session, ice, candidate->con_addr, candidate->con_port);
+	ice->addr = candidate_addr;
+	if (rtp_session->dtls) {
+		rtp_session->dtls->remote_addr = dtls_addr;
+	}
+
+	ice->missed_count = 0;
+	ice->ready = 1;
+	ice->rready = 1;
+	ice->cand_responsive = 1;
+	ice->initializing = 0;
+	ice->prflx_bootstrap_idx = candidate_idx;
+	ice->prflx_bootstrap_us = now;
+	ice->restart_provisional = 0;
+	ice->restart_provisional_us = 0;
+	ice->last_ok = now;
+	ice->selected_pair_last_response_us = now;
+	if (!ice->first_responsive_us) {
+		ice->first_responsive_us = now;
+	}
+	ice_selected_pair_check_reset(ice);
+	rtp_session->last_adj = now;
+
+	channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+	if (channel) {
+		switch_channel_clear_flag(channel, CF_NO_ICE);
+		switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
+		switch_core_media_gen_key_frame(rtp_session->session);
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+		"ICE controlling startup: nomination succeeded, selected %s candidate %s:%u idx:%d\n",
+		rtp_type(rtp_session), candidate->con_addr, candidate->con_port, candidate_idx);
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+}
+
+static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	switch_sockaddr_t *from_addr, int candidate_idx, const char *transaction_id,
+	switch_bool_t authenticated_response, switch_socket_t *local_socket, switch_port_t local_port,
+	int local_family, switch_time_t now)
+{
+	uint32_t failover_ms;
+	uint64_t selected_age_ms;
+	switch_bool_t current_tuple;
+
+	if (ice && ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
+		if (!ice_controlling_startup_ready(rtp_session, ice)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return SWITCH_TRUE;
+		}
+
+		if (switch_rtp_pvt_controlling_failover_response_matches(ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, candidate_idx, transaction_id,
+			authenticated_response, local_socket, local_port, local_family)) {
+			ice_controlling_startup_commit(rtp_session, ice, candidate_idx, now);
+		}
+		return SWITCH_TRUE;
+	}
+
+	current_tuple = ice->addr && switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
+	/* A selected pair is live only after an authenticated response matches a
+	 * check that we sent to that pair.  RTP or an unauthenticated STUN packet
+	 * proves neither bidirectional consent nor current-generation ownership and
+	 * must not suppress a controlling-side failover attempt. */
+	if (current_tuple && authenticated_response && ice_selected_pair_response_matches(ice, transaction_id,
+		from_addr, local_socket, local_port, local_family, SWITCH_FALSE, NULL)) {
+		ice->selected_pair_last_response_us = now;
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return SWITCH_FALSE;
+	}
+
+	if (!ice_controlling_failover_ready(rtp_session, ice)) {
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return SWITCH_FALSE;
+	}
+
+	if (current_tuple || candidate_idx < 0 || candidate_idx == ice->ice_params->chosen[ice->proto]) {
+		return SWITCH_FALSE;
+	}
+
+	/* With the feature enabled, an alternative response is never allowed to fall through to the
+	 * legacy responsive-candidate auto-adjust path. Only this transaction state machine may commit it. */
+	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		return SWITCH_TRUE;
+	}
+
+	failover_ms = ice_controlling_failover_ms(rtp_session, ice);
+	selected_age_ms = ice->selected_pair_last_response_us && now >= ice->selected_pair_last_response_us ?
+		(uint64_t)(now - ice->selected_pair_last_response_us) / 1000 : 0;
+	if (selected_age_ms < failover_ms) {
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return SWITCH_TRUE;
+	}
+
+	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING) {
+		if (!switch_rtp_pvt_controlling_failover_response_matches(ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, candidate_idx, transaction_id,
+			authenticated_response, local_socket, local_port, local_family)) {
+			return SWITCH_TRUE;
+		}
+
+		if (ice_send_controlling_check(rtp_session, ice, candidate_idx, SWITCH_TRUE,
+			ice->controlling_failover_nomination_id, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
+			ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING;
+			ice->controlling_failover_started_us = now;
+			ice->controlling_failover_sent_us = now;
+			ice->controlling_failover_attempts = 1;
+		} else {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		}
+		return SWITCH_TRUE;
+	}
+
+	if (switch_rtp_pvt_controlling_failover_response_matches(ice,
+		SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, candidate_idx, transaction_id,
+		authenticated_response, local_socket, local_port, local_family)) {
+		/* handle_ice acquired the nested write mutex before ice_mutex.  The
+		 * destination update re-enters write_mutex and therefore preserves the
+		 * established write -> ICE lock order. */
+		ice_controlling_failover_commit(rtp_session, ice, candidate_idx, now);
+	}
+
+	return SWITCH_TRUE;
+}
+
 void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len)
 {
 	switch_stun_packet_t *packet;
@@ -1539,30 +2405,50 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_channel_t *channel;
 	int i;
 	switch_sockaddr_t *from_addr = rtp_session->from_addr;
+	switch_sockaddr_t *response_local_addr = rtp_session->local_addr;
+	switch_socket_t *response_local_socket = rtp_session->sock_input;
 	const char *from_host = NULL;
 	switch_port_t from_port = 0;
+	switch_port_t response_local_port = 0;
+	int response_local_family = SWITCH_UNSPEC;
 	char faddr_buf[80] = "";
 	int got_use_candidate = 0;
 	int got_use_candidate_covered = 0;
 	int got_message_integrity = 0;
 	int got_fingerprint = 0;
+	int got_ice_controlled = 0;
+	int got_ice_controlling = 0;
 	uint32_t prflx_bootstrap_ms = 0;
 	uint32_t stun_packet_len = 0;
 	uint16_t raw_packet_type = 0;
 	switch_bool_t provisional_ice = SWITCH_FALSE;
 	switch_bool_t stun_auth_valid = SWITCH_FALSE;
+	switch_bool_t stun_response_auth_valid = SWITCH_FALSE;
 	switch_bool_t trusted_use_candidate = SWITCH_FALSE;
 	switch_bool_t authenticated_vanilla_use_candidate = SWITCH_FALSE;
+	switch_bool_t authenticated_current_request = SWITCH_FALSE;
+	switch_bool_t controlling_startup_request = SWITCH_FALSE;
 	switch_bool_t direct_username_match = SWITCH_FALSE;
 	switch_bool_t recovering = SWITCH_FALSE;
 	switch_rtp_recovery_nomination_proof_t nomination_proof = SWITCH_RTP_RECOVERY_NOMINATION_NONE;
+	switch_time_t packet_now = switch_micro_time_now();
+	int response_candidate_idx = -1;
+	int role_conflict_487 = 0;
+	switch_bool_t role_conflict_sent_controlling = SWITCH_FALSE;
+	switch_bool_t role_conflict_was_promoted = SWITCH_FALSE;
 
 	if (is_rtcp) {
 		from_addr = rtp_session->rtcp_from_addr;
+		response_local_addr = rtp_session->rtcp_local_addr;
+		response_local_socket = rtp_session->rtcp_sock_input;
 	}
 
 	from_host = switch_get_addr(faddr_buf, sizeof(faddr_buf), from_addr);
 	from_port = switch_sockaddr_get_port(from_addr);
+	if (response_local_addr) {
+		response_local_port = switch_sockaddr_get_port(response_local_addr);
+		response_local_family = switch_sockaddr_get_family(response_local_addr);
+	}
 
 	if (!switch_rtp_ready(rtp_session) || zstr(ice->user_ice) || zstr(ice->ice_user)) {
 		return;
@@ -1591,13 +2477,22 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && (ice->type & ICE_VANILLA)) {
 		stun_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->pass) ? SWITCH_TRUE : SWITCH_FALSE;
 	}
+	if ((raw_packet_type == SWITCH_STUN_BINDING_RESPONSE ||
+		raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) && (ice->type & ICE_VANILLA)) {
+		stun_response_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->rpass) ? SWITCH_TRUE : SWITCH_FALSE;
+	}
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST) {
 		prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
 	}
-	if (provisional_ice && (raw_packet_type != SWITCH_STUN_BINDING_REQUEST || !prflx_bootstrap_ms || !stun_auth_valid)) {
+	if (provisional_ice &&
+		!((raw_packet_type == SWITCH_STUN_BINDING_REQUEST && prflx_bootstrap_ms && stun_auth_valid) ||
+		  ((raw_packet_type == SWITCH_STUN_BINDING_RESPONSE ||
+		    raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) && stun_response_auth_valid &&
+		   ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING))) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
-			"ICE peer-reflexive bootstrap: rejected unvalidated %s STUN packet from %s:%d (bootstrap:%u auth:%d)\n",
-			rtp_type(rtp_session), from_host, from_port, prflx_bootstrap_ms, stun_auth_valid);
+			"ICE peer-reflexive bootstrap: rejected unvalidated %s STUN packet from %s:%d (bootstrap:%u request_auth:%d response_auth:%d state:%d)\n",
+			rtp_type(rtp_session), from_host, from_port, prflx_bootstrap_ms, stun_auth_valid,
+			stun_response_auth_valid, ice->controlling_failover_state);
 		goto end;
 	}
 
@@ -1643,6 +2538,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		case SWITCH_STUN_ATTR_FINGERPRINT:
 			got_fingerprint = 1;
 			break;
+		case SWITCH_STUN_ATTR_CONTROLLED:
+			got_ice_controlled = 1;
+			break;
+		case SWITCH_STUN_ATTR_CONTROLLING:
+			got_ice_controlling = 1;
+			break;
 		case SWITCH_STUN_ATTR_ERROR_CODE:
 			{
 				switch_stun_error_code_t *err = (switch_stun_error_code_t *) attr->value;
@@ -1655,24 +2556,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 								  );
 
 				if ((ice->type & ICE_VANILLA) && code == 487) {
-					/* Three role-conflict cases:
-					 *   1. We self-promoted (fallback) and peer rejects -> revert to CONTROLLED, disable fallback.
-					 *   2. We were CONTROLLED and peer 487s us -> RFC role-conflict flip to CONTROLLING.
-					 *   3. We were CONTROLLING and peer 487s us -> RFC role-conflict flip to CONTROLLED. */
-					if (ice->promoted_to_controlling && !(ice->type & ICE_CONTROLLED)) {
-						/* Peer rejected our self-promotion: it is legitimately controlling. Revert and stand down. */
-						ice->type |= ICE_CONTROLLED;
-						ice->promoted_to_controlling = 0;
-						ice->nomination_fallback_enabled = 0;
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN got role-conflict 487 after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
-					} else if ((ice->type & ICE_CONTROLLED)) {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN Changing role to CONTROLLING\n", rtp_type(rtp_session));
-						ice->type &= ~ICE_CONTROLLED;
-					} else {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN Changing role to CONTROLLED\n", rtp_type(rtp_session));
-						ice->type |= ICE_CONTROLLED;
-					}
-					packet->header.type = SWITCH_STUN_BINDING_RESPONSE;
+					role_conflict_487 = 1;
 				}
 
 			}
@@ -1718,6 +2602,53 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		xlen += 4 + switch_stun_attribute_padded_length(attr);
 	} while (xlen <= packet->header.length);
 
+	if ((raw_packet_type == SWITCH_STUN_BINDING_RESPONSE ||
+		raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) && ice->ice_params) {
+		for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+			if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
+				response_candidate_idx = i;
+				break;
+			}
+		}
+	}
+
+	if (raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) {
+		switch_bool_t authenticated_error = stun_response_auth_valid && got_message_integrity && got_fingerprint ?
+			SWITCH_TRUE : SWITCH_FALSE;
+
+		if (!role_conflict_487 || !switch_rtp_pvt_ice_role_conflict_response_matches(ice, from_addr,
+			response_candidate_idx, packet->header.id, authenticated_error,
+			response_local_socket, response_local_port, response_local_family,
+			&role_conflict_sent_controlling)) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"Ignoring unauthenticated or unmatched %s STUN error response from %s:%u\n",
+				rtp_type(rtp_session), from_host, from_port);
+			goto end;
+		}
+
+		role_conflict_was_promoted = ice->promoted_to_controlling ? SWITCH_TRUE : SWITCH_FALSE;
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_session->ice);
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_session->rtcp_ice);
+		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(rtp_session->ice_tie_breaker);
+		switch_rtp_pvt_ice_role_conflict_apply(&rtp_session->ice, role_conflict_sent_controlling);
+		switch_rtp_pvt_ice_role_conflict_apply(&rtp_session->rtcp_ice, role_conflict_sent_controlling);
+		/* A role-conflict response is allowed to mutate role state only after
+		 * authentication and exact transaction/transport matching above.  Apply
+		 * the role carried by the matched request, not mutable current state. */
+		if (role_conflict_sent_controlling && role_conflict_was_promoted) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"%s STUN got authenticated role-conflict 487 after fallback promotion; reverting to CONTROLLED\n",
+				rtp_type(rtp_session));
+		} else if (!role_conflict_sent_controlling) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"%s STUN authenticated role-conflict 487; changing role to CONTROLLING\n", rtp_type(rtp_session));
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"%s STUN authenticated role-conflict 487; changing role to CONTROLLED\n", rtp_type(rtp_session));
+		}
+		goto end;
+	}
+
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && got_use_candidate) {
 		authenticated_vanilla_use_candidate = ((ice->type & ICE_VANILLA) && got_use_candidate_covered &&
 			got_message_integrity && got_fingerprint && stun_auth_valid) ? SWITCH_TRUE : SWITCH_FALSE;
@@ -1727,6 +2658,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && !zstr(username) && !icecmp(username, ice)) {
 		direct_username_match = SWITCH_TRUE;
 	}
+	authenticated_current_request = raw_packet_type == SWITCH_STUN_BINDING_REQUEST && direct_username_match &&
+		got_message_integrity && got_fingerprint && stun_auth_valid ? SWITCH_TRUE : SWITCH_FALSE;
+	controlling_startup_request = provisional_ice && authenticated_current_request && pri &&
+		got_ice_controlled && !got_ice_controlling &&
+		rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice_controlling_startup_ready(rtp_session, ice) ?
+		SWITCH_TRUE : SWITCH_FALSE;
 	nomination_proof = switch_rtp_pvt_recovery_dtls_nomination_proof(authenticated_vanilla_use_candidate, direct_username_match);
 
 	if ((ice->type & ICE_GOOGLE_JINGLE) && ok) {
@@ -1741,6 +2678,13 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		if (!ok) ok = !memcmp(packet->header.id, ice->last_sent_id, 12);
 
 		if (packet->header.type == SWITCH_STUN_BINDING_RESPONSE) {
+			if (ice_controlling_failover_handle_response(rtp_session, ice, from_addr, response_candidate_idx,
+				packet->header.id, (stun_response_auth_valid && got_message_integrity && got_fingerprint) ?
+					SWITCH_TRUE : SWITCH_FALSE, response_local_socket, response_local_port,
+				response_local_family, packet_now)) {
+				goto end;
+			}
+
 			ok = 1;
 
 			if (rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]) {
@@ -1831,7 +2775,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		}
 		if (provisional_ice) {
 			ok = direct_username_match && pri &&
-				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate);
+				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate || controlling_startup_request);
 		}
 
 		if (ok && !provisional_ice) {
@@ -1962,6 +2906,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			int cmp = 0;
 			int same_host = 0;
 			int cur_idx = -1, is_relay = 0, is_responsive = 0, use_candidate = 0;
+			int failover_candidate_idx = -1;
+			int startup_nomination_idx = -1;
 			uint32_t mid_call_failover_ms = 0;
 			uint32_t nomination_age_ms = 0;
 			uint32_t nomination_fresh_ms = 0;
@@ -2062,6 +3008,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					ice->type |= ICE_CONTROLLED;
 					ice->promoted_to_controlling = 0;
 					ice->nomination_fallback_enabled = 0;
+					ice_controlling_failover_reset(ice, SWITCH_TRUE);
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
 						"%s late peer USE-CANDIDATE after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
 				}
@@ -2165,6 +3112,17 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 			}
 
+			if (!cmp && pri && authenticated_current_request) {
+				failover_candidate_idx = ice_controlling_failover_note_alternative(rtp_session, ice,
+					from_host, from_port, prflx_priority, authenticated_current_request, now);
+				if (failover_candidate_idx > -1) {
+					cur_idx = failover_candidate_idx;
+					is_relay = ice_candidate_is_relay(&ice->ice_params->cands[cur_idx][ice->proto]) ? 1 : 0;
+					is_responsive = ice->ice_params->cands[cur_idx][ice->proto].responsive ? 1 : 0;
+					use_candidate = ice->ice_params->cands[cur_idx][ice->proto].use_candidate ? 1 : 0;
+				}
+			}
+
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							  "%s %s STUN from %s:%d %s is_relay: %d is_responsive: %d use_candidate: %d ready: %d, rready: %d dtls_handshake: %d\n", switch_channel_get_name(channel), rtp_type(rtp_session), from_host, from_port, cmp ? "EXPECTED" : "IGNORED", is_relay, is_responsive, use_candidate, ice->ready, ice->rready, rtp_session->ice.dtls_handshake);
 
@@ -2180,7 +3138,23 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				 (!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) ? SWITCH_TRUE : SWITCH_FALSE,
 				prflx_bootstrap_ms, now);
 
-			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok && !guard_recovery_dtls_tuple &&
+			if (controlling_startup_request && !cmp && ok && !guard_recovery_dtls_tuple &&
+				(!dtls || dtls->state < DS_READY) &&
+				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
+				startup_nomination_idx = ice_controlling_startup_note_candidate(rtp_session, ice,
+					from_host, from_port, prflx_priority, authenticated_current_request, now);
+				if (startup_nomination_idx > -1) {
+					cur_idx = startup_nomination_idx;
+					is_relay = ice_candidate_is_relay(&ice->ice_params->cands[cur_idx][ice->proto]) ? 1 : 0;
+					is_responsive = 1;
+					use_candidate = 0;
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+						"ICE controlling startup: learned authenticated %s candidate %s:%d idx:%d priority:%u; pending FS nomination\n",
+						rtp_type(rtp_session), from_host, from_port, startup_nomination_idx, prflx_priority);
+				}
+			}
+
+			if (!controlling_startup_request && prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok && !guard_recovery_dtls_tuple &&
 				(!dtls || dtls->state < DS_READY || restart_prflx_allowed) && stun_auth_valid &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
@@ -2194,7 +3168,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
 							"ICE peer-reflexive bootstrap: failed to resolve learned tuple %s:%d\n", from_host, from_port);
 					} else {
-						prflx_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, from_host, from_port, prflx_priority, got_use_candidate ? SWITCH_TRUE : SWITCH_FALSE);
+						prflx_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, from_host, from_port,
+							prflx_priority, got_use_candidate ? SWITCH_TRUE : SWITCH_FALSE, SWITCH_TRUE);
 					}
 				}
 
@@ -2322,6 +3297,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 					"ICE preserving recovery DTLS restart tuple, ignoring non-nominated auto-adjust from %s:%d\n",
 					from_host, from_port);
+			} else if (!provisional_ice && failover_candidate_idx > -1 &&
+				ice_controlling_failover_ready(rtp_session, ice)) {
+				do_adj = 0;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"ICE controlling failover: authenticated alternative %s:%d is pending FS nomination; suppressing legacy auto-adjust\n",
+					from_host, from_port);
 			} else if (!provisional_ice && !do_adj && !rtp_session->ice.dtls_handshake) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE %d/%d dt:%d i:%d i2:%d cmp:%d\n", rtp_session->elapsed_stun, rtp_session->elapsed_media, (rtp_session->dtls && rtp_session->dtls->state != DS_READY), !ice->ready, !ice->rready, same_host);
 
@@ -2423,9 +3404,21 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				ice->last_ok = now;
 			}
 
-			if (!switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED) || cmp || do_adj) {
+			if (startup_nomination_idx > -1 || !switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED) || cmp || do_adj) {
 				switch_socket_sendto(sock_output, from_addr, 0, (void *) rpacket, &bytes);
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG6, "Send %s STUN Binding Response to %s:%u\n", rtp_type(rtp_session), from_host, from_port);
+				if (startup_nomination_idx > -1 &&
+					ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+					if (ice_send_controlling_check(rtp_session, ice, startup_nomination_idx, SWITCH_TRUE,
+						ice->controlling_failover_nomination_id, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
+						ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING;
+						ice->controlling_failover_started_us = now;
+						ice->controlling_failover_sent_us = now;
+						ice->controlling_failover_attempts = 1;
+					} else {
+						ice_controlling_failover_reset(ice, SWITCH_TRUE);
+					}
+				}
 				if (!(rtp_session->ice.type & ICE_LITE) && ice->initializing && !is_responsive) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Send %s STUN Binding Request on ICE candidate still unresponsive to %s:%u\n", rtp_type(rtp_session), from_host, from_port);
 					if (ice_out(rtp_session, ice, SWITCH_TRUE) != SWITCH_STATUS_SUCCESS)
@@ -6855,6 +7848,17 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	ice->mid_call_failover_ms = 0;
 	ice->mid_call_nominated_idx = -1;
 	ice->mid_call_nominated_us = 0;
+	ice->controlling_failover_cached = 0;
+	ice->controlling_failover_enabled = 0;
+	ice->controlling_failover_ms = 0;
+	ice->controlling_failover_idx = -1;
+	ice->controlling_failover_candidate_us = 0;
+	if (!rtp_session->ice_tie_breaker[0]) {
+		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(rtp_session->ice_tie_breaker);
+	}
+	ice->selected_pair_last_response_us = switch_micro_time_now();
+	ice_selected_pair_check_reset(ice);
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
 	ice->inbound_media_idx = -1;
 	ice->inbound_media_us = 0;
 	ice->prflx_bootstrap_cached = 0;
@@ -12104,7 +13108,9 @@ SWITCH_DECLARE(switch_sockaddr_t*) switch_rtp_session_get_remote_addr(switch_rtp
 
 rtp_extension_t *switch_rtp_find_extension(switch_rtp_t *rtp_session, uint8_t id) 
 {
-	for (int i = 0; i < rtp_session->num_remote_extensions; i++) {
+	int i;
+
+	for (i = 0; i < rtp_session->num_remote_extensions; i++) {
 		if (rtp_session->remote_extensions[i].id == id) {
 			return &rtp_session->remote_extensions[i];
 		}
@@ -12362,7 +13368,10 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 
 	{
 		uint32_t existing = ice->ice_params->cand_idx[ice->proto];
-		for (uint32_t i = 0; i < existing; i++) {
+		uint32_t i;
+		uint32_t j;
+
+		for (i = 0; i < existing; i++) {
 			const char *e_addr = ice->ice_params->cands[i][ice->proto].con_addr;
 			switch_port_t e_port = ice->ice_params->cands[i][ice->proto].con_port;
 			const char *e_found = ice->ice_params->cands[i][ice->proto].foundation;
@@ -12404,7 +13413,7 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 		}
 
 		if (existing > insert_at) {
-			for (uint32_t j = existing; j > insert_at; j--) {
+			for (j = existing; j > insert_at; j--) {
 				ice->ice_params->cands[j][ice->proto] = ice->ice_params->cands[j-1][ice->proto];
 			}
 
@@ -12414,6 +13423,10 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 
 			if (ice->mid_call_nominated_idx >= (int)insert_at) {
 				ice->mid_call_nominated_idx++;
+			}
+
+			if (ice->controlling_failover_idx >= (int)insert_at) {
+				ice->controlling_failover_idx++;
 			}
 
 			if (ice->inbound_media_idx >= (int)insert_at) {
@@ -12892,8 +13905,10 @@ static inline switch_bool_t cand_channel_bool(const switch_rtp_t *rtp_session, c
 
 static inline int addr_family_guess(const char *ip)
 {
+	const char *p;
+
 	if (!ip || !*ip) return AF_UNSPEC;
-	for (const char *p = ip; *p; ++p) {
+	for (p = ip; *p; ++p) {
 		if (*p == ':') return AF_INET6;
 		if (*p == '.') return AF_INET;
 	}
@@ -12906,9 +13921,10 @@ static inline switch_bool_t ipv4_is_linklocal(const char *ip)  { return !strncmp
 static inline switch_bool_t ipv4_is_multicast(const char *ip)
 {
 	int o1 = 0;
+	const char *p;
 	
 	if (!ip || !*ip) return SWITCH_FALSE;
-	for (const char *p = ip; *p && *p != '.'; ++p) {
+	for (p = ip; *p && *p != '.'; ++p) {
 		if (*p < '0' || *p > '9') return SWITCH_FALSE;
 		o1 = o1*10 + (*p - '0');
 		if (o1 > 255) return SWITCH_FALSE;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1398,17 +1398,22 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 }
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
-	char *ice_user, switch_size_t ice_user_len, switch_bool_t *has_addr)
+	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
+	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr)
 {
 	switch_rtp_ice_t *ice;
 
-	if (!rtp_session || (proto != IPR_RTP && proto != IPR_RTCP) || !ice_user || !ice_user_len || !has_addr) {
+	if (!rtp_session || (proto != IPR_RTP && proto != IPR_RTCP) ||
+		!ice_user || !ice_user_len || !local_pwd || !local_pwd_len ||
+		!remote_pwd || !remote_pwd_len || !has_addr) {
 		return SWITCH_STATUS_FALSE;
 	}
 
 	switch_mutex_lock(rtp_session->ice_mutex);
 	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
 	switch_snprintf(ice_user, ice_user_len, "%s", ice->ice_user ? ice->ice_user : "");
+	switch_snprintf(local_pwd, local_pwd_len, "%s", ice->pass ? ice->pass : "");
+	switch_snprintf(remote_pwd, remote_pwd_len, "%s", ice->rpass ? ice->rpass : "");
 	*has_addr = ice->addr ? SWITCH_TRUE : SWITCH_FALSE;
 	switch_mutex_unlock(rtp_session->ice_mutex);
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1448,6 +1448,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_port_t from_port = 0;
 	char faddr_buf[80] = "";
 	int got_use_candidate = 0;
+	int got_use_candidate_covered = 0;
 	int got_message_integrity = 0;
 	int got_fingerprint = 0;
 	uint32_t prflx_bootstrap_ms = 0;
@@ -1455,6 +1456,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_bool_t provisional_ice = SWITCH_FALSE;
 	switch_bool_t stun_auth_valid = SWITCH_FALSE;
 	switch_bool_t trusted_use_candidate = SWITCH_FALSE;
+	switch_bool_t authenticated_vanilla_use_candidate = SWITCH_FALSE;
 	switch_bool_t direct_username_match = SWITCH_FALSE;
 
 	if (is_rtcp) {
@@ -1528,6 +1530,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		switch (attr->type) {
 		case SWITCH_STUN_ATTR_USE_CAND:
 			got_use_candidate = 1;
+			if (!got_message_integrity) {
+				got_use_candidate_covered = 1;
+			}
 			break;
 		case SWITCH_STUN_ATTR_MESSAGE_INTEGRITY:
 			got_message_integrity = 1;
@@ -1611,8 +1616,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	} while (xlen <= packet->header.length);
 
 	if (got_use_candidate) {
-		trusted_use_candidate = (!(ice->type & ICE_VANILLA) ||
-			(got_message_integrity && got_fingerprint && stun_auth_valid)) ? SWITCH_TRUE : SWITCH_FALSE;
+		authenticated_vanilla_use_candidate = ((ice->type & ICE_VANILLA) && got_use_candidate_covered &&
+			got_message_integrity && got_fingerprint && stun_auth_valid) ? SWITCH_TRUE : SWITCH_FALSE;
+		trusted_use_candidate = (!(ice->type & ICE_VANILLA) || authenticated_vanilla_use_candidate) ? SWITCH_TRUE : SWITCH_FALSE;
 	}
 
 	if ((ice->type & ICE_GOOGLE_JINGLE) && ok) {
@@ -1943,7 +1949,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 							(uint32_t)((now - ice->inbound_media_us) / 1000) <= nomination_fresh_ms;
 					}
 					if (fresh_nomination && trusted_use_candidate &&
-						((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent || peer_candidate)) {
+						((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent || (authenticated_vanilla_use_candidate && peer_candidate))) {
 						allow_mid_call_failover = SWITCH_TRUE;
 					}
 				}
@@ -1956,10 +1962,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				if (ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE)) {
 					if (dtls_ready) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), allow_mid_call_failover ? SWITCH_LOG_DEBUG : SWITCH_LOG_DEBUG5,
-							"USE-CANDIDATE: DTLS already READY, %s %s nomination from %s:%d (elapsed_stun=%u, elapsed_media=%u, mid_call_failover_ms=%u, controlled=%d, known_candidate=%d, fresh_nomination=%d, nomination_age_ms=%u, media_unhealthy=%d, nominated_media_recent=%d, trusted_use=%d, rtcp_mux=%d)\n",
+							"USE-CANDIDATE: DTLS already READY, %s %s nomination from %s:%d (elapsed_stun=%u, elapsed_media=%u, mid_call_failover_ms=%u, controlled=%d, known_candidate=%d, fresh_nomination=%d, nomination_age_ms=%u, media_unhealthy=%d, nominated_media_recent=%d, trusted_use=%d, vanilla_auth_use=%d, rtcp_mux=%d)\n",
 							allow_mid_call_failover ? "accepted" : "ignoring", rtp_type(rtp_session), from_host, from_port, rtp_session->elapsed_stun, rtp_session->elapsed_media, mid_call_failover_ms,
 							!!(ice->type & ICE_CONTROLLED), peer_candidate, fresh_nomination, nomination_age_ms, media_unhealthy, nominated_media_recent,
-							trusted_use_candidate, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
+							trusted_use_candidate, authenticated_vanilla_use_candidate, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
 					} else if (preserve_dtls_tuple) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							"USE-CANDIDATE: preserving active %s DTLS tuple %s:%d during handshake, ignoring nomination from %s:%d\n",
@@ -2142,11 +2148,11 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						(uint32_t)((now - ice->inbound_media_us) / 1000) <= nomination_fresh_ms;
 				}
 				if (fresh_nomination && trusted_use_candidate &&
-					((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent || cur_idx > -1)) {
+					((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent || (authenticated_vanilla_use_candidate && cur_idx > -1))) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
-						"%s %s %s ICE mid-call failover accepting freshly nominated %s:%d (elapsed_stun=%u, elapsed_media=%u, nomination_age_ms=%u, nominated_media_recent=%d, trusted_use=%d, current: %s:%d typ: %s)\n",
+						"%s %s %s ICE mid-call failover accepting freshly nominated %s:%d (elapsed_stun=%u, elapsed_media=%u, nomination_age_ms=%u, nominated_media_recent=%d, trusted_use=%d, vanilla_auth_use=%d, current: %s:%d typ: %s)\n",
 						switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, rtp_session->elapsed_stun,
-						rtp_session->elapsed_media, nomination_age_ms, nominated_media_recent, trusted_use_candidate,
+						rtp_session->elapsed_media, nomination_age_ms, nominated_media_recent, trusted_use_candidate, authenticated_vanilla_use_candidate,
 						ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]),
 						ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port,
 						ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -785,6 +785,35 @@ static const char *ice_candidate_type_safe(const icand_t *cand)
 	return (cand && cand->cand_type) ? cand->cand_type : "(unknown)";
 }
 
+static void ice_track_inbound_media_candidate(switch_rtp_ice_t *ice, switch_sockaddr_t *from_addr)
+{
+	char media_buf[80] = "";
+	const char *media_host;
+	switch_port_t media_port;
+	int i;
+
+	if (!ice || !ice->ice_params || !from_addr) {
+		return;
+	}
+
+	media_host = switch_get_addr(media_buf, sizeof(media_buf), from_addr);
+	media_port = switch_sockaddr_get_port(from_addr);
+
+	if (ice->inbound_media_idx > -1 && ice->inbound_media_idx < ice->ice_params->cand_idx[ice->proto] &&
+		ice_candidate_matches_addr(&ice->ice_params->cands[ice->inbound_media_idx][ice->proto], media_host, media_port)) {
+		ice->inbound_media_us = switch_micro_time_now();
+		return;
+	}
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], media_host, media_port)) {
+			ice->inbound_media_idx = i;
+			ice->inbound_media_us = switch_micro_time_now();
+			break;
+		}
+	}
+}
+
 static switch_bool_t ice_should_preserve_active_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
 {
 	if (is_rtcp || !rtp_session || !ice || !ice->addr || !dtls || !dtls->handshake_peer_set || !dtls->handshake_peer_addr) {
@@ -1752,6 +1781,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			uint32_t prflx_priority = 0;
 			switch_bool_t dtls_ready = SWITCH_FALSE;
 			switch_bool_t fresh_nomination = SWITCH_FALSE;
+			switch_bool_t nominated_media_recent = SWITCH_FALSE;
 			switch_bool_t media_unhealthy = SWITCH_FALSE;
 			switch_bool_t mid_call_failover = SWITCH_FALSE;
 			switch_bool_t prflx_bootstrap = SWITCH_FALSE;
@@ -1793,6 +1823,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				switch_bool_t allow_mid_call_failover = SWITCH_FALSE;
 				switch_bool_t peer_candidate = SWITCH_FALSE;
 				switch_bool_t fresh_nomination = SWITCH_FALSE;
+				switch_bool_t nominated_media_recent = SWITCH_FALSE;
 				switch_bool_t media_unhealthy = SWITCH_FALSE;
 				switch_bool_t defer_to_prflx_bootstrap = SWITCH_FALSE;
 				switch_bool_t preserve_dtls_tuple = SWITCH_FALSE;
@@ -1849,8 +1880,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						nomination_age_ms = (uint32_t)((now - ice->mid_call_nominated_us) / 1000);
 						nomination_fresh_ms = mid_call_failover_ms > (UINT_MAX / 2) ? UINT_MAX : (mid_call_failover_ms * 2);
 						fresh_nomination = ice->mid_call_nominated_idx == peer_candidate_idx && nomination_age_ms <= nomination_fresh_ms;
+						nominated_media_recent = ice->inbound_media_idx == peer_candidate_idx && ice->inbound_media_us &&
+							(uint32_t)((now - ice->inbound_media_us) / 1000) <= nomination_fresh_ms;
 					}
-					if (fresh_nomination && media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) {
+					if (fresh_nomination && ((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent)) {
 						allow_mid_call_failover = SWITCH_TRUE;
 					}
 				}
@@ -1863,9 +1896,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				if (ice->addr && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE)) {
 					if (dtls_ready) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), allow_mid_call_failover ? SWITCH_LOG_DEBUG : SWITCH_LOG_DEBUG5,
-							"USE-CANDIDATE: DTLS already READY, %s %s nomination from %s:%d (elapsed_stun=%u, elapsed_media=%u, mid_call_failover_ms=%u, controlled=%d, known_candidate=%d, fresh_nomination=%d, nomination_age_ms=%u, media_unhealthy=%d, rtcp_mux=%d)\n",
+							"USE-CANDIDATE: DTLS already READY, %s %s nomination from %s:%d (elapsed_stun=%u, elapsed_media=%u, mid_call_failover_ms=%u, controlled=%d, known_candidate=%d, fresh_nomination=%d, nomination_age_ms=%u, media_unhealthy=%d, nominated_media_recent=%d, rtcp_mux=%d)\n",
 							allow_mid_call_failover ? "accepted" : "ignoring", rtp_type(rtp_session), from_host, from_port, rtp_session->elapsed_stun, rtp_session->elapsed_media, mid_call_failover_ms,
-							!!(ice->type & ICE_CONTROLLED), peer_candidate, fresh_nomination, nomination_age_ms, media_unhealthy, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
+							!!(ice->type & ICE_CONTROLLED), peer_candidate, fresh_nomination, nomination_age_ms, media_unhealthy, nominated_media_recent, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
 					} else if (preserve_dtls_tuple) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							"USE-CANDIDATE: preserving active %s DTLS tuple %s:%d during handshake, ignoring nomination from %s:%d\n",
@@ -2018,12 +2051,14 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					nomination_age_ms = (uint32_t)((now - ice->mid_call_nominated_us) / 1000);
 					nomination_fresh_ms = mid_call_failover_ms > (UINT_MAX / 2) ? UINT_MAX : (mid_call_failover_ms * 2);
 					fresh_nomination = nomination_age_ms <= nomination_fresh_ms;
+					nominated_media_recent = ice->inbound_media_idx == cur_idx && ice->inbound_media_us &&
+						(uint32_t)((now - ice->inbound_media_us) / 1000) <= nomination_fresh_ms;
 				}
-				if (fresh_nomination && media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) {
+				if (fresh_nomination && ((media_unhealthy && rtp_session->elapsed_stun >= mid_call_failover_ms) || nominated_media_recent)) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
-						"%s %s %s ICE mid-call failover accepting freshly nominated %s:%d after %u ms without active-pair STUN (elapsed_media=%u, nomination_age_ms=%u, current: %s:%d typ: %s)\n",
+						"%s %s %s ICE mid-call failover accepting freshly nominated %s:%d (elapsed_stun=%u, elapsed_media=%u, nomination_age_ms=%u, nominated_media_recent=%d, current: %s:%d typ: %s)\n",
 						switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, rtp_session->elapsed_stun,
-						rtp_session->elapsed_media, nomination_age_ms,
+						rtp_session->elapsed_media, nomination_age_ms, nominated_media_recent,
 						ice_candidate_addr_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]),
 						ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].con_port,
 						ice_candidate_type_safe(&ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto]));
@@ -6536,6 +6571,8 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	ice->mid_call_failover_ms = 0;
 	ice->mid_call_nominated_idx = -1;
 	ice->mid_call_nominated_us = 0;
+	ice->inbound_media_idx = -1;
+	ice->inbound_media_us = 0;
 	ice->prflx_bootstrap_cached = 0;
 	ice->prflx_bootstrap_enabled = 0;
 	ice->prflx_bootstrap_require_use_candidate = 1;
@@ -7759,6 +7796,7 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 				}
 			}
 
+
 			/* Drop audio packets during active DTMF events to prevent corruption (MS Teams RFC2833 workaround) */
 			if (accept_packet &&
 				rtp_session->flags[SWITCH_RTP_FLAG_IGNORE_RTP_DURING_DTMF] &&
@@ -7875,6 +7913,10 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 	}
 
 	switch_mutex_lock(rtp_session->ice_mutex);
+
+	if (*bytes && rtp_session->has_rtp && rtp_session->ice.ice_user) {
+		ice_track_inbound_media_candidate(&rtp_session->ice, rtp_session->from_addr);
+	}
 
 	if (rtp_session->dtls) {
 
@@ -12068,6 +12110,10 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 
 			if (ice->mid_call_nominated_idx >= (int)insert_at) {
 				ice->mid_call_nominated_idx++;
+			}
+
+			if (ice->inbound_media_idx >= (int)insert_at) {
+				ice->inbound_media_idx++;
 			}
 
 			if (ice->prflx_bootstrap_idx >= (int)insert_at) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -306,6 +306,8 @@ typedef struct switch_dtls_s {
 	void *data;
 	switch_socket_t *sock_output;
 	switch_sockaddr_t *remote_addr;
+	switch_sockaddr_t *handshake_peer_addr;
+	uint8_t handshake_peer_set;
 	char *rsa;
 	char *pvt;
 	char *ca;
@@ -783,26 +785,17 @@ static const char *ice_candidate_type_safe(const icand_t *cand)
 	return (cand && cand->cand_type) ? cand->cand_type : "(unknown)";
 }
 
-static switch_bool_t ice_should_preserve_peer_nominated_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
+static switch_bool_t ice_should_preserve_active_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
 {
-	int idx;
-	char cur_buf[80] = "";
-	const char *cur_host;
-	switch_port_t cur_port;
-
-	if (is_rtcp || !rtp_session || !ice || !ice->ice_params || !ice->addr || !dtls || dtls->state >= DS_READY || !rtp_session->ice.dtls_handshake) {
+	if (is_rtcp || !rtp_session || !ice || !ice->addr || !dtls || !dtls->handshake_peer_set || !dtls->handshake_peer_addr) {
 		return SWITCH_FALSE;
 	}
 
-	idx = ice->mid_call_nominated_idx;
-	if (idx < 0 || idx >= ice->ice_params->cand_idx[ice->proto]) {
+	if (dtls->state <= DS_OFF || dtls->state >= DS_READY) {
 		return SWITCH_FALSE;
 	}
 
-	cur_host = switch_get_addr(cur_buf, sizeof(cur_buf), ice->addr);
-	cur_port = switch_sockaddr_get_port(ice->addr);
-
-	return ice_candidate_matches_addr(&ice->ice_params->cands[idx][ice->proto], cur_host, cur_port) ? SWITCH_TRUE : SWITCH_FALSE;
+	return switch_cmp_addr(ice->addr, dtls->handshake_peer_addr, SWITCH_TRUE) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
 static uint32_t ice_prflx_bootstrap_ms(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
@@ -1579,7 +1572,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Marked %s ICE candidate %s:%d as responsive (is_relay: %d)\n", rtp_type(rtp_session), ice->ice_params->cands[i][ice->proto].con_addr, ice->ice_params->cands[i][ice->proto].con_port, is_relay);
 
 						if (!ice->cand_responsive && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) && (!is_relay || rtp_session->elapsed_stun >= 1000) &&
-							!ice_should_preserve_peer_nominated_dtls_tuple(rtp_session, ice, is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls, is_rtcp)) {
+							!ice_should_preserve_active_dtls_tuple(rtp_session, ice, is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls, is_rtcp)) {
 							switch_channel_t *channel = NULL;
 							char ice_cur_buf[80] = "";
 							const char *ice_cur_host = switch_get_addr(ice_cur_buf, sizeof(ice_cur_buf), ice->addr);
@@ -1803,17 +1796,15 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				switch_bool_t media_unhealthy = SWITCH_FALSE;
 				switch_bool_t defer_to_prflx_bootstrap = SWITCH_FALSE;
 				switch_bool_t preserve_dtls_tuple = SWITCH_FALSE;
-				switch_bool_t prior_current_nomination = SWITCH_FALSE;
-				const char *current_host = NULL;
-				switch_port_t current_port = 0;
-				char current_buf[80] = "";
+				const char *active_host = NULL;
+				switch_port_t active_port = 0;
+				char active_buf[80] = "";
 				switch_dtls_t *dtls = is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls;
-				int prior_nominated_idx = ice->mid_call_nominated_idx;
 				int peer_candidate_idx = -1;
 
 				if (ice->addr) {
-					current_host = switch_get_addr(current_buf, sizeof(current_buf), ice->addr);
-					current_port = switch_sockaddr_get_port(ice->addr);
+					active_host = switch_get_addr(active_buf, sizeof(active_buf), ice->addr);
+					active_port = switch_sockaddr_get_port(ice->addr);
 				}
 
 				ice->rready = 1;
@@ -1827,14 +1818,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					}
 				}
 
-				if (prior_nominated_idx > -1 && prior_nominated_idx < ice->ice_params->cand_idx[ice->proto] && current_host &&
-					ice_candidate_matches_addr(&ice->ice_params->cands[prior_nominated_idx][ice->proto], current_host, current_port)) {
-					prior_current_nomination = SWITCH_TRUE;
-				}
-
 				dtls_ready = dtls && dtls->state >= DS_READY && ice->ready;
-				preserve_dtls_tuple = !is_rtcp && peer_candidate && prior_current_nomination && peer_candidate_idx != prior_nominated_idx &&
-					!dtls_ready && rtp_session->ice.dtls_handshake && ice->cand_responsive ? SWITCH_TRUE : SWITCH_FALSE;
+				preserve_dtls_tuple = peer_candidate && active_host && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE) &&
+					ice_should_preserve_active_dtls_tuple(rtp_session, ice, dtls, is_rtcp) ? SWITCH_TRUE : SWITCH_FALSE;
 
 				if (peer_candidate_idx > -1 && !preserve_dtls_tuple) {
 					for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
@@ -1882,8 +1868,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 							!!(ice->type & ICE_CONTROLLED), peer_candidate, fresh_nomination, nomination_age_ms, media_unhealthy, !!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]);
 					} else if (preserve_dtls_tuple) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
-							"USE-CANDIDATE: preserving %s DTLS tuple during handshake, ignoring nomination from %s:%d (cand_responsive=%d, prior_idx=%d)\n",
-							rtp_type(rtp_session), from_host, from_port, ice->cand_responsive, prior_nominated_idx);
+							"USE-CANDIDATE: preserving active %s DTLS tuple %s:%d during handshake, ignoring nomination from %s:%d\n",
+							rtp_type(rtp_session), active_host, active_port, from_host, from_port);
 					} else if (peer_candidate || !defer_to_prflx_bootstrap) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
 							"USE-CANDIDATE: switching %s ice dest from current to nominated %s:%d\n",
@@ -2100,9 +2086,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			}
 
 			if ((ice->type & ICE_VANILLA) && ice->ice_params && do_adj &&
-				ice_should_preserve_peer_nominated_dtls_tuple(rtp_session, ice, dtls, is_rtcp)) {
+				ice_should_preserve_active_dtls_tuple(rtp_session, ice, dtls, is_rtcp)) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
-					"ICE preserving peer-nominated %s DTLS tuple during handshake, ignoring auto-adjust from %s:%d (idx:%d)\n",
+					"ICE preserving active %s DTLS tuple during handshake, ignoring auto-adjust from %s:%d (idx:%d)\n",
 					rtp_type(rtp_session), from_host, from_port, cur_idx);
 				do_adj = 0;
 			}
@@ -4663,6 +4649,18 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 		}
 	}
 
+	if (is_ice && dtls->bytes > 0 && dtls->data && dtls->state > DS_OFF && dtls->state < DS_READY && !dtls->handshake_peer_set) {
+		char dtls_peer_buf[80] = "";
+		const char *dtls_peer_host = switch_get_addr(dtls_peer_buf, sizeof(dtls_peer_buf), rtp_session->from_addr);
+		switch_port_t dtls_peer_port = switch_sockaddr_get_port(rtp_session->from_addr);
+
+		if (!zstr(dtls_peer_host) && switch_sockaddr_info_get(&dtls->handshake_peer_addr, dtls_peer_host, SWITCH_UNSPEC, dtls_peer_port, 0, rtp_session->pool) == SWITCH_STATUS_SUCCESS) {
+			dtls->handshake_peer_set = 1;
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+				"DTLS handshake peer locked to %s:%d until READY\n", dtls_peer_host, dtls_peer_port);
+		}
+	}
+
 	if (dtls->bytes > 0 && dtls->data) {
 		ret = BIO_write(dtls->read_bio, dtls->data, (int)dtls->bytes);
 		if (ret <= 0) {
@@ -5135,6 +5133,8 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_dtls(switch_rtp_t *rtp_session, d
 	}
 
 	dtls = switch_core_alloc(rtp_session->pool, sizeof(*dtls));
+	dtls->handshake_peer_addr = NULL;
+	dtls->handshake_peer_set = 0;
 
 	dtls->pem = switch_core_sprintf(rtp_session->pool, "%s%s%s.pem", SWITCH_GLOBAL_dirs.certs_dir, SWITCH_PATH_SEPARATOR, DTLS_SRTP_FNAME);
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1397,6 +1397,24 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	return status;
 }
 
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
+	char *ice_user, switch_size_t ice_user_len, switch_bool_t *has_addr)
+{
+	switch_rtp_ice_t *ice;
+
+	if (!rtp_session || (proto != IPR_RTP && proto != IPR_RTCP) || !ice_user || !ice_user_len || !has_addr) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_mutex_lock(rtp_session->ice_mutex);
+	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
+	switch_snprintf(ice_user, ice_user_len, "%s", ice->ice_user ? ice->ice_user : "");
+	*has_addr = ice->addr ? SWITCH_TRUE : SWITCH_FALSE;
+	switch_mutex_unlock(rtp_session->ice_mutex);
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
 int icecmp(const char *them, switch_rtp_ice_t *ice)
 {
 	if (strchr(them, ':')) {
@@ -1682,7 +1700,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			}
 		}
 		if (provisional_ice) {
-			ok = direct_username_match;
+			ok = direct_username_match && pri &&
+				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate);
 		}
 
 		if (ok && !provisional_ice) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -266,7 +266,7 @@ struct switch_rtp_rfc2833_data {
 	unsigned int out_digit_sofar;
 	unsigned int out_digit_sub_sofar;
 	unsigned int out_digit_dur;
-	switch_time_t out_digit_last_progress_us; /* gate against sub-ptime do_2833() wakeups; see ENGDESK-48201 */
+	switch_time_t out_digit_last_progress_us; /* Prevents sub-ptime do_2833() wakeups. */
 	uint16_t in_digit_seq;
 	uint32_t in_digit_ts;
 	uint32_t last_in_digit_ts;
@@ -1427,6 +1427,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	int got_use_candidate = 0;
 	int got_message_integrity = 0;
 	int got_fingerprint = 0;
+	uint32_t prflx_bootstrap_ms = 0;
+	uint16_t raw_packet_type = 0;
+	switch_bool_t provisional_ice = SWITCH_FALSE;
+	switch_bool_t stun_auth_valid = SWITCH_FALSE;
 
 	if (is_rtcp) {
 		from_addr = rtp_session->rtcp_from_addr;
@@ -1453,6 +1457,23 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	}
 
 	channel = switch_core_session_get_channel(rtp_session->session);
+	provisional_ice = ice->addr ? SWITCH_FALSE : SWITCH_TRUE;
+	if (cpylen >= sizeof(switch_stun_packet_header_t)) {
+		memcpy(&raw_packet_type, data, sizeof(raw_packet_type));
+		raw_packet_type = ntohs(raw_packet_type);
+	}
+	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST) {
+		prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
+		if (prflx_bootstrap_ms > 0) {
+			stun_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->pass) ? SWITCH_TRUE : SWITCH_FALSE;
+		}
+	}
+	if (provisional_ice && (raw_packet_type != SWITCH_STUN_BINDING_REQUEST || !prflx_bootstrap_ms || !stun_auth_valid)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+			"ICE peer-reflexive bootstrap: rejected unvalidated %s STUN packet from %s:%d (bootstrap:%u auth:%d)\n",
+			rtp_type(rtp_session), from_host, from_port, prflx_bootstrap_ms, stun_auth_valid);
+		goto end;
+	}
 
 	memcpy(buf, data, cpylen);
 	packet = switch_stun_packet_parse(buf, (uint32_t)cpylen);
@@ -1644,7 +1665,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		}
 			
 
-		if (!ok && ice == &rtp_session->ice && rtp_session->rtcp_ice.ice_params && pri &&
+		if (!provisional_ice && !ok && ice == &rtp_session->ice && rtp_session->rtcp_ice.ice_params && pri &&
 			*pri == rtp_session->rtcp_ice.ice_params->cands[rtp_session->rtcp_ice.ice_params->chosen[1]][1].priority) {
 			ice = &rtp_session->rtcp_ice;
 			ok = 1;
@@ -1653,7 +1674,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		if (!zstr(username)) {
 			if (!icecmp(username, ice)) {
 				ok = 1;
-			} else if(!zstr(rtp_session->rtcp_ice.user_ice) && !icecmp(username, &rtp_session->rtcp_ice)) {
+			} else if(!provisional_ice && !zstr(rtp_session->rtcp_ice.user_ice) && !icecmp(username, &rtp_session->rtcp_ice)) {
 				ice = &rtp_session->rtcp_ice;
 				ok = 1;
 			}
@@ -1661,7 +1682,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 		if (ok) {
 			ice->missed_count = 0;
-		} else {
+		} else if (!provisional_ice) {
 			switch_rtp_ice_t *icep[2] = { &rtp_session->ice, &rtp_session->rtcp_ice };
 			switch_port_t port = 0;
 			char *host = NULL;
@@ -1749,7 +1770,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		}
 	}
 
-	if (ice->missed_count > 5 && !(ice->type & ICE_GOOGLE_JINGLE)) {
+	if (!provisional_ice && ice->missed_count > 5 && !(ice->type & ICE_GOOGLE_JINGLE)) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "missed too many: %d, looking for new ICE dest.\n",
 						  ice->missed_count);
 		ice->rready = 0;
@@ -1779,7 +1800,6 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			uint32_t mid_call_failover_ms = 0;
 			uint32_t nomination_age_ms = 0;
 			uint32_t nomination_fresh_ms = 0;
-			uint32_t prflx_bootstrap_ms = 0;
 			uint32_t prflx_age_ms = 0;
 			uint32_t prflx_priority = 0;
 			switch_bool_t dtls_ready = SWITCH_FALSE;
@@ -1787,19 +1807,20 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_bool_t nominated_media_recent = SWITCH_FALSE;
 			switch_bool_t media_unhealthy = SWITCH_FALSE;
 			switch_bool_t mid_call_failover = SWITCH_FALSE;
-			switch_bool_t prflx_bootstrap = SWITCH_FALSE;
 			switch_bool_t prflx_addr_ok = SWITCH_FALSE;
+			switch_bool_t prflx_bootstrap_installed = SWITCH_FALSE;
 			switch_dtls_t *dtls = is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls;
 
 			if (is_rtcp) {
 				sock_output = rtp_session->rtcp_sock_output;
 			}
 
-			if (!ice->ready) {
-				ice->ready = 1;
+			if (!provisional_ice) {
+				if (!ice->ready) {
+					ice->ready = 1;
+				}
+				switch_channel_clear_flag(channel, CF_NO_ICE);
 			}
-
-			switch_channel_clear_flag(channel, CF_NO_ICE);
 			memset(stunbuf, 0, sizeof(stunbuf));
 			rpacket = switch_stun_packet_build_header(SWITCH_STUN_BINDING_RESPONSE, packet->header.id, stunbuf);
 
@@ -1818,7 +1839,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 			bytes = switch_stun_packet_length(rpacket);
 
-			if (got_use_candidate) {
+			if (got_use_candidate && !provisional_ice) {
 				uint32_t mid_call_failover_ms = 0;
 				uint32_t nomination_age_ms = 0;
 				uint32_t nomination_fresh_ms = 0;
@@ -1930,7 +1951,6 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 			}
 
-			prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
 			if (pri) {
 				prflx_priority = ntohl(*pri);
 			}
@@ -1968,7 +1988,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 							  "%s %s STUN from %s:%d %s is_relay: %d is_responsive: %d use_candidate: %d ready: %d, rready: %d dtls_handshake: %d\n", switch_channel_get_name(channel), rtp_type(rtp_session), from_host, from_port, cmp ? "EXPECTED" : "IGNORED", is_relay, is_responsive, use_candidate, ice->ready, ice->rready, rtp_session->ice.dtls_handshake);
 
 			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp &&
-				(!dtls || dtls->state < DS_READY) && got_message_integrity && got_fingerprint &&
+				(!dtls || dtls->state < DS_READY) && stun_auth_valid &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
 				int prflx_family = AF_UNSPEC;
@@ -1992,12 +2012,28 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					ice->ice_params->chosen[ice->proto] = prflx_idx;
 					ice->ice_params->is_chosen[ice->proto] = 1;
 					ice->missed_count = 0;
+					ice->ready = 1;
 					ice->rready = 1;
 					ice->cand_responsive = 1;
 					ice->prflx_bootstrap_idx = prflx_idx;
 					ice->prflx_bootstrap_us = now;
-					prflx_bootstrap = SWITCH_TRUE;
+					prflx_bootstrap_installed = SWITCH_TRUE;
+					ice->initializing = 0;
+					if (!ice->first_responsive_us) {
+						ice->first_responsive_us = now;
+					}
+					switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
+					ice->addr = prflx_ice_addr;
+					if (dtls && prflx_dtls_addr) {
+						dtls->remote_addr = prflx_dtls_addr;
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+							"ICE peer-reflexive bootstrap: updated DTLS remote addr to %s:%d\n", from_host, from_port);
+					}
+					switch_channel_clear_flag(channel, CF_NO_ICE);
+					switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
+					switch_core_media_gen_key_frame(rtp_session->session);
 					do_adj++;
+					ice->last_ok = now;
 					rtp_session->last_adj = now;
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
 						"ICE peer-reflexive bootstrap: learned %s candidate %s:%d idx:%d priority:%u use_candidate:%d\n",
@@ -2010,7 +2046,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 			}
 
-			if (ice->initializing && !cmp && !rtp_session->ice.dtls_handshake) {
+			if (!provisional_ice && ice->initializing && !cmp && !rtp_session->ice.dtls_handshake) {
 				if (!rtp_session->adj_window && (!ice->ready || !ice->rready || (!rtp_session->dtls || rtp_session->dtls->state != DS_READY))) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE set ADJUST window to 10 seconds on binding request from %s:%d (is_relay: %d, is_responsivie: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
 									switch_channel_get_name(channel), rtp_type(rtp_session), is_rtcp ? "rtcp" : "rtp", from_host, from_port, is_relay, is_responsive, use_candidate,
@@ -2054,9 +2090,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 			dtls_ready = dtls && dtls->state >= DS_READY && ice->ready;
 
-			if (cmp) {
+			if (!provisional_ice && cmp) {
 				ice->last_ok = now;
-			} else if (!do_adj && !is_rtcp && rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && dtls_ready && (ice->type & ICE_CONTROLLED) && use_candidate) {
+			} else if (!provisional_ice && !do_adj && !is_rtcp && rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] && dtls_ready && (ice->type & ICE_CONTROLLED) && use_candidate) {
 				mid_call_failover_ms = ice_mid_call_failover_ms(rtp_session, ice);
 				if (mid_call_failover_ms > 0) {
 					media_unhealthy = rtp_session->elapsed_media >= mid_call_failover_ms || !ice->cand_responsive || !ice->rready;
@@ -2085,7 +2121,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					do_adj++;
 					rtp_session->last_adj = now;
 				}
-			} else if (!do_adj && !rtp_session->ice.dtls_handshake) {
+			} else if (!provisional_ice && !do_adj && !rtp_session->ice.dtls_handshake) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE %d/%d dt:%d i:%d i2:%d cmp:%d\n", rtp_session->elapsed_stun, rtp_session->elapsed_media, (rtp_session->dtls && rtp_session->dtls->state != DS_READY), !ice->ready, !ice->rready, same_host);
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s %s %s ICE ADJUST ELAPSED vs 1000 %d on binding request from %s:%d (is_relay: %d, is_responsive: %d, use_candidate: %d) Current cand: %s:%d typ: %s\n",
@@ -2134,7 +2170,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 			}
 
-			if ((ice->type & ICE_VANILLA) && ice->ice_params && do_adj &&
+			if (!provisional_ice && !prflx_bootstrap_installed && (ice->type & ICE_VANILLA) && ice->ice_params && do_adj &&
 				ice_should_preserve_active_dtls_tuple(rtp_session, ice, dtls, is_rtcp)) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 					"ICE preserving active %s DTLS tuple during handshake, ignoring auto-adjust from %s:%d (idx:%d)\n",
@@ -2142,7 +2178,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				do_adj = 0;
 			}
 
-			if ((ice->type & ICE_VANILLA) && ice->ice_params && do_adj) {
+			if (!provisional_ice && !prflx_bootstrap_installed && (ice->type & ICE_VANILLA) && ice->ice_params && do_adj) {
 				switch_channel_t *channel = NULL;
 
 				if (rtp_session->session) {
@@ -2165,16 +2201,6 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				switch_core_media_gen_key_frame(rtp_session->session);
 
 				switch_rtp_change_ice_dest(rtp_session, ice, from_host, from_port);
-				if (prflx_bootstrap) {
-					if (!ice->addr && prflx_ice_addr) {
-						ice->addr = prflx_ice_addr;
-					}
-					if (dtls && prflx_dtls_addr) {
-						dtls->remote_addr = prflx_dtls_addr;
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
-							"ICE peer-reflexive bootstrap: updated DTLS remote addr to %s:%d\n", from_host, from_port);
-					}
-				}
 				if (mid_call_failover && !is_rtcp && dtls && dtls->remote_addr) {
 					if (switch_sockaddr_info_get(&dtls->remote_addr, from_host, SWITCH_UNSPEC, from_port, 0, rtp_session->pool) == SWITCH_STATUS_SUCCESS) {
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
@@ -7170,8 +7196,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 		int x, loops = 1;
 		switch_time_t now_us = switch_micro_time_now();
 
-		/* ENGDESK-48201: drop calls less than half a ptime since the last in-flight progress
-		   so a tight-looping read path (e.g. silent peer + SIG_BREAK) can't collapse the digit. */
+		/* Ignore sub-ptime wakeups so tight read loops cannot collapse the digit. */
 		if (rtp_session->dtmf_data.out_digit_last_progress_us &&
 			rtp_session->samples_per_second &&
 			rtp_session->samples_per_interval) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -814,17 +814,28 @@ static void ice_track_inbound_media_candidate(switch_rtp_ice_t *ice, switch_sock
 	}
 }
 
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(switch_sockaddr_t *current_addr,
+	switch_sockaddr_t *handshake_peer_addr, dtls_state_t dtls_state, switch_bool_t handshake_peer_set, switch_bool_t is_rtcp)
+{
+	if (is_rtcp || !current_addr || !handshake_peer_set || !handshake_peer_addr) {
+		return SWITCH_FALSE;
+	}
+
+	if (dtls_state <= DS_OFF || dtls_state >= DS_READY) {
+		return SWITCH_FALSE;
+	}
+
+	return switch_cmp_addr(current_addr, handshake_peer_addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
+}
+
 static switch_bool_t ice_should_preserve_active_dtls_tuple(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_dtls_t *dtls, switch_bool_t is_rtcp)
 {
-	if (is_rtcp || !rtp_session || !ice || !ice->addr || !dtls || !dtls->handshake_peer_set || !dtls->handshake_peer_addr) {
+	if (!rtp_session || !ice || !dtls) {
 		return SWITCH_FALSE;
 	}
 
-	if (dtls->state <= DS_OFF || dtls->state >= DS_READY) {
-		return SWITCH_FALSE;
-	}
-
-	return switch_cmp_addr(ice->addr, dtls->handshake_peer_addr, SWITCH_TRUE) ? SWITCH_TRUE : SWITCH_FALSE;
+	return switch_rtp_pvt_should_preserve_active_dtls_tuple(ice->addr, dtls->handshake_peer_addr, dtls->state,
+		dtls->handshake_peer_set ? SWITCH_TRUE : SWITCH_FALSE, is_rtcp);
 }
 
 static uint32_t ice_prflx_bootstrap_ms(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
@@ -1397,6 +1408,24 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	return status;
 }
 
+SWITCH_DECLARE(void) switch_rtp_prepare_ice_restart(switch_rtp_t *rtp_session, ice_proto_t proto, switch_bool_t explicit_restart)
+{
+	switch_rtp_ice_t *ice;
+
+	if (!rtp_session || (proto != IPR_RTP && proto != IPR_RTCP)) {
+		return;
+	}
+
+	switch_mutex_lock(rtp_session->ice_mutex);
+	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
+	ice->restart_pending = explicit_restart ? 1 : 0;
+	if (!explicit_restart) {
+		ice->restart_provisional = 0;
+		ice->restart_provisional_us = 0;
+	}
+	switch_mutex_unlock(rtp_session->ice_mutex);
+}
+
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
 	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
 	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr)
@@ -1418,6 +1447,36 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_s
 	switch_mutex_unlock(rtp_session->ice_mutex);
 
 	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ice_t *ice, dtls_state_t dtls_state,
+	switch_bool_t provisional_ice, switch_bool_t direct_username_match, switch_bool_t stun_auth_valid,
+	switch_bool_t got_message_integrity, switch_bool_t got_fingerprint, switch_bool_t got_use_candidate,
+	switch_bool_t got_use_candidate_covered, switch_bool_t has_priority, switch_bool_t within_bootstrap_window,
+	uint32_t bootstrap_ms, switch_time_t now)
+{
+	uint64_t age_ms;
+
+	if (!ice || !ice->restart_provisional) {
+		return SWITCH_FALSE;
+	}
+
+	if (!ice->restart_provisional_us || !bootstrap_ms || now < ice->restart_provisional_us) {
+		ice->restart_provisional = 0;
+		ice->restart_provisional_us = 0;
+		return SWITCH_FALSE;
+	}
+
+	age_ms = (uint64_t)(now - ice->restart_provisional_us) / 1000;
+	if (age_ms > bootstrap_ms) {
+		ice->restart_provisional = 0;
+		ice->restart_provisional_us = 0;
+		return SWITCH_FALSE;
+	}
+
+	return dtls_state == DS_READY && provisional_ice && direct_username_match && stun_auth_valid &&
+		got_message_integrity && got_fingerprint && got_use_candidate && got_use_candidate_covered &&
+		has_priority && within_bootstrap_window ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
 int icecmp(const char *them, switch_rtp_ice_t *ice)
@@ -1855,6 +1914,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_bool_t mid_call_failover = SWITCH_FALSE;
 			switch_bool_t prflx_addr_ok = SWITCH_FALSE;
 			switch_bool_t prflx_bootstrap_installed = SWITCH_FALSE;
+			switch_bool_t restart_prflx_allowed = SWITCH_FALSE;
 			switch_dtls_t *dtls = is_rtcp ? rtp_session->rtcp_dtls : rtp_session->dtls;
 
 			if (is_rtcp) {
@@ -1920,7 +1980,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				}
 
 				dtls_ready = dtls && dtls->state >= DS_READY && ice->ready;
-				preserve_dtls_tuple = peer_candidate && active_host && !switch_cmp_addr(from_addr, ice->addr, SWITCH_TRUE) &&
+				preserve_dtls_tuple = peer_candidate && active_host && !switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) &&
 					ice_should_preserve_active_dtls_tuple(rtp_session, ice, dtls, is_rtcp) ? SWITCH_TRUE : SWITCH_FALSE;
 
 				if (peer_candidate_idx > -1 && !preserve_dtls_tuple) {
@@ -2035,8 +2095,15 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 							  "%s %s STUN from %s:%d %s is_relay: %d is_responsive: %d use_candidate: %d ready: %d, rready: %d dtls_handshake: %d\n", switch_channel_get_name(channel), rtp_type(rtp_session), from_host, from_port, cmp ? "EXPECTED" : "IGNORED", is_relay, is_responsive, use_candidate, ice->ready, ice->rready, rtp_session->ice.dtls_handshake);
 
+			restart_prflx_allowed = switch_rtp_pvt_restart_prflx_allowed(ice, dtls ? dtls->state : DS_OFF,
+				provisional_ice, direct_username_match, stun_auth_valid, got_message_integrity, got_fingerprint,
+				got_use_candidate, got_use_candidate_covered, pri ? SWITCH_TRUE : SWITCH_FALSE,
+				(rtp_session->elapsed_stun <= prflx_bootstrap_ms &&
+				 (!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) ? SWITCH_TRUE : SWITCH_FALSE,
+				prflx_bootstrap_ms, now);
+
 			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok &&
-				(!dtls || dtls->state < DS_READY) && stun_auth_valid &&
+				(!dtls || dtls->state < DS_READY || restart_prflx_allowed) && stun_auth_valid &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
 				int prflx_family = AF_UNSPEC;
@@ -2065,6 +2132,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					ice->cand_responsive = 1;
 					ice->prflx_bootstrap_idx = prflx_idx;
 					ice->prflx_bootstrap_us = now;
+					ice->restart_provisional = 0;
+					ice->restart_provisional_us = 0;
 					prflx_bootstrap_installed = SWITCH_TRUE;
 					ice->initializing = 0;
 					if (!ice->first_responsive_us) {
@@ -4101,6 +4170,12 @@ SWITCH_DECLARE(void) switch_rtp_reset(switch_rtp_t *rtp_session)
 
 	rtp_session->ice.remote_eoc_received = 0;
 	rtp_session->rtcp_ice.remote_eoc_received = 0;
+	rtp_session->ice.restart_pending = 0;
+	rtp_session->ice.restart_provisional = 0;
+	rtp_session->ice.restart_provisional_us = 0;
+	rtp_session->rtcp_ice.restart_pending = 0;
+	rtp_session->rtcp_ice.restart_provisional = 0;
+	rtp_session->rtcp_ice.restart_provisional_us = 0;
 
 	if (rtp_session->ice.ready) {
 		switch_rtp_reset_vb(rtp_session);
@@ -4721,7 +4796,7 @@ static int do_dtls(switch_rtp_t *rtp_session, switch_dtls_t *dtls)
 		return 0;
 	}
 
-	if (is_ice && !switch_cmp_addr(rtp_session->from_addr, rtp_session->ice.addr, SWITCH_TRUE)) {
+	if (is_ice && !switch_cmp_addr(rtp_session->from_addr, rtp_session->ice.addr, SWITCH_FALSE)) {
 		char tmp_buf1[80] = "";
 		char tmp_buf2[80] = "";
 		const char *host_from = switch_get_addr(tmp_buf1, sizeof(tmp_buf1), rtp_session->from_addr);
@@ -6612,9 +6687,24 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	char bufc[50];
 	int provisional = 0;
 	icand_t *candidate = NULL;
+	switch_bool_t explicit_restart = SWITCH_FALSE;
+	switch_bool_t generation_changed = SWITCH_FALSE;
 
 
 	switch_mutex_lock(rtp_session->ice_mutex);
+
+	if (proto == IPR_RTP) {
+		ice = &rtp_session->ice;
+		rtp_session->flags[SWITCH_RTP_FLAG_PAUSE] = 0;
+		rtp_session->flags[SWITCH_RTP_FLAG_MUTE] = 0;
+	} else {
+		ice = &rtp_session->rtcp_ice;
+	}
+
+	explicit_restart = ice->restart_pending ? SWITCH_TRUE : SWITCH_FALSE;
+	ice->restart_pending = 0;
+	ice->restart_provisional = 0;
+	ice->restart_provisional_us = 0;
 
 	/* VANILLA ICE requires all four creds to sign outbound STUN; refuse and log
 	   loudly rather than emit USERNAME with NULL/empty values. */
@@ -6630,14 +6720,6 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 			zstr(rpassword) ? "EMPTY" : "set");
 		switch_mutex_unlock(rtp_session->ice_mutex);
 		return SWITCH_STATUS_FALSE;
-	}
-
-	if (proto == IPR_RTP) {
-		ice = &rtp_session->ice;
-		rtp_session->flags[SWITCH_RTP_FLAG_PAUSE] = 0;
-		rtp_session->flags[SWITCH_RTP_FLAG_MUTE] = 0;
-	} else {
-		ice = &rtp_session->rtcp_ice;
 	}
 
 	ice->proto = proto;
@@ -6656,6 +6738,11 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 		ice->ready = ice->rready = 1;
 		ice->remote_eoc_received = 0;
 		ice->cand_responsive = 0;
+	}
+	if (explicit_restart && !zstr(ice->ice_user) &&
+		(strcmp(ice->ice_user, ice_user) || strcmp(ice->pass ? ice->pass : "", password ? password : "") ||
+		 strcmp(ice->rpass ? ice->rpass : "", rpassword ? rpassword : ""))) {
+		generation_changed = SWITCH_TRUE;
 	}
 	ice->first_responsive_us = 0;
 	ice->promoted_to_controlling = 0;
@@ -6726,6 +6813,11 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 
 	if (switch_channel_var_true(switch_core_session_get_channel(rtp_session->session), "ice_no_response_to_ignored_candidate")) {
 		switch_rtp_set_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED);
+	}
+
+	if (provisional && generation_changed) {
+		ice->restart_provisional = 1;
+		ice->restart_provisional_us = switch_micro_time_now();
 	}
 
 	if (provisional) {

--- a/src/switch_stun.c
+++ b/src/switch_stun.c
@@ -583,6 +583,112 @@ SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_fingerprint(switch_stun
 	return 1;
 }
 
+static uint8_t stun_constant_time_equal(const uint8_t *left, const uint8_t *right, uint32_t len)
+{
+	uint8_t difference = 0;
+	uint32_t i;
+
+	for (i = 0; i < len; i++) {
+		difference |= left[i] ^ right[i];
+	}
+
+	return difference == 0;
+}
+
+SWITCH_DECLARE(uint8_t) switch_stun_packet_validate_auth(const void *data, uint32_t len, const char *pass)
+{
+	const uint8_t *raw = (const uint8_t *)data;
+	uint8_t digest[EVP_MAX_MD_SIZE];
+	uint8_t *signed_data = NULL;
+	unsigned int digest_len = 0;
+	uint16_t message_length = 0;
+	uint16_t attribute_type = 0;
+	uint16_t attribute_length = 0;
+	uint16_t adjusted_length = 0;
+	uint32_t cookie = 0;
+	uint32_t total_length = 0;
+	uint32_t offset = sizeof(switch_stun_packet_header_t);
+	uint32_t padded_length = 0;
+	uint32_t integrity_offset = 0;
+	uint32_t fingerprint_offset = 0;
+	uint32_t received_fingerprint = 0;
+	uint32_t expected_fingerprint = 0;
+	uint8_t valid = 0;
+
+	if (!raw || zstr(pass) || len < sizeof(switch_stun_packet_header_t)) {
+		return 0;
+	}
+
+	memcpy(&message_length, raw + 2, sizeof(message_length));
+	message_length = ntohs(message_length);
+	memcpy(&cookie, raw + 4, sizeof(cookie));
+	if ((message_length & 3) || ntohl(cookie) != STUN_MAGIC_COOKIE || message_length != len - sizeof(switch_stun_packet_header_t)) {
+		return 0;
+	}
+
+	total_length = sizeof(switch_stun_packet_header_t) + message_length;
+	while (offset < total_length) {
+		if (total_length - offset < sizeof(switch_stun_packet_attribute_t)) {
+			return 0;
+		}
+
+		memcpy(&attribute_type, raw + offset, sizeof(attribute_type));
+		memcpy(&attribute_length, raw + offset + 2, sizeof(attribute_length));
+		attribute_type = ntohs(attribute_type);
+		attribute_length = ntohs(attribute_length);
+		padded_length = ((uint32_t)attribute_length + 3) & ~3U;
+		if (padded_length > total_length - offset - sizeof(switch_stun_packet_attribute_t)) {
+			return 0;
+		}
+
+		if (attribute_type == SWITCH_STUN_ATTR_MESSAGE_INTEGRITY) {
+			if (integrity_offset || attribute_length != 20) {
+				return 0;
+			}
+			integrity_offset = offset;
+		} else if (attribute_type == SWITCH_STUN_ATTR_FINGERPRINT) {
+			if (fingerprint_offset || attribute_length != 4) {
+				return 0;
+			}
+			fingerprint_offset = offset;
+		}
+
+		offset += sizeof(switch_stun_packet_attribute_t) + padded_length;
+	}
+
+	if (!integrity_offset || !fingerprint_offset ||
+		integrity_offset + sizeof(switch_stun_packet_attribute_t) + 20 != fingerprint_offset ||
+		fingerprint_offset + sizeof(switch_stun_packet_attribute_t) + 4 != total_length) {
+		return 0;
+	}
+
+	signed_data = malloc(integrity_offset);
+	if (!signed_data) {
+		return 0;
+	}
+
+	memcpy(signed_data, raw, integrity_offset);
+	adjusted_length = htons((uint16_t)(integrity_offset + sizeof(switch_stun_packet_attribute_t)));
+	memcpy(signed_data + 2, &adjusted_length, sizeof(adjusted_length));
+	if (!HMAC(EVP_sha1(), (const unsigned char *)pass, (int)strlen(pass), signed_data, integrity_offset, digest, &digest_len) ||
+		digest_len != 20 || !stun_constant_time_equal(digest, raw + integrity_offset + sizeof(switch_stun_packet_attribute_t), 20)) {
+		goto done;
+	}
+
+	memcpy(&received_fingerprint, raw + fingerprint_offset + sizeof(switch_stun_packet_attribute_t), sizeof(received_fingerprint));
+	received_fingerprint = ntohl(received_fingerprint);
+	expected_fingerprint = switch_crc32_8bytes(raw, fingerprint_offset) ^ 0x5354554e;
+	if (received_fingerprint != expected_fingerprint) {
+		goto done;
+	}
+
+	valid = 1;
+
+ done:
+	switch_safe_free(signed_data);
+	return valid;
+}
+
 
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_use_candidate(switch_stun_packet_t *packet)
 {

--- a/src/switch_stun.c
+++ b/src/switch_stun.c
@@ -703,30 +703,48 @@ SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_use_candidate(switch_st
 
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling(switch_stun_packet_t *packet)
 {
-	switch_stun_packet_attribute_t *attribute;
 	char buf[8];
 
 	switch_stun_random_string(buf, 8, NULL);
+	return switch_stun_packet_attribute_add_controlling_value(packet, buf);
+}
+
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling_value(switch_stun_packet_t *packet, const char *tie_breaker)
+{
+	switch_stun_packet_attribute_t *attribute;
+
+	if (!packet || !tie_breaker) {
+		return 0;
+	}
 
 	attribute = (switch_stun_packet_attribute_t *) ((uint8_t *) & packet->first_attribute + ntohs(packet->header.length));
 	attribute->type = htons(SWITCH_STUN_ATTR_CONTROLLING);
 	attribute->length = htons(8);
-	memcpy(attribute->value, buf, 8);
+	memcpy(attribute->value, tie_breaker, 8);
 	packet->header.length += htons(sizeof(switch_stun_packet_attribute_t)) + attribute->length;
 	return 1;
 }
 
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled(switch_stun_packet_t *packet)
 {
-	switch_stun_packet_attribute_t *attribute;
 	char buf[8];
 
 	switch_stun_random_string(buf, 8, NULL);
+	return switch_stun_packet_attribute_add_controlled_value(packet, buf);
+}
+
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled_value(switch_stun_packet_t *packet, const char *tie_breaker)
+{
+	switch_stun_packet_attribute_t *attribute;
+
+	if (!packet || !tie_breaker) {
+		return 0;
+	}
 
 	attribute = (switch_stun_packet_attribute_t *) ((uint8_t *) & packet->first_attribute + ntohs(packet->header.length));
 	attribute->type = htons(SWITCH_STUN_ATTR_CONTROLLED);
 	attribute->length = htons(8);
-	memcpy(attribute->value, buf, 8);
+	memcpy(attribute->value, tie_breaker, 8);
 	packet->header.length += htons(sizeof(switch_stun_packet_attribute_t)) + attribute->length;
 	return 1;
 }

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -44,6 +44,39 @@ FST_TEARDOWN_END()
 		switch_assert(packet);
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_stun_auth_validation)
+	{
+		static const uint8_t authenticated_request[] = {
+			0x00, 0x01, 0x00, 0x58, 0x21, 0x12, 0xa4, 0x42,
+			0xb7, 0xe7, 0xa7, 0x01, 0xbc, 0x34, 0xd6, 0x86,
+			0xfa, 0x87, 0xdf, 0xae, 0x80, 0x22, 0x00, 0x10,
+			0x53, 0x54, 0x55, 0x4e, 0x20, 0x74, 0x65, 0x73,
+			0x74, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+			0x00, 0x24, 0x00, 0x04, 0x6e, 0x00, 0x01, 0xff,
+			0x80, 0x29, 0x00, 0x08, 0x93, 0x2f, 0xf9, 0xb1,
+			0x51, 0x26, 0x3b, 0x36, 0x00, 0x06, 0x00, 0x09,
+			0x65, 0x76, 0x74, 0x6a, 0x3a, 0x68, 0x36, 0x76,
+			0x59, 0x20, 0x20, 0x20, 0x00, 0x08, 0x00, 0x14,
+			0x9a, 0xea, 0xa7, 0x0c, 0xbf, 0xd8, 0xcb, 0x56,
+			0x78, 0x1e, 0xf2, 0xb5, 0xb2, 0xd3, 0xf2, 0x49,
+			0xc1, 0xb5, 0x71, 0xa2, 0x80, 0x28, 0x00, 0x04,
+			0xe5, 0x7a, 0x3b, 0xcf
+		};
+		static const char password[] = "VOkJxbRl1RmTxUk/WvJxBt";
+		uint8_t tampered[sizeof(authenticated_request)];
+
+		fst_check(switch_stun_packet_validate_auth(authenticated_request, sizeof(authenticated_request), password));
+		fst_check(!switch_stun_packet_validate_auth(authenticated_request, sizeof(authenticated_request), "wrong-password"));
+
+		memcpy(tampered, authenticated_request, sizeof(tampered));
+		tampered[80] ^= 0x01;
+		fst_check(!switch_stun_packet_validate_auth(tampered, sizeof(tampered), password));
+
+		memcpy(tampered, authenticated_request, sizeof(tampered));
+		tampered[104] ^= 0x01;
+		fst_check(!switch_stun_packet_validate_auth(tampered, sizeof(tampered), password));
+	}
+	FST_TEST_END()
 		FST_SESSION_BEGIN(test_stun_msg)
 		{
 				/* Binding Success Response */
@@ -156,6 +189,100 @@ FST_TEARDOWN_END()
 			switch_rtp_pvt_handle_ice(rtp_session, &ice, incoming, sizeof(incoming));
 
 			fst_check(ice.ready);
+
+			switch_rtp_destroy(&rtp_session);
+			switch_core_session_rwunlock(session);
+			switch_core_destroy_memory_pool(&pool);
+		}
+		FST_SESSION_END()
+		FST_SESSION_BEGIN(test_provisional_ice_requires_explicit_bootstrap)
+		{
+			static const uint8_t authenticated_request[] = {
+				0x00, 0x01, 0x00, 0x58, 0x21, 0x12, 0xa4, 0x42,
+				0xb7, 0xe7, 0xa7, 0x01, 0xbc, 0x34, 0xd6, 0x86,
+				0xfa, 0x87, 0xdf, 0xae, 0x80, 0x22, 0x00, 0x10,
+				0x53, 0x54, 0x55, 0x4e, 0x20, 0x74, 0x65, 0x73,
+				0x74, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
+				0x00, 0x24, 0x00, 0x04, 0x6e, 0x00, 0x01, 0xff,
+				0x80, 0x29, 0x00, 0x08, 0x93, 0x2f, 0xf9, 0xb1,
+				0x51, 0x26, 0x3b, 0x36, 0x00, 0x06, 0x00, 0x09,
+				0x65, 0x76, 0x74, 0x6a, 0x3a, 0x68, 0x36, 0x76,
+				0x59, 0x20, 0x20, 0x20, 0x00, 0x08, 0x00, 0x14,
+				0x9a, 0xea, 0xa7, 0x0c, 0xbf, 0xd8, 0xcb, 0x56,
+				0x78, 0x1e, 0xf2, 0xb5, 0xb2, 0xd3, 0xf2, 0x49,
+				0xc1, 0xb5, 0x71, 0xa2, 0x80, 0x28, 0x00, 0x04,
+				0xe5, 0x7a, 0x3b, 0xcf
+			};
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_status_t status;
+			switch_call_cause_t cause;
+			switch_rtp_ice_t ice = { 0 };
+			switch_memory_pool_t *pool = NULL;
+			static switch_rtp_t *rtp_session = NULL;
+			static switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+			const char *err = NULL;
+			ice_t ice_params = { 0 };
+			uint8_t tampered[sizeof(authenticated_request)];
+
+			switch_core_new_memory_pool(&pool);
+			status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+			fst_check(session);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			channel = switch_core_session_get_channel(session);
+			fst_check(channel);
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap_ms", "5000");
+
+			switch_core_memory_pool_set_data(pool, "__session", session);
+			rtp_session = switch_rtp_new(rx_host, rx_port, tx_host, tx_port, TEST_PT, 8000, 20 * 1000, flags, "soft", &err, pool);
+			fst_xcheck(rtp_session != NULL, "switch_rtp_new()");
+			fst_check(switch_rtp_ready(rtp_session));
+			switch_core_media_set_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO, rtp_session);
+
+			ice.ice_params = &ice_params;
+			ice.user_ice = "evtj:h6vY";
+			ice.ice_user = "h6vY:evtj";
+			ice.pass = "VOkJxbRl1RmTxUk/WvJxBt";
+			ice.rpass = "remote-pass";
+			ice.type = ICE_VANILLA | ICE_CONTROLLED;
+			ice.proto = IPR_RTP;
+			ice.initializing = 1;
+			ice.ice_params->chosen[ice.proto] = 0;
+			ice.ice_params->cand_idx[ice.proto] = 1;
+			ice.ice_params->cands[0][ice.proto].priority = 0x6e0001ff;
+
+			memcpy(tampered, authenticated_request, sizeof(tampered));
+			tampered[80] ^= 0x01;
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+
+			memcpy(tampered, authenticated_request, sizeof(tampered));
+			tampered[104] ^= 0x01;
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, (void *)authenticated_request, sizeof(authenticated_request));
+
+			fst_check(!ice.ready);
+			fst_check(!ice.rready);
+			fst_check(!ice.cand_responsive);
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.ice_params->chosen[ice.proto] == 0);
+
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap_require_use_candidate", "false");
+			ice.prflx_bootstrap_cached = 0;
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, (void *)authenticated_request, sizeof(authenticated_request));
+			fst_check(ice.ready);
+			fst_check(ice.rready);
+			fst_check(ice.cand_responsive);
+			fst_check(ice.addr != NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 2);
+			fst_check(ice.ice_params->chosen[ice.proto] == 1);
 
 			switch_rtp_destroy(&rtp_session);
 			switch_core_session_rwunlock(session);

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -199,6 +199,110 @@ FST_TEARDOWN_END()
 		switch_core_destroy_memory_pool(&pool);
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_recovery_dtls_nomination_proof_requires_authenticated_direct_request)
+	{
+		fst_check(switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_FALSE, SWITCH_FALSE) ==
+			SWITCH_RTP_RECOVERY_NOMINATION_NONE);
+		fst_check(switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_FALSE, SWITCH_TRUE) ==
+			SWITCH_RTP_RECOVERY_NOMINATION_NONE);
+		fst_check(switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_TRUE, SWITCH_FALSE) ==
+			SWITCH_RTP_RECOVERY_NOMINATION_NONE);
+		fst_check(switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_TRUE, SWITCH_TRUE) ==
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_recovery_dtls_restart_tuple_mutation_policy)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *same_addr = NULL;
+		switch_sockaddr_t *different_port_addr = NULL;
+		switch_sockaddr_t *relay_addr = NULL;
+		switch_rtp_recovery_nomination_proof_t trusted_proof;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "198.51.100.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current address");
+		fst_xcheck(switch_sockaddr_info_get(&same_addr, "198.51.100.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"same address");
+		fst_xcheck(switch_sockaddr_info_get(&different_port_addr, "198.51.100.10", SWITCH_UNSPEC, 40002, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"different-port address");
+		fst_xcheck(switch_sockaddr_info_get(&relay_addr, "198.51.100.20", SWITCH_UNSPEC, 50000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"relay address");
+
+		trusted_proof = switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_TRUE, SWITCH_TRUE);
+		fst_check(switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, relay_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+		fst_check(switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, different_port_addr, DS_SETUP,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, relay_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, trusted_proof));
+		/* DTLS packets cannot renew persisted nomination proof. */
+		fst_check(switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, relay_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED));
+		/* A moved ICE tuple needs no off-current bypass. */
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, same_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_recovery_dtls_candidate_response_and_fallback_policy)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *candidate_addr = NULL;
+		switch_rtp_recovery_nomination_proof_t trusted_proof;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "203.0.113.10", SWITCH_UNSPEC, 41000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current address");
+		fst_xcheck(switch_sockaddr_info_get(&candidate_addr, "203.0.113.20", SWITCH_UNSPEC, 51000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"candidate address");
+
+		trusted_proof = switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_TRUE, SWITCH_TRUE);
+		/* Binding responses cannot prove current-generation nomination. */
+		fst_check(switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+		fst_check(switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_SETUP,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED));
+		/* Missed-candidate fallback may use only proof from this request. */
+		fst_check(switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, trusted_proof));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_recovery_dtls_tuple_policy_leaves_other_paths_unchanged)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *candidate_addr = NULL;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "192.0.2.10", SWITCH_UNSPEC, 42000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current address");
+		fst_xcheck(switch_sockaddr_info_get(&candidate_addr, "192.0.2.20", SWITCH_UNSPEC, 52000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"candidate address");
+
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_OFF,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_READY,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_FALSE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, candidate_addr, DS_HANDSHAKE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(NULL, candidate_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(current_addr, NULL, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
 		FST_SESSION_BEGIN(test_stun_msg)
 		{
 				/* Binding Success Response */

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -9,6 +9,31 @@ static switch_port_t rx_port = 1234;
 static const char *tx_host = "127.0.0.1";
 static switch_port_t tx_port = 54320;
 
+static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buflen, const char *username,
+												 const char *password, switch_bool_t use_candidate)
+{
+	switch_stun_packet_t *packet;
+	switch_size_t bytes;
+
+	switch_assert(buf);
+	switch_assert(buflen >= 128);
+	memset(buf, 0, buflen);
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+	switch_stun_packet_attribute_add_priority(packet, 0x6e0001ff);
+	if (username) {
+		switch_stun_packet_attribute_add_username(packet, (char *)username, (uint16_t)strlen(username));
+	}
+	if (use_candidate) {
+		switch_stun_packet_attribute_add_use_candidate(packet);
+	}
+	switch_stun_packet_attribute_add_integrity(packet, password);
+	switch_stun_packet_attribute_add_fingerprint(packet);
+	bytes = switch_stun_packet_length(packet);
+	switch_assert(bytes <= buflen);
+
+	return bytes;
+}
+
 static void fsctl_debug(switch_core_session_t *session) 
 {
 		switch_stream_handle_t stream = { 0 };
@@ -224,6 +249,12 @@ FST_TEARDOWN_END()
 			const char *err = NULL;
 			ice_t ice_params = { 0 };
 			uint8_t tampered[sizeof(authenticated_request)];
+			uint8_t missing_username[128];
+			uint8_t wrong_username[128];
+			switch_size_t missing_username_len;
+			switch_size_t wrong_username_len;
+			int initial_cand_idx;
+			int initial_chosen;
 
 			switch_core_new_memory_pool(&pool);
 			status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
@@ -253,17 +284,46 @@ FST_TEARDOWN_END()
 			ice.ice_params->cand_idx[ice.proto] = 1;
 			ice.ice_params->cands[0][ice.proto].priority = 0x6e0001ff;
 
+			ice.missed_count = 7;
+			initial_cand_idx = ice.ice_params->cand_idx[ice.proto];
+			initial_chosen = ice.ice_params->chosen[ice.proto];
+			missing_username_len = build_authenticated_request(missing_username, sizeof(missing_username), NULL, ice.pass, SWITCH_TRUE);
+			fst_check(switch_stun_packet_validate_auth(missing_username, (uint32_t)missing_username_len, ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, missing_username, missing_username_len);
+			fst_check(!ice.ready);
+			fst_check(!ice.rready);
+			fst_check(!ice.cand_responsive);
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
+			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
+			fst_check(ice.missed_count == 7);
+
+			wrong_username_len = build_authenticated_request(wrong_username, sizeof(wrong_username), "wrong:username", ice.pass, SWITCH_TRUE);
+			fst_check(switch_stun_packet_validate_auth(wrong_username, (uint32_t)wrong_username_len, ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, wrong_username, wrong_username_len);
+			fst_check(!ice.ready);
+			fst_check(!ice.rready);
+			fst_check(!ice.cand_responsive);
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
+			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
+			fst_check(ice.missed_count == 7);
+
 			memcpy(tampered, authenticated_request, sizeof(tampered));
 			tampered[80] ^= 0x01;
 			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
 			fst_check(ice.addr == NULL);
-			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
+			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
+			fst_check(ice.missed_count == 7);
 
 			memcpy(tampered, authenticated_request, sizeof(tampered));
 			tampered[104] ^= 0x01;
 			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
 			fst_check(ice.addr == NULL);
-			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
+			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
+			fst_check(ice.missed_count == 7);
 
 			switch_rtp_pvt_handle_ice(rtp_session, &ice, (void *)authenticated_request, sizeof(authenticated_request));
 
@@ -271,8 +331,9 @@ FST_TEARDOWN_END()
 			fst_check(!ice.rready);
 			fst_check(!ice.cand_responsive);
 			fst_check(ice.addr == NULL);
-			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
-			fst_check(ice.ice_params->chosen[ice.proto] == 0);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
+			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
+			fst_check(ice.missed_count == 7);
 
 			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap_require_use_candidate", "false");
 			ice.prflx_bootstrap_cached = 0;
@@ -283,6 +344,7 @@ FST_TEARDOWN_END()
 			fst_check(ice.addr != NULL);
 			fst_check(ice.ice_params->cand_idx[ice.proto] == 2);
 			fst_check(ice.ice_params->chosen[ice.proto] == 1);
+			fst_check(ice.missed_count == 0);
 
 			switch_rtp_destroy(&rtp_session);
 			switch_core_session_rwunlock(session);

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -87,6 +87,7 @@ FST_TEARDOWN_END()
 			0xc1, 0xb5, 0x71, 0xa2, 0x80, 0x28, 0x00, 0x04,
 			0xe5, 0x7a, 0x3b, 0xcf
 		};
+		/* RFC 5769 Section 2.1 request vector. */
 		static const char password[] = "VOkJxbRl1RmTxUk/WvJxBt";
 		uint8_t tampered[sizeof(authenticated_request)];
 
@@ -223,22 +224,6 @@ FST_TEARDOWN_END()
 		FST_SESSION_END()
 		FST_SESSION_BEGIN(test_provisional_ice_requires_explicit_bootstrap)
 		{
-			static const uint8_t authenticated_request[] = {
-				0x00, 0x01, 0x00, 0x58, 0x21, 0x12, 0xa4, 0x42,
-				0xb7, 0xe7, 0xa7, 0x01, 0xbc, 0x34, 0xd6, 0x86,
-				0xfa, 0x87, 0xdf, 0xae, 0x80, 0x22, 0x00, 0x10,
-				0x53, 0x54, 0x55, 0x4e, 0x20, 0x74, 0x65, 0x73,
-				0x74, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74,
-				0x00, 0x24, 0x00, 0x04, 0x6e, 0x00, 0x01, 0xff,
-				0x80, 0x29, 0x00, 0x08, 0x93, 0x2f, 0xf9, 0xb1,
-				0x51, 0x26, 0x3b, 0x36, 0x00, 0x06, 0x00, 0x09,
-				0x65, 0x76, 0x74, 0x6a, 0x3a, 0x68, 0x36, 0x76,
-				0x59, 0x20, 0x20, 0x20, 0x00, 0x08, 0x00, 0x14,
-				0x9a, 0xea, 0xa7, 0x0c, 0xbf, 0xd8, 0xcb, 0x56,
-				0x78, 0x1e, 0xf2, 0xb5, 0xb2, 0xd3, 0xf2, 0x49,
-				0xc1, 0xb5, 0x71, 0xa2, 0x80, 0x28, 0x00, 0x04,
-				0xe5, 0x7a, 0x3b, 0xcf
-			};
 			switch_core_session_t *session = NULL;
 			switch_channel_t *channel = NULL;
 			switch_status_t status;
@@ -249,7 +234,7 @@ FST_TEARDOWN_END()
 			static switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
 			const char *err = NULL;
 			ice_t ice_params = { 0 };
-			uint8_t tampered[sizeof(authenticated_request)];
+			uint8_t tampered[128];
 			uint8_t missing_username[128];
 			uint8_t wrong_username[128];
 			uint8_t successful_request[128];
@@ -259,6 +244,7 @@ FST_TEARDOWN_END()
 			switch_size_t missing_username_len;
 			switch_size_t wrong_username_len;
 			switch_size_t successful_request_len;
+			switch_size_t no_use_candidate_len;
 			switch_sockaddr_t *remote_addr;
 			int initial_cand_idx;
 			int initial_chosen;
@@ -282,12 +268,13 @@ FST_TEARDOWN_END()
 			switch_core_media_set_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO, rtp_session);
 
 			ice.ice_params = &ice_params;
-			ice.user_ice = "evtj:h6vY";
-			ice.ice_user = "h6vY:evtj";
-			ice.pass = "VOkJxbRl1RmTxUk/WvJxBt";
-			ice.rpass = "remote-pass";
+			ice.user_ice = "remoteUfrag:localUfrag";
+			ice.ice_user = "localUfrag:remoteUfrag";
+			ice.pass = "test-local-ice-password";
+			ice.rpass = "test-remote-ice-password";
 			ice.type = ICE_VANILLA | ICE_CONTROLLED;
 			ice.proto = IPR_RTP;
+			ice.prflx_bootstrap_require_use_candidate = 1;
 			ice.initializing = 1;
 			ice.ice_params->chosen[ice.proto] = 0;
 			ice.ice_params->cand_idx[ice.proto] = 1;
@@ -318,25 +305,26 @@ FST_TEARDOWN_END()
 			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
 			fst_check(ice.missed_count == 7);
 
-			memcpy(tampered, authenticated_request, sizeof(tampered));
-			tampered[80] ^= 0x01;
-			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
+			successful_request_len = build_authenticated_request(successful_request, sizeof(successful_request), ice.user_ice, ice.pass, SWITCH_TRUE);
+			memcpy(tampered, successful_request, successful_request_len);
+			tampered[successful_request_len - 28] ^= 0x01;
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, successful_request_len);
 			fst_check(ice.addr == NULL);
 			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
 			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
 			fst_check(ice.missed_count == 7);
 
-			memcpy(tampered, authenticated_request, sizeof(tampered));
-			tampered[104] ^= 0x01;
-			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
+			memcpy(tampered, successful_request, successful_request_len);
+			tampered[successful_request_len - 4] ^= 0x01;
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, successful_request_len);
 			fst_check(ice.addr == NULL);
 			fst_check(ice.ice_params->cand_idx[ice.proto] == initial_cand_idx);
 			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
 			fst_check(ice.missed_count == 7);
 
-			memcpy(tampered, authenticated_request, sizeof(tampered));
-			fst_check(switch_stun_packet_validate_auth(tampered, sizeof(tampered), ice.pass));
-			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
+			no_use_candidate_len = build_authenticated_request(tampered, sizeof(tampered), ice.user_ice, ice.pass, SWITCH_FALSE);
+			fst_check(switch_stun_packet_validate_auth(tampered, (uint32_t)no_use_candidate_len, ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, no_use_candidate_len);
 
 			fst_check(!ice.ready);
 			fst_check(!ice.rready);
@@ -346,7 +334,6 @@ FST_TEARDOWN_END()
 			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
 			fst_check(ice.missed_count == 7);
 
-			successful_request_len = build_authenticated_request(successful_request, sizeof(successful_request), ice.user_ice, ice.pass, SWITCH_TRUE);
 			fst_check(switch_stun_packet_validate_auth(successful_request, (uint32_t)successful_request_len, ice.pass));
 			switch_rtp_pvt_handle_ice(rtp_session, &ice, successful_request, successful_request_len);
 			fst_check(ice.ready);

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -141,6 +141,7 @@ FST_TEARDOWN_END()
 				ice.ice_user = "ice_user";
 
 				ice.type = ICE_VANILLA;
+				ice.addr = switch_rtp_session_get_remote_addr(rtp_session);
 				switch_rtp_pvt_handle_ice(rtp_session, &ice, incoming, sizeof(incoming));
 
 				fst_check(ice.rready);
@@ -251,8 +252,14 @@ FST_TEARDOWN_END()
 			uint8_t tampered[sizeof(authenticated_request)];
 			uint8_t missing_username[128];
 			uint8_t wrong_username[128];
+			uint8_t successful_request[128];
+			char bootstrap_host[80] = { 0 };
+			char learned_host[80] = { 0 };
+			char remote_host[80] = { 0 };
 			switch_size_t missing_username_len;
 			switch_size_t wrong_username_len;
+			switch_size_t successful_request_len;
+			switch_sockaddr_t *remote_addr;
 			int initial_cand_idx;
 			int initial_chosen;
 
@@ -267,7 +274,9 @@ FST_TEARDOWN_END()
 			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap_ms", "5000");
 
 			switch_core_memory_pool_set_data(pool, "__session", session);
-			rtp_session = switch_rtp_new(rx_host, rx_port, tx_host, tx_port, TEST_PT, 8000, 20 * 1000, flags, "soft", &err, pool);
+			fst_xcheck(switch_find_local_ip(bootstrap_host, sizeof(bootstrap_host), NULL, AF_INET) == SWITCH_STATUS_SUCCESS, "switch_find_local_ip()");
+			fst_xcheck(strncmp(bootstrap_host, "127.", 4), "non-loopback bootstrap host");
+			rtp_session = switch_rtp_new(bootstrap_host, rx_port, tx_host, tx_port, TEST_PT, 8000, 20 * 1000, flags, "soft", &err, pool);
 			fst_xcheck(rtp_session != NULL, "switch_rtp_new()");
 			fst_check(switch_rtp_ready(rtp_session));
 			switch_core_media_set_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO, rtp_session);
@@ -325,7 +334,9 @@ FST_TEARDOWN_END()
 			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
 			fst_check(ice.missed_count == 7);
 
-			switch_rtp_pvt_handle_ice(rtp_session, &ice, (void *)authenticated_request, sizeof(authenticated_request));
+			memcpy(tampered, authenticated_request, sizeof(tampered));
+			fst_check(switch_stun_packet_validate_auth(tampered, sizeof(tampered), ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, sizeof(tampered));
 
 			fst_check(!ice.ready);
 			fst_check(!ice.rready);
@@ -335,9 +346,9 @@ FST_TEARDOWN_END()
 			fst_check(ice.ice_params->chosen[ice.proto] == initial_chosen);
 			fst_check(ice.missed_count == 7);
 
-			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap_require_use_candidate", "false");
-			ice.prflx_bootstrap_cached = 0;
-			switch_rtp_pvt_handle_ice(rtp_session, &ice, (void *)authenticated_request, sizeof(authenticated_request));
+			successful_request_len = build_authenticated_request(successful_request, sizeof(successful_request), ice.user_ice, ice.pass, SWITCH_TRUE);
+			fst_check(switch_stun_packet_validate_auth(successful_request, (uint32_t)successful_request_len, ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, successful_request, successful_request_len);
 			fst_check(ice.ready);
 			fst_check(ice.rready);
 			fst_check(ice.cand_responsive);
@@ -345,6 +356,30 @@ FST_TEARDOWN_END()
 			fst_check(ice.ice_params->cand_idx[ice.proto] == 2);
 			fst_check(ice.ice_params->chosen[ice.proto] == 1);
 			fst_check(ice.missed_count == 0);
+			if (ice.addr) {
+				fst_check(!strcmp(switch_get_addr(learned_host, sizeof(learned_host), ice.addr), bootstrap_host));
+				fst_check(switch_sockaddr_get_port(ice.addr) == rx_port);
+			}
+			remote_addr = switch_rtp_session_get_remote_addr(rtp_session);
+			fst_check(remote_addr != NULL);
+			if (remote_addr) {
+				fst_check(!strcmp(switch_get_addr(remote_host, sizeof(remote_host), remote_addr), bootstrap_host));
+				fst_check(switch_sockaddr_get_port(remote_addr) == rx_port);
+			}
+			if (ice.ice_params->cand_idx[ice.proto] == 2) {
+				fst_check(ice.ice_params->cands[1][ice.proto].con_addr != NULL);
+				if (ice.ice_params->cands[1][ice.proto].con_addr) {
+					fst_check(!strcmp(ice.ice_params->cands[1][ice.proto].con_addr, bootstrap_host));
+				}
+				fst_check(ice.ice_params->cands[1][ice.proto].con_port == rx_port);
+				fst_check(ice.ice_params->cands[1][ice.proto].cand_type != NULL);
+				if (ice.ice_params->cands[1][ice.proto].cand_type) {
+					fst_check(!strcmp(ice.ice_params->cands[1][ice.proto].cand_type, "prflx"));
+				}
+				fst_check(ice.ice_params->cands[1][ice.proto].responsive);
+				fst_check(ice.ice_params->cands[1][ice.proto].ready);
+				fst_check(ice.ice_params->cands[1][ice.proto].use_candidate);
+			}
 
 			switch_rtp_destroy(&rtp_session);
 			switch_core_session_rwunlock(session);

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -9,9 +9,11 @@ static switch_port_t rx_port = 1234;
 static const char *tx_host = "127.0.0.1";
 static switch_port_t tx_port = 54320;
 
-static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buflen, const char *username,
-												 const char *password, switch_bool_t use_candidate)
+static switch_size_t build_authenticated_request_with_role(uint8_t *buf, switch_size_t buflen,
+	const char *username, const char *password, switch_bool_t use_candidate,
+	switch_bool_t peer_controlled, switch_bool_t peer_controlling)
 {
+	static const char tie_breaker[8] = { 0x01, 0x23, 0x45, 0x67, 0x11, 0x22, 0x33, 0x44 };
 	switch_stun_packet_t *packet;
 	switch_size_t bytes;
 
@@ -26,6 +28,38 @@ static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buf
 	if (use_candidate) {
 		switch_stun_packet_attribute_add_use_candidate(packet);
 	}
+	if (peer_controlled) {
+		switch_stun_packet_attribute_add_controlled_value(packet, tie_breaker);
+	}
+	if (peer_controlling) {
+		switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker);
+	}
+	switch_stun_packet_attribute_add_integrity(packet, password);
+	switch_stun_packet_attribute_add_fingerprint(packet);
+	bytes = switch_stun_packet_length(packet);
+	switch_assert(bytes <= buflen);
+
+	return bytes;
+}
+
+static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buflen, const char *username,
+	const char *password, switch_bool_t use_candidate)
+{
+	return build_authenticated_request_with_role(buf, buflen, username, password, use_candidate,
+		SWITCH_FALSE, SWITCH_FALSE);
+}
+
+static switch_size_t build_authenticated_response(uint8_t *buf, switch_size_t buflen,
+	char *transaction_id, const char *password)
+{
+	switch_stun_packet_t *packet;
+	switch_size_t bytes;
+
+	switch_assert(buf);
+	switch_assert(buflen >= 128);
+	switch_assert(transaction_id);
+	memset(buf, 0, buflen);
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_RESPONSE, transaction_id, buf);
 	switch_stun_packet_attribute_add_integrity(packet, password);
 	switch_stun_packet_attribute_add_fingerprint(packet);
 	bytes = switch_stun_packet_length(packet);
@@ -125,6 +159,246 @@ FST_TEARDOWN_END()
 		fingerprint = htonl(switch_crc32_8bytes(late_use_candidate, (uint32_t)fingerprint_offset + 4) ^ 0x5354554e);
 		memcpy(late_use_candidate + fingerprint_offset + 8, &fingerprint, sizeof(fingerprint));
 		fst_check(!switch_stun_packet_validate_auth(late_use_candidate, (uint32_t)late_use_candidate_len, generated_password));
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_controlling_failover_requires_exact_authenticated_response)
+	{
+		switch_rtp_ice_t ice = { 0 };
+		static const char probe_id[13] = "probe-id-123";
+		static const char nomination_id[13] = "nominate-123";
+		static const char wrong_id[13] = "wrong-id-123";
+		switch_socket_t *local_socket = (switch_socket_t *)&ice;
+		switch_socket_t *other_socket = (switch_socket_t *)&probe_id;
+
+		ice.controlling_failover_idx = 3;
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice.controlling_failover_local_port = 27018;
+		ice.controlling_failover_local_family = AF_INET;
+		ice.controlling_failover_socket = local_socket;
+		memcpy(ice.controlling_failover_probe_id, probe_id, 12);
+		memcpy(ice.controlling_failover_nomination_id, nomination_id, 12);
+
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_FALSE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 2, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, wrong_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			other_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27019, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET6));
+		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING;
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING;
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_FALSE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 2, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, wrong_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			other_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27019, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET6));
+		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_role_conflict_requires_authenticated_exact_transaction_and_tuple)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *alternative_addr = NULL;
+		switch_rtp_ice_t ice = { 0 };
+		static const char selected_id[13] = "selected-123";
+		static const char probe_id[13] = "probe-id-123";
+		static const char wrong_id[13] = "wrong-id-123";
+		switch_socket_t *local_socket = (switch_socket_t *)&ice;
+		switch_bool_t sent_controlling = SWITCH_FALSE;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "192.0.2.10", SWITCH_UNSPEC, 40000, 0, pool) ==
+			SWITCH_STATUS_SUCCESS, "current address");
+		fst_xcheck(switch_sockaddr_info_get(&alternative_addr, "192.0.2.20", SWITCH_UNSPEC, 50000, 0, pool) ==
+			SWITCH_STATUS_SUCCESS, "alternative address");
+
+		ice.addr = current_addr;
+		memcpy(ice.selected_pair_check_ids[0], selected_id, 12);
+		ice.selected_pair_check_controlling[0] = 1;
+		ice.selected_pair_check_remote_addr[0] = current_addr;
+		ice.selected_pair_check_count = 1;
+		ice.selected_pair_check_socket = local_socket;
+		ice.selected_pair_check_local_port = 27018;
+		ice.selected_pair_check_local_family = AF_INET;
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			selected_id, SWITCH_FALSE, local_socket, 27018, AF_INET, &sent_controlling));
+		/* A destination migration must not make the old transaction match the
+		 * new current tuple; it remains correlated to its request destination. */
+		ice.addr = alternative_addr;
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			selected_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			wrong_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			selected_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(sent_controlling);
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			selected_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+
+		/* Apply the role carried by the matched request, even if current state
+		 * changed while that transaction was in flight. */
+		ice.type = ICE_VANILLA | ICE_CONTROLLED;
+		switch_rtp_pvt_ice_role_conflict_apply(&ice, SWITCH_TRUE);
+		fst_check(ice.type & ICE_CONTROLLED);
+		ice.type = ICE_VANILLA;
+		switch_rtp_pvt_ice_role_conflict_apply(&ice, SWITCH_FALSE);
+		fst_check(!(ice.type & ICE_CONTROLLED));
+
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice.controlling_failover_idx = 1;
+		ice.controlling_failover_local_port = 27018;
+		ice.controlling_failover_local_family = AF_INET;
+		ice.controlling_failover_socket = local_socket;
+		memcpy(ice.controlling_failover_probe_id, probe_id, 12);
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			probe_id, SWITCH_TRUE, local_socket, 27019, AF_INET, &sent_controlling));
+		fst_check(switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			probe_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(sent_controlling);
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			probe_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_role_conflict_cancels_transactions_and_rotates_tie_breaker)
+	{
+		switch_rtp_ice_t rtp_ice = { 0 };
+		switch_rtp_ice_t rtcp_ice = { 0 };
+		char tie_breaker[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		char old_tie_breaker[8];
+
+		rtp_ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		rtp_ice.controlling_failover_idx = 2;
+		memcpy(rtp_ice.controlling_failover_probe_id, "probe-id-123", 12);
+		memcpy(rtp_ice.selected_pair_check_ids[0], "selected-123", 12);
+		rtp_ice.selected_pair_check_controlling[0] = 1;
+		rtp_ice.selected_pair_check_remote_addr[0] = (switch_sockaddr_t *)&rtp_ice;
+		rtp_ice.selected_pair_check_count = 1;
+		memcpy(rtp_ice.last_sent_id, "selected-123", 12);
+		memcpy(rtcp_ice.selected_pair_check_ids[0], "rtcp-check12", 12);
+		rtcp_ice.selected_pair_check_count = 1;
+
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_ice);
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtcp_ice);
+		fst_check(rtp_ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+		fst_check(rtp_ice.controlling_failover_idx == -1);
+		fst_check(!rtp_ice.selected_pair_check_count);
+		fst_check(!rtcp_ice.selected_pair_check_count);
+		fst_check(!rtp_ice.selected_pair_check_ids[0][0]);
+		fst_check(!rtp_ice.selected_pair_check_remote_addr[0]);
+		fst_check(!rtcp_ice.selected_pair_check_ids[0][0]);
+		fst_check(!rtp_ice.last_sent_id[0]);
+
+		rtp_ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING;
+		rtp_ice.controlling_failover_idx = 1;
+		memcpy(rtp_ice.controlling_failover_nomination_id, "nominate-123", 12);
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_ice);
+		fst_check(rtp_ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+		fst_check(rtp_ice.controlling_failover_idx == -1);
+		fst_check(!rtp_ice.controlling_failover_nomination_id[0]);
+
+		memcpy(old_tie_breaker, tie_breaker, sizeof(tie_breaker));
+		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(tie_breaker);
+		fst_check(memcmp(tie_breaker, old_tie_breaker, sizeof(tie_breaker)));
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_local_prflx_priority_uses_component_id)
+	{
+		fst_check(switch_rtp_pvt_ice_local_prflx_priority(SWITCH_FALSE, SWITCH_FALSE) == 0x6effffffU);
+		fst_check(switch_rtp_pvt_ice_local_prflx_priority(SWITCH_TRUE, SWITCH_TRUE) == 0x6effffffU);
+		fst_check(switch_rtp_pvt_ice_local_prflx_priority(SWITCH_TRUE, SWITCH_FALSE) == 0x6efffffeU);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_controlling_failover_retransmission_timer)
+	{
+		switch_time_t started_us = 1000000;
+
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE, 0, 0, 0, started_us) ==
+			SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us, 1,
+			started_us + 999000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us, 1,
+			started_us + 1000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, started_us, started_us + 3000000, 4,
+			started_us + 3999000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, started_us, started_us + 3000000, 4,
+			started_us + 4000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us + 4000000, 2,
+			started_us + 5000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, started_us, started_us, 1,
+			started_us + 1000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_ice_role_attributes_accept_stable_tie_breaker)
+	{
+		uint8_t buf[128] = { 0 };
+		static const char tie_breaker[8] = { 0x01, 0x23, 0x45, 0x67, 0x11, 0x22, 0x33, 0x44 };
+		switch_stun_packet_t *packet;
+		switch_stun_packet_attribute_t *attribute;
+
+		packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+		fst_check(switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker));
+		attribute = (switch_stun_packet_attribute_t *)&packet->first_attribute;
+		fst_check(ntohs(attribute->type) == SWITCH_STUN_ATTR_CONTROLLING);
+		fst_check(ntohs(attribute->length) == sizeof(tie_breaker));
+		fst_check(!memcmp(attribute->value, tie_breaker, sizeof(tie_breaker)));
+
+		memset(buf, 0, sizeof(buf));
+		packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+		fst_check(switch_stun_packet_attribute_add_controlled_value(packet, tie_breaker));
+		attribute = (switch_stun_packet_attribute_t *)&packet->first_attribute;
+		fst_check(ntohs(attribute->type) == SWITCH_STUN_ATTR_CONTROLLED);
+		fst_check(ntohs(attribute->length) == sizeof(tie_breaker));
+		fst_check(!memcmp(attribute->value, tie_breaker, sizeof(tie_breaker)));
 	}
 	FST_TEST_END()
 	FST_TEST_BEGIN(test_restart_prflx_requires_explicit_authenticated_current_generation)
@@ -481,25 +755,33 @@ FST_TEARDOWN_END()
 			switch_status_t status;
 			switch_call_cause_t cause;
 			switch_rtp_ice_t ice = { 0 };
+			switch_rtp_ice_t timeout_ice = { 0 };
 			switch_memory_pool_t *pool = NULL;
 			static switch_rtp_t *rtp_session = NULL;
 			static switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
 			const char *err = NULL;
 			ice_t ice_params = { 0 };
+			ice_t timeout_params = { 0 };
 			uint8_t tampered[128];
 			uint8_t missing_username[128];
 			uint8_t wrong_username[128];
 			uint8_t successful_request[128];
+			uint8_t controlling_request[128];
+			uint8_t nomination_response[128];
 			char bootstrap_host[80] = { 0 };
 			char learned_host[80] = { 0 };
 			char remote_host[80] = { 0 };
+			char wrong_nomination_id[13] = "wrong-id-123";
 			switch_size_t missing_username_len;
 			switch_size_t wrong_username_len;
 			switch_size_t successful_request_len;
 			switch_size_t no_use_candidate_len;
+			switch_size_t controlling_request_len;
+			switch_size_t nomination_response_len;
 			switch_sockaddr_t *remote_addr;
 			int initial_cand_idx;
 			int initial_chosen;
+			int reused_idx;
 
 			switch_core_new_memory_pool(&pool);
 			status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
@@ -514,6 +796,7 @@ FST_TEARDOWN_END()
 			switch_core_memory_pool_set_data(pool, "__session", session);
 			fst_xcheck(switch_find_local_ip(bootstrap_host, sizeof(bootstrap_host), NULL, AF_INET) == SWITCH_STATUS_SUCCESS, "switch_find_local_ip()");
 			fst_xcheck(strncmp(bootstrap_host, "127.", 4), "non-loopback bootstrap host");
+			flags[SWITCH_RTP_FLAG_RTCP_MUX] = 1;
 			rtp_session = switch_rtp_new(bootstrap_host, rx_port, tx_host, tx_port, TEST_PT, 8000, 20 * 1000, flags, "soft", &err, pool);
 			fst_xcheck(rtp_session != NULL, "switch_rtp_new()");
 			fst_check(switch_rtp_ready(rtp_session));
@@ -619,6 +902,124 @@ FST_TEARDOWN_END()
 				fst_check(ice.ice_params->cands[1][ice.proto].ready);
 				fst_check(ice.ice_params->cands[1][ice.proto].use_candidate);
 			}
+
+			memset(&ice, 0, sizeof(ice));
+			memset(&ice_params, 0, sizeof(ice_params));
+			ice.ice_params = &ice_params;
+			ice.user_ice = "remoteUfrag:localUfrag";
+			ice.ice_user = "localUfrag:remoteUfrag";
+			ice.pass = "test-local-ice-password";
+			ice.rpass = "test-remote-ice-password";
+			ice.type = ICE_VANILLA;
+			ice.proto = IPR_RTP;
+			ice.prflx_bootstrap_require_use_candidate = 1;
+			ice.initializing = 1;
+			ice.controlling_failover_idx = -1;
+			ice.prflx_bootstrap_idx = -1;
+			ice.ice_params->chosen[ice.proto] = 0;
+			ice.ice_params->cand_idx[ice.proto] = 1;
+			ice.ice_params->cands[0][ice.proto].priority = 0x6e0001ff;
+
+			no_use_candidate_len = build_authenticated_request(tampered, sizeof(tampered),
+				ice.user_ice, ice.pass, SWITCH_FALSE);
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, no_use_candidate_len);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+
+			no_use_candidate_len = build_authenticated_request_with_role(tampered, sizeof(tampered),
+				ice.user_ice, ice.pass, SWITCH_FALSE, SWITCH_FALSE, SWITCH_TRUE);
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, no_use_candidate_len);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+
+			controlling_request_len = build_authenticated_request_with_role(controlling_request,
+				sizeof(controlling_request), ice.user_ice, ice.pass, SWITCH_FALSE,
+				SWITCH_TRUE, SWITCH_FALSE);
+			fst_check(switch_stun_packet_validate_auth(controlling_request,
+				(uint32_t)controlling_request_len, ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, controlling_request, controlling_request_len);
+
+			fst_check(!ice.ready);
+			fst_check(!ice.rready);
+			fst_check(!ice.cand_responsive);
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 2);
+			fst_check(ice.ice_params->chosen[ice.proto] == 0);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING);
+			fst_check(ice.controlling_failover_idx == 1);
+			fst_check(ice.controlling_failover_nomination_id[0]);
+			fst_check(!ice.ice_params->cands[1][ice.proto].use_candidate);
+			fst_check(!ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(!ice.ice_params->cands[1][ice.proto].ready);
+
+			nomination_response_len = build_authenticated_response(nomination_response,
+				sizeof(nomination_response), ice.controlling_failover_nomination_id, "wrong-password");
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, nomination_response, nomination_response_len);
+			fst_check(!ice.ready);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING);
+			fst_check(!ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(!ice.ice_params->cands[1][ice.proto].ready);
+
+			nomination_response_len = build_authenticated_response(nomination_response,
+				sizeof(nomination_response), wrong_nomination_id, ice.rpass);
+			fst_check(switch_stun_packet_validate_auth(nomination_response,
+				(uint32_t)nomination_response_len, ice.rpass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, nomination_response, nomination_response_len);
+			fst_check(!ice.ready);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING);
+			fst_check(!ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(!ice.ice_params->cands[1][ice.proto].ready);
+
+			nomination_response_len = build_authenticated_response(nomination_response,
+				sizeof(nomination_response), ice.controlling_failover_nomination_id, ice.rpass);
+			fst_check(switch_stun_packet_validate_auth(nomination_response,
+				(uint32_t)nomination_response_len, ice.rpass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, nomination_response, nomination_response_len);
+
+			fst_check(ice.ready);
+			fst_check(ice.rready);
+			fst_check(ice.cand_responsive);
+			fst_check(ice.addr != NULL);
+			fst_check(ice.ice_params->chosen[ice.proto] == 1);
+			fst_check(ice.ice_params->cands[1][ice.proto].use_candidate);
+			fst_check(ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(ice.ice_params->cands[1][ice.proto].ready);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+			fst_check(ice.controlling_failover_idx == -1);
+			if (ice.addr) {
+				fst_check(!strcmp(switch_get_addr(learned_host, sizeof(learned_host), ice.addr), bootstrap_host));
+				fst_check(switch_sockaddr_get_port(ice.addr) == rx_port);
+			}
+			remote_addr = switch_rtp_session_get_remote_addr(rtp_session);
+			fst_check(remote_addr != NULL);
+			if (remote_addr) {
+				fst_check(!strcmp(switch_get_addr(remote_host, sizeof(remote_host), remote_addr), bootstrap_host));
+				fst_check(switch_sockaddr_get_port(remote_addr) == rx_port);
+			}
+
+			/* A startup nomination timeout leaves the uncommitted prflx slot reusable,
+			 * so a changed authenticated NAT tuple can be nominated without growing
+			 * or blocking the candidate list. */
+			timeout_ice.ice_params = &timeout_params;
+			timeout_ice.proto = IPR_RTP;
+			timeout_ice.prflx_bootstrap_idx = 1;
+			timeout_ice.controlling_failover_idx = -1;
+			timeout_ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE;
+			timeout_ice.ice_params->chosen[timeout_ice.proto] = 0;
+			timeout_ice.ice_params->cand_idx[timeout_ice.proto] = 2;
+			timeout_ice.ice_params->cands[1][timeout_ice.proto].cand_type = (char *)"prflx";
+			timeout_ice.ice_params->cands[1][timeout_ice.proto].con_addr = (char *)"192.0.2.10";
+			timeout_ice.ice_params->cands[1][timeout_ice.proto].con_port = 40000;
+			reused_idx = switch_rtp_pvt_reuse_pending_startup_prflx_candidate(rtp_session,
+				&timeout_ice, "192.0.2.20", 50000, 0x6e0001fe);
+			fst_check(reused_idx == 1);
+			fst_check(timeout_ice.ice_params->cand_idx[timeout_ice.proto] == 2);
+			fst_check(!strcmp(timeout_ice.ice_params->cands[1][timeout_ice.proto].con_addr, "192.0.2.20"));
+			fst_check(timeout_ice.ice_params->cands[1][timeout_ice.proto].con_port == 50000);
+			fst_check(timeout_ice.ice_params->cands[1][timeout_ice.proto].priority == 0x6e0001fe);
+			fst_check(!timeout_ice.ice_params->cands[1][timeout_ice.proto].responsive);
+			fst_check(!timeout_ice.ice_params->cands[1][timeout_ice.proto].ready);
+			fst_check(!timeout_ice.ice_params->cands[1][timeout_ice.proto].use_candidate);
 
 			switch_rtp_destroy(&rtp_session);
 			switch_core_session_rwunlock(session);

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -127,6 +127,78 @@ FST_TEARDOWN_END()
 		fst_check(!switch_stun_packet_validate_auth(late_use_candidate, (uint32_t)late_use_candidate_len, generated_password));
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_restart_prflx_requires_explicit_authenticated_current_generation)
+	{
+		switch_rtp_ice_t ice = { 0 };
+		switch_time_t now = 10000000;
+
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+
+		ice.restart_provisional = 1;
+		ice.restart_provisional_us = now - 1000;
+		fst_check(switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_HANDSHAKE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_FALSE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_FALSE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_FALSE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_FALSE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_FALSE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_FALSE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_FALSE, SWITCH_TRUE, 5000, now));
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_FALSE, 5000, now));
+
+		ice.restart_provisional_us = now - 6000000;
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!ice.restart_provisional);
+		fst_check(!ice.restart_provisional_us);
+
+		ice.restart_provisional = 1;
+		ice.restart_provisional_us = now + 1;
+		fst_check(!switch_rtp_pvt_restart_prflx_allowed(&ice, DS_READY, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, SWITCH_TRUE, 5000, now));
+		fst_check(!ice.restart_provisional);
+		fst_check(!ice.restart_provisional_us);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_preserve_active_dtls_tuple_requires_exact_current_peer)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *different_port_addr = NULL;
+		switch_sockaddr_t *handshake_peer_addr = NULL;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "192.0.2.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current address");
+		fst_xcheck(switch_sockaddr_info_get(&different_port_addr, "192.0.2.10", SWITCH_UNSPEC, 40002, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"different-port address");
+		fst_xcheck(switch_sockaddr_info_get(&handshake_peer_addr, "192.0.2.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"handshake peer address");
+
+		fst_check(switch_rtp_pvt_should_preserve_active_dtls_tuple(current_addr, handshake_peer_addr, DS_HANDSHAKE, SWITCH_TRUE, SWITCH_FALSE));
+		fst_check(!switch_rtp_pvt_should_preserve_active_dtls_tuple(different_port_addr, handshake_peer_addr, DS_HANDSHAKE, SWITCH_TRUE, SWITCH_FALSE));
+		fst_check(!switch_rtp_pvt_should_preserve_active_dtls_tuple(current_addr, handshake_peer_addr, DS_OFF, SWITCH_TRUE, SWITCH_FALSE));
+		fst_check(!switch_rtp_pvt_should_preserve_active_dtls_tuple(current_addr, handshake_peer_addr, DS_READY, SWITCH_TRUE, SWITCH_FALSE));
+		fst_check(!switch_rtp_pvt_should_preserve_active_dtls_tuple(current_addr, handshake_peer_addr, DS_HANDSHAKE, SWITCH_FALSE, SWITCH_FALSE));
+		fst_check(!switch_rtp_pvt_should_preserve_active_dtls_tuple(current_addr, handshake_peer_addr, DS_HANDSHAKE, SWITCH_TRUE, SWITCH_TRUE));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
 		FST_SESSION_BEGIN(test_stun_msg)
 		{
 				/* Binding Success Response */

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -89,7 +89,15 @@ FST_TEARDOWN_END()
 		};
 		/* RFC 5769 Section 2.1 request vector. */
 		static const char password[] = "VOkJxbRl1RmTxUk/WvJxBt";
+		static const char generated_password[] = "test-local-ice-password";
 		uint8_t tampered[sizeof(authenticated_request)];
+		uint8_t late_use_candidate[128];
+		switch_size_t late_use_candidate_len;
+		switch_size_t fingerprint_offset;
+		uint16_t attribute_type;
+		uint16_t attribute_length = 0;
+		uint16_t message_length;
+		uint32_t fingerprint;
 
 		fst_check(switch_stun_packet_validate_auth(authenticated_request, sizeof(authenticated_request), password));
 		fst_check(!switch_stun_packet_validate_auth(authenticated_request, sizeof(authenticated_request), "wrong-password"));
@@ -101,6 +109,22 @@ FST_TEARDOWN_END()
 		memcpy(tampered, authenticated_request, sizeof(tampered));
 		tampered[104] ^= 0x01;
 		fst_check(!switch_stun_packet_validate_auth(tampered, sizeof(tampered), password));
+
+		late_use_candidate_len = build_authenticated_request(late_use_candidate, sizeof(late_use_candidate), "remote:local", generated_password, SWITCH_FALSE);
+		fst_check(switch_stun_packet_validate_auth(late_use_candidate, (uint32_t)late_use_candidate_len, generated_password));
+
+		fingerprint_offset = late_use_candidate_len - 8;
+		memmove(late_use_candidate + fingerprint_offset + 4, late_use_candidate + fingerprint_offset, 8);
+		attribute_type = htons(SWITCH_STUN_ATTR_USE_CAND);
+		memcpy(late_use_candidate + fingerprint_offset, &attribute_type, sizeof(attribute_type));
+		memcpy(late_use_candidate + fingerprint_offset + 2, &attribute_length, sizeof(attribute_length));
+		memcpy(&message_length, late_use_candidate + 2, sizeof(message_length));
+		message_length = htons((uint16_t)(ntohs(message_length) + 4));
+		memcpy(late_use_candidate + 2, &message_length, sizeof(message_length));
+		late_use_candidate_len += 4;
+		fingerprint = htonl(switch_crc32_8bytes(late_use_candidate, (uint32_t)fingerprint_offset + 4) ^ 0x5354554e);
+		memcpy(late_use_candidate + fingerprint_offset + 8, &fingerprint, sizeof(fingerprint));
+		fst_check(!switch_stun_packet_validate_auth(late_use_candidate, (uint32_t)late_use_candidate_len, generated_password));
 	}
 	FST_TEST_END()
 		FST_SESSION_BEGIN(test_stun_msg)

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -211,6 +211,58 @@ FST_TEARDOWN_END()
 			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT);
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_authenticated_recovery_nomination_syncs_nonmux_ice_addr)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *remote_addr = NULL;
+		switch_sockaddr_t *nominated_addr = NULL;
+		switch_sockaddr_t *other_addr = NULL;
+		switch_sockaddr_t *ice_addr = NULL;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "198.51.100.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current address");
+		fst_xcheck(switch_sockaddr_info_get(&remote_addr, "198.51.100.20", SWITCH_UNSPEC, 50000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"remote address");
+		fst_xcheck(switch_sockaddr_info_get(&nominated_addr, "198.51.100.20", SWITCH_UNSPEC, 50000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"nominated address");
+		fst_xcheck(switch_sockaddr_info_get(&other_addr, "198.51.100.20", SWITCH_UNSPEC, 50002, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"other address");
+
+		ice_addr = current_addr;
+		fst_check(switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, nominated_addr,
+			DS_HANDSHAKE, SWITCH_FALSE, SWITCH_FALSE, SWITCH_TRUE,
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT));
+		fst_check(ice_addr == remote_addr);
+		fst_check(!switch_rtp_pvt_should_guard_recovery_dtls_tuple(ice_addr, nominated_addr, DS_HANDSHAKE,
+			SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_NONE));
+
+		ice_addr = current_addr;
+		fst_check(!switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, nominated_addr,
+			DS_HANDSHAKE, SWITCH_FALSE, SWITCH_FALSE, SWITCH_TRUE, SWITCH_RTP_RECOVERY_NOMINATION_PERSISTED));
+		fst_check(ice_addr == current_addr);
+		fst_check(!switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, other_addr,
+			DS_HANDSHAKE, SWITCH_FALSE, SWITCH_FALSE, SWITCH_TRUE,
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT));
+		fst_check(ice_addr == current_addr);
+		fst_check(!switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, nominated_addr,
+			DS_HANDSHAKE, SWITCH_TRUE, SWITCH_FALSE, SWITCH_TRUE,
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT));
+		fst_check(!switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, nominated_addr,
+			DS_HANDSHAKE, SWITCH_FALSE, SWITCH_TRUE, SWITCH_TRUE,
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT));
+		fst_check(!switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, nominated_addr,
+			DS_READY, SWITCH_FALSE, SWITCH_FALSE, SWITCH_TRUE,
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT));
+		fst_check(!switch_rtp_pvt_sync_authenticated_recovery_ice_addr(&ice_addr, remote_addr, nominated_addr,
+			DS_SETUP, SWITCH_FALSE, SWITCH_FALSE, SWITCH_FALSE,
+			SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT));
+		fst_check(ice_addr == current_addr);
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
 	FST_TEST_BEGIN(test_recovery_dtls_restart_tuple_mutation_policy)
 	{
 		switch_memory_pool_t *pool = NULL;

--- a/tests/unit/switch_trickle_ice.c
+++ b/tests/unit/switch_trickle_ice.c
@@ -1,6 +1,7 @@
 #include <switch.h>
 #include <switch_rtp.h>
 #include <test/switch_test.h>
+#include <private/switch_rtp_pvt.h>
 #include "switch_telnyx.h"
 #include <sofia-sip/sdp.h>
 
@@ -329,6 +330,76 @@ FCT_BGN()
 			if (telnyx_pool) { switch_core_destroy_memory_pool(&telnyx_pool); telnyx_pool = NULL; }
 		}
 		FCT_TEARDOWN_END();
+
+		FCT_TEST_BGN(restart_ice_rearms_unchanged_media)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_rtp_t *rtp = NULL;
+			switch_status_t status;
+			const char *err = NULL;
+			char ice_user[256] = "";
+			switch_bool_t has_addr = SWITCH_FALSE;
+			ice_t old_ice;
+			uint8_t match;
+			uint8_t proceed = 0;
+			const char *restart_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118196 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"a=group:BUNDLE 0\n"
+				"m=audio 9 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 0.0.0.0\n"
+				"a=ice-ufrag:restartRemoteUfrag\n"
+				"a=ice-pwd:restartRemotePassword123456\n"
+				"a=ice-options:trickle\n"
+				"a=rtcp-mux\n"
+				"a=setup:active\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=fingerprint:sha-256 17:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
+				"a=mid:0\n";
+
+			memset(&old_ice, 0, sizeof(old_ice));
+			old_ice.cands[0][IPR_RTP].priority = 1;
+			old_ice.cands[0][IPR_RTP].con_addr = "0.0.0.0";
+			old_ice.cands[0][IPR_RTP].con_port = 9;
+			old_ice.cands[0][IPR_RTP].ready = 1;
+
+			status = make_session_and_rtp_with_sdp(&session, &rtp, NULL, NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && rtp);
+			channel = switch_core_session_get_channel(session);
+			fst_requires(channel != NULL);
+
+			status = switch_rtp_set_remote_address(rtp, "0.0.0.0", 9, 0, SWITCH_FALSE, &err);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			status = switch_rtp_activate_ice(rtp, "oldRemoteUfrag", "oldLocalUfrag",
+				"oldLocalPassword", "oldRemotePassword", IPR_RTP, ICE_VANILLA, &old_ice);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP, ice_user, sizeof(ice_user), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_check_string_equals(ice_user, "oldRemoteUfrag:oldLocalUfrag");
+			fst_check(has_addr == SWITCH_TRUE);
+
+			switch_core_media_clear_ice(session);
+			switch_channel_set_flag(channel, CF_REINVITE);
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
+			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
+			fst_requires(match != 0);
+			status = switch_core_media_activate_rtp(session);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			memset(ice_user, 0, sizeof(ice_user));
+			has_addr = SWITCH_TRUE;
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP, ice_user, sizeof(ice_user), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_check(strstr(ice_user, "restartRemoteUfrag") != NULL);
+			fst_check(has_addr == SWITCH_FALSE);
+
+			cleanup_session_and_media(session);
+		}
+		FCT_TEST_END();
 
 		/* 1) Registration toggles + candidate emit */
 		FCT_TEST_BGN(registration_and_emit_basic)

--- a/tests/unit/switch_trickle_ice.c
+++ b/tests/unit/switch_trickle_ice.c
@@ -511,7 +511,7 @@ FCT_BGN()
 		}
 		FCT_TEST_END();
 
-		FCT_TEST_BGN(local_answer_restart_rearms_rtp_and_rtcp_with_unchanged_remote_credentials)
+		FCT_TEST_BGN(local_answer_recovery_with_ready_candidates_avoids_duplicate_ice_activation)
 		{
 			switch_core_session_t *session = NULL;
 			switch_channel_t *channel = NULL;
@@ -556,6 +556,23 @@ FCT_BGN()
 				"a=sendrecv\n"
 				"a=fingerprint:sha-256 17:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
 				"a=mid:0\n";
+			const char *recovery_remote_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118199 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:stableRemoteUfrag\n"
+				"a=ice-pwd:stableRemotePassword123456\n"
+				"a=candidate:1 1 udp 2130706431 127.0.0.1 18215 typ host\n"
+				"a=candidate:2 2 udp 2130706430 127.0.0.1 18216 typ host\n"
+				"a=rtcp:18216 IN IP4 127.0.0.1\n"
+				"a=setup:active\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=fingerprint:sha-256 18:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
+				"a=mid:0\n";
 
 			status = make_session_and_rtp_with_sdp_ex(&session, &rtp, &sdp_session, &parser,
 				same_remote_sdp, "PCMU", SWITCH_FALSE, SWITCH_TRUE);
@@ -589,7 +606,7 @@ FCT_BGN()
 			switch_core_media_clear_ice(session);
 			switch_channel_set_flag(channel, CF_REINVITE);
 			switch_channel_set_flag(channel, CF_RECOVERING);
-			match = switch_core_media_negotiate_sdp(session, same_remote_sdp, &proceed, SDP_ANSWER);
+			match = switch_core_media_negotiate_sdp(session, recovery_remote_sdp, &proceed, SDP_ANSWER);
 			fst_requires(match != 0);
 			status = switch_core_media_activate_rtp(session);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
@@ -623,7 +640,7 @@ FCT_BGN()
 		}
 		FCT_TEST_END();
 
-		FCT_TEST_BGN(restart_ice_rotates_credentials_and_rearms_unchanged_media)
+		FCT_TEST_BGN(recovery_with_provisional_candidates_rearms_prflx_bootstrap)
 		{
 			switch_core_session_t *session = NULL;
 			switch_channel_t *channel = NULL;
@@ -661,7 +678,7 @@ FCT_BGN()
 				"a=setup:active\n"
 				"a=rtpmap:0 PCMU/8000\n"
 				"a=sendrecv\n"
-				"a=fingerprint:sha-256 17:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
+				"a=fingerprint:sha-256 18:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
 				"a=mid:0\n";
 
 			status = make_session_and_rtp_with_sdp(&session, &rtp, &sdp_session, &parser);
@@ -690,6 +707,7 @@ FCT_BGN()
 
 			switch_core_media_clear_ice(session);
 			switch_channel_set_flag(channel, CF_REINVITE);
+			switch_channel_set_flag(channel, CF_RECOVERING);
 			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
 			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
 			fst_requires(match != 0);
@@ -723,7 +741,7 @@ FCT_BGN()
 		}
 		FCT_TEST_END();
 
-		FCT_TEST_BGN(unbundled_video_ready_restart_rearms_rtp_and_rtcp)
+		FCT_TEST_BGN(unbundled_video_ready_recovery_avoids_duplicate_ice_activation)
 		{
 			switch_core_session_t *session = NULL;
 			switch_channel_t *channel = NULL;
@@ -818,6 +836,7 @@ FCT_BGN()
 			switch_channel_clear_flag(channel, CF_VIDEO);
 			switch_core_media_clear_ice(session);
 			switch_channel_set_flag(channel, CF_REINVITE);
+			switch_channel_set_flag(channel, CF_RECOVERING);
 			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
 			fst_requires(match != 0);
 			switch_core_media_gen_local_sdp(session, SDP_ANSWER, NULL, 0, NULL, 0);
@@ -858,7 +877,7 @@ FCT_BGN()
 		}
 		FCT_TEST_END();
 
-		FCT_TEST_BGN(unbundled_video_provisional_restart_rearms_rtp_and_rtcp)
+		FCT_TEST_BGN(unbundled_video_provisional_recovery_rearms_prflx_bootstrap)
 		{
 			switch_core_session_t *session = NULL;
 			switch_channel_t *channel = NULL;
@@ -946,6 +965,7 @@ FCT_BGN()
 			switch_channel_clear_flag(channel, CF_VIDEO);
 			switch_core_media_clear_ice(session);
 			switch_channel_set_flag(channel, CF_REINVITE);
+			switch_channel_set_flag(channel, CF_RECOVERING);
 			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
 			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
 			fst_requires(match != 0);

--- a/tests/unit/switch_trickle_ice.c
+++ b/tests/unit/switch_trickle_ice.c
@@ -39,6 +39,44 @@ static switch_status_t copy_sdp_attribute(const char *sdp, const char *attribute
 	return SWITCH_STATUS_SUCCESS;
 }
 
+static switch_status_t copy_sdp_media_attribute(const char *sdp, const char *media, const char *attribute,
+		char *value, switch_size_t value_len)
+{
+	char media_needle[64];
+	char attr_needle[64];
+	const char *section;
+	const char *next_section;
+	const char *start;
+	const char *end;
+	switch_size_t len;
+
+	if (zstr(sdp) || zstr(media) || zstr(attribute) || !value || !value_len) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_snprintf(media_needle, sizeof(media_needle), "m=%s ", media);
+	if (!(section = strstr(sdp, media_needle))) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	next_section = strstr(section + strlen(media_needle), "\nm=");
+	switch_snprintf(attr_needle, sizeof(attr_needle), "a=%s:", attribute);
+	if (!(start = strstr(section, attr_needle)) || (next_section && start > next_section)) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	start += strlen(attr_needle);
+	end = strpbrk(start, "\r\n");
+	len = end ? (switch_size_t)(end - start) : strlen(start);
+	if (!len || len >= value_len) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	memcpy(value, start, len);
+	value[len] = '\0';
+	return SWITCH_STATUS_SUCCESS;
+}
+
 typedef struct trickle_captured_s {
 	int called;
 	int last_mline;
@@ -140,14 +178,14 @@ static void cleanup_session_and_media(switch_core_session_t *session)
 
 	if (!session) return;
 
-	/* Clean up media handle and RTP sessions to free DTLS contexts */
+	switch_channel_clear_flag(switch_core_session_get_channel(session), CF_VIDEO_PASSIVE);
+	switch_core_session_wake_video_thread(session);
+	switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 	smh = switch_core_session_get_media_handle(session);
 	if (smh) {
-		/* Deactivate RTP which will call switch_rtp_destroy internally */
 		switch_core_media_deactivate_rtp(session);
 	}
 
-	switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 	switch_core_session_rwunlock(session);
 }
 
@@ -160,10 +198,14 @@ static void cleanup_session_media_and_sdp(switch_core_session_t *session, void *
 	cleanup_session_and_media(session);
 }
 
-static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out_session,
-                                                      switch_rtp_t **out_rtp,
-                                                      void **out_sdp_session,
-                                                      sdp_parser_t **out_parser)
+static switch_status_t make_session_and_rtp_with_sdp_ex(switch_core_session_t **out_session,
+                                                         switch_rtp_t **out_rtp,
+                                                         void **out_sdp_session,
+                                                         sdp_parser_t **out_parser,
+                                                         const char *offer_sdp,
+                                                         const char *codec_string,
+                                                         switch_bool_t use_bundle,
+                                                         switch_bool_t activate_rtp)
 {
 	switch_status_t st;
 	switch_call_cause_t cause = SWITCH_CAUSE_NONE, cancel = SWITCH_CAUSE_NONE;
@@ -174,6 +216,7 @@ static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out
 	switch_channel_t *chan = NULL;
 	char *r_sdp;
 	uint8_t match = 0, p = 0;
+	const char *selected_codec = zstr(codec_string) ? "PCMU" : codec_string;
 
 	const char *br = "{"
 		"absolute_codec_string=PCMU,"
@@ -206,8 +249,8 @@ static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out
 	chan = switch_core_session_get_channel(session);
 
 	mparams = switch_core_session_alloc(session, sizeof(switch_core_media_params_t));
-	mparams->inbound_codec_string = switch_core_session_strdup(session, "PCMU");
-	mparams->outbound_codec_string = switch_core_session_strdup(session, "PCMU");
+	mparams->inbound_codec_string = switch_core_session_strdup(session, selected_codec);
+	mparams->outbound_codec_string = switch_core_session_strdup(session, selected_codec);
 	mparams->rtpip = switch_core_session_strdup(session, (char *)rx_host);
 	mparams->rtpip4 = switch_core_session_strdup(session, (char *)rx_host);
 
@@ -217,7 +260,8 @@ static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out
 		return SWITCH_STATUS_FALSE;
 	}
 
-	switch_channel_set_variable(chan, "absolute_codec_string", "PCMU");
+	switch_channel_set_variable(chan, "absolute_codec_string", selected_codec);
+	switch_channel_set_variable(chan, "rtp_use_bundle", use_bundle ? "true" : "false");
 	switch_channel_set_variable(chan, "send_silence_when_idle", "-1");
 	switch_channel_set_variable(chan, "rtp_timer_name", "soft");
 	switch_channel_set_variable(chan, "media_timeout", "1000");
@@ -249,6 +293,10 @@ static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out
 			"a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\n"
 			"a=msid:de61dc02-51d0-4164-9d7a-b74141a4548e 9dc86822-54a5-4506-8476-9be2238be778\n"
 			"a=rtcp-rsize\n");
+
+	if (!zstr(offer_sdp)) {
+		r_sdp = switch_core_session_strdup(session, offer_sdp);
+	}
 
 	if (switch_core_media_prepare_codecs(session, SWITCH_FALSE) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to prepare codecs\n");
@@ -293,14 +341,14 @@ static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to choose ports\n");
 		goto fail;
 	}
-	if (switch_core_media_activate_rtp(session) != SWITCH_STATUS_SUCCESS) {
+	if (activate_rtp && switch_core_media_activate_rtp(session) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to activate RTP\n");
 		goto fail;
 	}
 
 	*out_session = session;
-	*out_rtp = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO);
-	if (!*out_rtp) {
+	*out_rtp = activate_rtp ? switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO) : NULL;
+	if (activate_rtp && !*out_rtp) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to get RTP session\n");
 		goto fail;
 	}
@@ -311,6 +359,15 @@ fail:
 	switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 	switch_core_session_rwunlock(session);
 	return SWITCH_STATUS_FALSE;
+}
+
+static switch_status_t make_session_and_rtp_with_sdp(switch_core_session_t **out_session,
+                                                      switch_rtp_t **out_rtp,
+                                                      void **out_sdp_session,
+                                                      sdp_parser_t **out_parser)
+{
+	return make_session_and_rtp_with_sdp_ex(out_session, out_rtp, out_sdp_session, out_parser,
+		NULL, "PCMU", SWITCH_TRUE, SWITCH_TRUE);
 }
 
 static volatile int trickle_ev_seen = 0;
@@ -359,9 +416,10 @@ FCT_BGN()
 		}
 		FCT_TEARDOWN_END();
 
-		FCT_TEST_BGN(same_generation_trickle_preserves_credentials)
+		FCT_TEST_BGN(same_generation_clear_preserves_credentials_and_rearms_unchanged_media)
 		{
 			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
 			switch_media_handle_t *smh = NULL;
 			switch_rtp_t *rtp = NULL;
 			switch_status_t status;
@@ -370,15 +428,41 @@ FCT_BGN()
 			char initial_ice_user[256] = "";
 			char initial_local_pwd[256] = "";
 			char initial_remote_pwd[256] = "";
-			char trickled_ice_user[256] = "";
-			char trickled_local_pwd[256] = "";
-			char trickled_remote_pwd[256] = "";
+			char rearmed_ice_user[256] = "";
+			char rearmed_local_pwd[256] = "";
+			char rearmed_remote_pwd[256] = "";
+			char answer_local_ufrag[256] = "";
+			char answer_local_pwd[256] = "";
+			const char *initial_local_ufrag;
+			const char *rearmed_local_ufrag;
+			const char *local_sdp;
 			switch_bool_t has_addr = SWITCH_FALSE;
+			uint8_t match;
+			uint8_t proceed = 0;
+			const char *same_generation_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118197 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"a=group:BUNDLE 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 50.114.144.39\n"
+				"a=ice-ufrag:aZJpsl00bYnjrOZtkCFMtKhFC/CHAfcv\n"
+				"a=ice-pwd:aNniSnLLp43SSsJrz6TNPty1zPrxZNzh\n"
+				"a=ice-options:trickle\n"
+				"a=candidate:265031753 1 udp 1685921533 50.114.144.39 18215 typ srflx raddr 100.69.211.204 rport 54081\n"
+				"a=rtcp-mux\n"
+				"a=setup:active\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=fingerprint:sha-256 17:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
+				"a=mid:0\n";
 
 			status = make_session_and_rtp_with_sdp(&session, &rtp, &sdp_session, &parser);
 			fst_requires(status == SWITCH_STATUS_SUCCESS && session && rtp && sdp_session && parser);
+			channel = switch_core_session_get_channel(session);
 			smh = switch_core_session_get_media_handle(session);
-			fst_requires(smh != NULL);
+			fst_requires(channel != NULL && smh != NULL);
 
 			status = switch_core_media_trickle_remote_candidate_and_recheck(
 				session, smh, sdp_session, SDP_TYPE_REQUEST, "0", 0,
@@ -389,24 +473,151 @@ FCT_BGN()
 				initial_local_pwd, sizeof(initial_local_pwd),
 				initial_remote_pwd, sizeof(initial_remote_pwd), &has_addr);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
-			fst_requires(initial_ice_user[0] != '\0' && initial_local_pwd[0] != '\0' && initial_remote_pwd[0] != '\0');
+			initial_local_ufrag = strchr(initial_ice_user, ':');
+			fst_requires(initial_local_ufrag != NULL && initial_local_ufrag[1] != '\0');
+			initial_local_ufrag++;
 			fst_check(has_addr == SWITCH_TRUE);
 
-			status = switch_core_media_trickle_remote_candidate_and_recheck(
-				session, smh, sdp_session, SDP_TYPE_REQUEST, "0", 0,
-				"candidate:265031754 1 udp 1685921534 50.114.144.40 18216 typ srflx raddr 100.69.211.204 rport 54081", 0);
+			switch_core_media_clear_ice(session);
+			switch_channel_set_flag(channel, CF_REINVITE);
+			match = switch_core_media_negotiate_sdp(session, same_generation_sdp, &proceed, SDP_OFFER);
+			fst_requires(match != 0);
+			switch_core_media_gen_local_sdp(session, SDP_ANSWER, NULL, 0, NULL, 0);
+			local_sdp = switch_channel_get_variable(channel, "rtp_local_sdp_str");
+			fst_requires(copy_sdp_attribute(local_sdp, "ice-ufrag", answer_local_ufrag,
+				sizeof(answer_local_ufrag)) == SWITCH_STATUS_SUCCESS);
+			fst_requires(copy_sdp_attribute(local_sdp, "ice-pwd", answer_local_pwd,
+				sizeof(answer_local_pwd)) == SWITCH_STATUS_SUCCESS);
+			status = switch_core_media_activate_rtp(session);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
 
 			has_addr = SWITCH_FALSE;
 			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
-				trickled_ice_user, sizeof(trickled_ice_user),
-				trickled_local_pwd, sizeof(trickled_local_pwd),
-				trickled_remote_pwd, sizeof(trickled_remote_pwd), &has_addr);
+				rearmed_ice_user, sizeof(rearmed_ice_user),
+				rearmed_local_pwd, sizeof(rearmed_local_pwd),
+				rearmed_remote_pwd, sizeof(rearmed_remote_pwd), &has_addr);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
-			fst_check_string_equals(trickled_ice_user, initial_ice_user);
-			fst_check_string_equals(trickled_local_pwd, initial_local_pwd);
-			fst_check_string_equals(trickled_remote_pwd, initial_remote_pwd);
+			rearmed_local_ufrag = strchr(rearmed_ice_user, ':');
+			fst_requires(rearmed_local_ufrag != NULL && rearmed_local_ufrag[1] != '\0');
+			rearmed_local_ufrag++;
+			fst_check_string_equals(rearmed_ice_user, initial_ice_user);
+			fst_check_string_equals(rearmed_local_pwd, initial_local_pwd);
+			fst_check_string_equals(rearmed_remote_pwd, initial_remote_pwd);
+			fst_check_string_equals(answer_local_ufrag, initial_local_ufrag);
+			fst_check_string_equals(answer_local_pwd, initial_local_pwd);
 			fst_check(has_addr == SWITCH_TRUE);
+
+			cleanup_session_media_and_sdp(session, sdp_session, parser);
+		}
+		FCT_TEST_END();
+
+		FCT_TEST_BGN(local_answer_restart_rearms_rtp_and_rtcp_with_unchanged_remote_credentials)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_rtp_t *rtp = NULL;
+			void *sdp_session = NULL;
+			sdp_parser_t *parser = NULL;
+			switch_status_t status;
+			uint8_t match;
+			uint8_t proceed = 0;
+			char initial_rtp_user[256] = "";
+			char initial_rtp_local_pwd[256] = "";
+			char initial_rtp_remote_pwd[256] = "";
+			char initial_rtcp_user[256] = "";
+			char initial_rtcp_local_pwd[256] = "";
+			char initial_rtcp_remote_pwd[256] = "";
+			char offered_local_ufrag[256] = "";
+			char offered_local_pwd[256] = "";
+			char restarted_rtp_user[256] = "";
+			char restarted_rtp_local_pwd[256] = "";
+			char restarted_rtp_remote_pwd[256] = "";
+			char restarted_rtcp_user[256] = "";
+			char restarted_rtcp_local_pwd[256] = "";
+			char restarted_rtcp_remote_pwd[256] = "";
+			const char *initial_local_ufrag;
+			const char *restarted_local_ufrag;
+			const char *local_sdp;
+			switch_bool_t has_addr = SWITCH_FALSE;
+			const char *same_remote_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118198 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:stableRemoteUfrag\n"
+				"a=ice-pwd:stableRemotePassword123456\n"
+				"a=candidate:1 1 udp 2130706431 127.0.0.1 18215 typ host\n"
+				"a=candidate:2 2 udp 2130706430 127.0.0.1 18216 typ host\n"
+				"a=rtcp:18216 IN IP4 127.0.0.1\n"
+				"a=setup:active\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=fingerprint:sha-256 17:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
+				"a=mid:0\n";
+
+			status = make_session_and_rtp_with_sdp_ex(&session, &rtp, &sdp_session, &parser,
+				same_remote_sdp, "PCMU", SWITCH_FALSE, SWITCH_TRUE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && rtp && sdp_session && parser);
+			channel = switch_core_session_get_channel(session);
+			fst_requires(channel != NULL);
+
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				initial_rtp_user, sizeof(initial_rtp_user), initial_rtp_local_pwd, sizeof(initial_rtp_local_pwd),
+				initial_rtp_remote_pwd, sizeof(initial_rtp_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+			initial_local_ufrag = strchr(initial_rtp_user, ':');
+			fst_requires(initial_local_ufrag != NULL && initial_local_ufrag[1] != '\0');
+			initial_local_ufrag++;
+			has_addr = SWITCH_FALSE;
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTCP,
+				initial_rtcp_user, sizeof(initial_rtcp_user), initial_rtcp_local_pwd, sizeof(initial_rtcp_local_pwd),
+				initial_rtcp_remote_pwd, sizeof(initial_rtcp_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+
+			switch_core_session_stop_media(session);
+			switch_core_media_gen_local_sdp(session, SDP_OFFER, NULL, 0, NULL, 0);
+			local_sdp = switch_channel_get_variable(channel, "rtp_local_sdp_str");
+			fst_requires(copy_sdp_attribute(local_sdp, "ice-ufrag", offered_local_ufrag,
+				sizeof(offered_local_ufrag)) == SWITCH_STATUS_SUCCESS);
+			fst_requires(copy_sdp_attribute(local_sdp, "ice-pwd", offered_local_pwd,
+				sizeof(offered_local_pwd)) == SWITCH_STATUS_SUCCESS);
+			fst_check(strcmp(offered_local_ufrag, initial_local_ufrag) != 0);
+			fst_check(strcmp(offered_local_pwd, initial_rtp_local_pwd) != 0);
+
+			switch_core_media_clear_ice(session);
+			switch_channel_set_flag(channel, CF_REINVITE);
+			switch_channel_set_flag(channel, CF_RECOVERING);
+			match = switch_core_media_negotiate_sdp(session, same_remote_sdp, &proceed, SDP_ANSWER);
+			fst_requires(match != 0);
+			status = switch_core_media_activate_rtp(session);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			has_addr = SWITCH_FALSE;
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				restarted_rtp_user, sizeof(restarted_rtp_user), restarted_rtp_local_pwd, sizeof(restarted_rtp_local_pwd),
+				restarted_rtp_remote_pwd, sizeof(restarted_rtp_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+			restarted_local_ufrag = strchr(restarted_rtp_user, ':');
+			fst_requires(restarted_local_ufrag != NULL && restarted_local_ufrag[1] != '\0');
+			restarted_local_ufrag++;
+			fst_check(!strncmp(restarted_rtp_user, "stableRemoteUfrag:", strlen("stableRemoteUfrag:")));
+			fst_check_string_equals(restarted_rtp_remote_pwd, "stableRemotePassword123456");
+			fst_check_string_equals(restarted_local_ufrag, offered_local_ufrag);
+			fst_check_string_equals(restarted_rtp_local_pwd, offered_local_pwd);
+
+			has_addr = SWITCH_FALSE;
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTCP,
+				restarted_rtcp_user, sizeof(restarted_rtcp_user), restarted_rtcp_local_pwd, sizeof(restarted_rtcp_local_pwd),
+				restarted_rtcp_remote_pwd, sizeof(restarted_rtcp_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+			fst_check_string_equals(restarted_rtcp_user, restarted_rtp_user);
+			fst_check_string_equals(restarted_rtcp_local_pwd, offered_local_pwd);
+			fst_check_string_equals(restarted_rtcp_remote_pwd, "stableRemotePassword123456");
+			fst_check(strcmp(restarted_rtcp_user, initial_rtcp_user) != 0);
+			fst_check(strcmp(restarted_rtcp_local_pwd, initial_rtcp_local_pwd) != 0);
+			fst_check_string_equals(initial_rtp_remote_pwd, initial_rtcp_remote_pwd);
 
 			cleanup_session_media_and_sdp(session, sdp_session, parser);
 		}
@@ -507,6 +718,268 @@ FCT_BGN()
 			fst_check_string_equals(restarted_sdp_local_ufrag, restarted_local_ufrag);
 			fst_check_string_equals(restarted_sdp_local_pwd, restarted_local_pwd);
 			fst_check(has_addr == SWITCH_FALSE);
+
+			cleanup_session_media_and_sdp(session, sdp_session, parser);
+		}
+		FCT_TEST_END();
+
+		FCT_TEST_BGN(unbundled_video_ready_restart_rearms_rtp_and_rtcp)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_rtp_t *audio_rtp = NULL;
+			switch_rtp_t *video_rtp = NULL;
+			void *sdp_session = NULL;
+			sdp_parser_t *parser = NULL;
+			switch_status_t status;
+			uint8_t match;
+			uint8_t proceed = 0;
+			char initial_video_user[256] = "";
+			char initial_video_pwd[256] = "";
+			char initial_video_remote_pwd[256] = "";
+			char offered_video_ufrag[256] = "";
+			char offered_video_pwd[256] = "";
+			char restarted_video_user[256] = "";
+			char restarted_video_pwd[256] = "";
+			char restarted_video_remote_pwd[256] = "";
+			char restarted_video_rtcp_user[256] = "";
+			char restarted_video_rtcp_pwd[256] = "";
+			char restarted_video_rtcp_remote_pwd[256] = "";
+			const char *initial_video_local_ufrag;
+			const char *restarted_video_local_ufrag;
+			const char *local_sdp;
+			switch_bool_t has_addr = SWITCH_FALSE;
+			const char *audio_video_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118195 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:audioStableUfrag\n"
+				"a=ice-pwd:audioStablePassword123456\n"
+				"a=candidate:1 1 udp 2130706431 127.0.0.1 18215 typ host\n"
+				"a=candidate:2 2 udp 2130706430 127.0.0.1 18216 typ host\n"
+				"a=rtcp:18216 IN IP4 127.0.0.1\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=mid:0\n"
+				"m=video 18217 UDP/TLS/RTP/SAVPF 96\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:videoStableUfrag\n"
+				"a=ice-pwd:videoStablePassword123456\n"
+				"a=candidate:3 1 udp 2130706431 127.0.0.1 18217 typ host\n"
+				"a=candidate:4 2 udp 2130706430 127.0.0.1 18218 typ host\n"
+				"a=rtcp:18218 IN IP4 127.0.0.1\n"
+				"a=rtpmap:96 VP8/90000\n"
+				"a=sendrecv\n"
+				"a=mid:1\n";
+			const char *restart_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118196 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:audioStableUfrag\n"
+				"a=ice-pwd:audioStablePassword123456\n"
+				"a=candidate:1 1 udp 2130706431 127.0.0.1 18215 typ host\n"
+				"a=candidate:2 2 udp 2130706430 127.0.0.1 18216 typ host\n"
+				"a=rtcp:18216 IN IP4 127.0.0.1\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=mid:0\n"
+				"m=video 18217 UDP/TLS/RTP/SAVPF 96\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:videoRestartUfrag\n"
+				"a=ice-pwd:videoRestartPassword123456\n"
+				"a=candidate:3 1 udp 2130706431 127.0.0.1 18217 typ host\n"
+				"a=candidate:4 2 udp 2130706430 127.0.0.1 18218 typ host\n"
+				"a=rtcp:18218 IN IP4 127.0.0.1\n"
+				"a=rtpmap:96 VP8/90000\n"
+				"a=sendrecv\n"
+				"a=mid:1\n";
+
+			status = make_session_and_rtp_with_sdp_ex(&session, &audio_rtp, &sdp_session, &parser,
+				audio_video_sdp, "PCMU,VP8", SWITCH_FALSE, SWITCH_TRUE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && audio_rtp && sdp_session && parser);
+			channel = switch_core_session_get_channel(session);
+			video_rtp = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_VIDEO);
+			fst_requires(channel != NULL && video_rtp != NULL);
+
+			status = switch_rtp_pvt_get_ice_state(video_rtp, IPR_RTP,
+				initial_video_user, sizeof(initial_video_user), initial_video_pwd, sizeof(initial_video_pwd),
+				initial_video_remote_pwd, sizeof(initial_video_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+			initial_video_local_ufrag = strchr(initial_video_user, ':');
+			fst_requires(initial_video_local_ufrag != NULL && initial_video_local_ufrag[1] != '\0');
+			initial_video_local_ufrag++;
+
+			switch_channel_clear_flag(channel, CF_VIDEO);
+			switch_core_media_clear_ice(session);
+			switch_channel_set_flag(channel, CF_REINVITE);
+			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
+			fst_requires(match != 0);
+			switch_core_media_gen_local_sdp(session, SDP_ANSWER, NULL, 0, NULL, 0);
+			local_sdp = switch_channel_get_variable(channel, "rtp_local_sdp_str");
+			fst_requires(copy_sdp_media_attribute(local_sdp, "video", "ice-ufrag", offered_video_ufrag,
+				sizeof(offered_video_ufrag)) == SWITCH_STATUS_SUCCESS);
+			fst_requires(copy_sdp_media_attribute(local_sdp, "video", "ice-pwd", offered_video_pwd,
+				sizeof(offered_video_pwd)) == SWITCH_STATUS_SUCCESS);
+			fst_check(strcmp(offered_video_ufrag, initial_video_local_ufrag) != 0);
+			fst_check(strcmp(offered_video_pwd, initial_video_pwd) != 0);
+			status = switch_core_media_activate_rtp(session);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			has_addr = SWITCH_FALSE;
+			status = switch_rtp_pvt_get_ice_state(video_rtp, IPR_RTP,
+				restarted_video_user, sizeof(restarted_video_user), restarted_video_pwd, sizeof(restarted_video_pwd),
+				restarted_video_remote_pwd, sizeof(restarted_video_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+			restarted_video_local_ufrag = strchr(restarted_video_user, ':');
+			fst_requires(restarted_video_local_ufrag != NULL && restarted_video_local_ufrag[1] != '\0');
+			restarted_video_local_ufrag++;
+			fst_check(!strncmp(restarted_video_user, "videoRestartUfrag:", strlen("videoRestartUfrag:")));
+			fst_check_string_equals(restarted_video_local_ufrag, offered_video_ufrag);
+			fst_check_string_equals(restarted_video_pwd, offered_video_pwd);
+			fst_check_string_equals(restarted_video_remote_pwd, "videoRestartPassword123456");
+
+			has_addr = SWITCH_FALSE;
+			status = switch_rtp_pvt_get_ice_state(video_rtp, IPR_RTCP,
+				restarted_video_rtcp_user, sizeof(restarted_video_rtcp_user), restarted_video_rtcp_pwd,
+				sizeof(restarted_video_rtcp_pwd), restarted_video_rtcp_remote_pwd,
+				sizeof(restarted_video_rtcp_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+			fst_check_string_equals(restarted_video_rtcp_user, restarted_video_user);
+			fst_check_string_equals(restarted_video_rtcp_pwd, offered_video_pwd);
+			fst_check_string_equals(restarted_video_rtcp_remote_pwd, "videoRestartPassword123456");
+
+			cleanup_session_media_and_sdp(session, sdp_session, parser);
+		}
+		FCT_TEST_END();
+
+		FCT_TEST_BGN(unbundled_video_provisional_restart_rearms_rtp_and_rtcp)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_rtp_t *audio_rtp = NULL;
+			switch_rtp_t *video_rtp = NULL;
+			void *sdp_session = NULL;
+			sdp_parser_t *parser = NULL;
+			switch_status_t status;
+			uint8_t match;
+			uint8_t proceed = 0;
+			char initial_video_user[256] = "";
+			char initial_video_pwd[256] = "";
+			char initial_video_remote_pwd[256] = "";
+			char offered_video_ufrag[256] = "";
+			char offered_video_pwd[256] = "";
+			char restarted_video_user[256] = "";
+			char restarted_video_pwd[256] = "";
+			char restarted_video_remote_pwd[256] = "";
+			char restarted_video_rtcp_user[256] = "";
+			char restarted_video_rtcp_pwd[256] = "";
+			char restarted_video_rtcp_remote_pwd[256] = "";
+			const char *restarted_video_local_ufrag;
+			const char *local_sdp;
+			switch_bool_t has_addr = SWITCH_FALSE;
+			const char *initial_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118195 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:audioInitialUfrag\n"
+				"a=ice-pwd:audioInitialPassword123456\n"
+				"a=candidate:1 1 udp 2130706431 127.0.0.1 18215 typ host\n"
+				"a=candidate:2 2 udp 2130706430 127.0.0.1 18216 typ host\n"
+				"a=rtcp:18216 IN IP4 127.0.0.1\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=mid:0\n"
+				"m=video 18217 UDP/TLS/RTP/SAVPF 96\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:videoInitialUfrag\n"
+				"a=ice-pwd:videoInitialPassword123456\n"
+				"a=candidate:3 1 udp 2130706431 127.0.0.1 18217 typ host\n"
+				"a=candidate:4 2 udp 2130706430 127.0.0.1 18218 typ host\n"
+				"a=rtcp:18218 IN IP4 127.0.0.1\n"
+				"a=rtpmap:96 VP8/90000\n"
+				"a=sendrecv\n"
+				"a=mid:1\n";
+			const char *restart_sdp =
+				"v=0\n"
+				"o=- 1683118194 1683118196 IN IP4 0.0.0.0\n"
+				"s=-\n"
+				"t=0 0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:audioInitialUfrag\n"
+				"a=ice-pwd:audioInitialPassword123456\n"
+				"a=candidate:1 1 udp 2130706431 127.0.0.1 18215 typ host\n"
+				"a=candidate:2 2 udp 2130706430 127.0.0.1 18216 typ host\n"
+				"a=rtcp:18216 IN IP4 127.0.0.1\n"
+				"a=rtpmap:0 PCMU/8000\n"
+				"a=sendrecv\n"
+				"a=mid:0\n"
+				"m=video 18217 UDP/TLS/RTP/SAVPF 96\n"
+				"c=IN IP4 127.0.0.1\n"
+				"a=ice-ufrag:videoRestartUfrag\n"
+				"a=ice-pwd:videoRestartPassword123456\n"
+				"a=rtcp:18218 IN IP4 127.0.0.1\n"
+				"a=rtpmap:96 VP8/90000\n"
+				"a=sendrecv\n"
+				"a=mid:1\n";
+
+			status = make_session_and_rtp_with_sdp_ex(&session, &audio_rtp, &sdp_session, &parser,
+				initial_sdp, "PCMU,VP8", SWITCH_FALSE, SWITCH_TRUE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && audio_rtp && sdp_session && parser);
+			channel = switch_core_session_get_channel(session);
+			video_rtp = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_VIDEO);
+			fst_requires(channel != NULL && video_rtp != NULL);
+			status = switch_rtp_pvt_get_ice_state(video_rtp, IPR_RTP,
+				initial_video_user, sizeof(initial_video_user), initial_video_pwd, sizeof(initial_video_pwd),
+				initial_video_remote_pwd, sizeof(initial_video_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_TRUE);
+
+			switch_channel_clear_flag(channel, CF_VIDEO);
+			switch_core_media_clear_ice(session);
+			switch_channel_set_flag(channel, CF_REINVITE);
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
+			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
+			fst_requires(match != 0);
+			switch_core_media_gen_local_sdp(session, SDP_ANSWER, NULL, 0, NULL, 0);
+			local_sdp = switch_channel_get_variable(channel, "rtp_local_sdp_str");
+			fst_requires(copy_sdp_media_attribute(local_sdp, "video", "ice-ufrag", offered_video_ufrag,
+				sizeof(offered_video_ufrag)) == SWITCH_STATUS_SUCCESS);
+			fst_requires(copy_sdp_media_attribute(local_sdp, "video", "ice-pwd", offered_video_pwd,
+				sizeof(offered_video_pwd)) == SWITCH_STATUS_SUCCESS);
+			status = switch_core_media_activate_rtp(session);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			has_addr = SWITCH_TRUE;
+			status = switch_rtp_pvt_get_ice_state(video_rtp, IPR_RTP,
+				restarted_video_user, sizeof(restarted_video_user), restarted_video_pwd, sizeof(restarted_video_pwd),
+				restarted_video_remote_pwd, sizeof(restarted_video_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_FALSE);
+			restarted_video_local_ufrag = strchr(restarted_video_user, ':');
+			fst_requires(restarted_video_local_ufrag != NULL && restarted_video_local_ufrag[1] != '\0');
+			restarted_video_local_ufrag++;
+			fst_check(!strncmp(restarted_video_user, "videoRestartUfrag:", strlen("videoRestartUfrag:")));
+			fst_check_string_equals(restarted_video_local_ufrag, offered_video_ufrag);
+			fst_check_string_equals(restarted_video_pwd, offered_video_pwd);
+			fst_check_string_equals(restarted_video_remote_pwd, "videoRestartPassword123456");
+
+			has_addr = SWITCH_TRUE;
+			status = switch_rtp_pvt_get_ice_state(video_rtp, IPR_RTCP,
+				restarted_video_rtcp_user, sizeof(restarted_video_rtcp_user), restarted_video_rtcp_pwd,
+				sizeof(restarted_video_rtcp_pwd), restarted_video_rtcp_remote_pwd,
+				sizeof(restarted_video_rtcp_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_FALSE);
+			fst_check_string_equals(restarted_video_rtcp_user, restarted_video_user);
+			fst_check_string_equals(restarted_video_rtcp_pwd, offered_video_pwd);
+			fst_check_string_equals(restarted_video_rtcp_remote_pwd, "videoRestartPassword123456");
 
 			cleanup_session_media_and_sdp(session, sdp_session, parser);
 		}

--- a/tests/unit/switch_trickle_ice.c
+++ b/tests/unit/switch_trickle_ice.c
@@ -11,6 +11,34 @@ extern char *fst_getenv_default(const char *, char *, switch_bool_t);
 static void _silence_unused(void) { (void)fst_getenv_default; }
 static const char *rx_host = "127.0.0.1";
 
+static switch_status_t copy_sdp_attribute(const char *sdp, const char *attribute, char *value, switch_size_t value_len)
+{
+	char needle[64];
+	const char *start;
+	const char *end;
+	switch_size_t len;
+
+	if (zstr(sdp) || zstr(attribute) || !value || !value_len) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_snprintf(needle, sizeof(needle), "a=%s:", attribute);
+	if (!(start = strstr(sdp, needle))) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	start += strlen(needle);
+	end = strpbrk(start, "\r\n");
+	len = end ? (switch_size_t)(end - start) : strlen(start);
+	if (!len || len >= value_len) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	memcpy(value, start, len);
+	value[len] = '\0';
+	return SWITCH_STATUS_SUCCESS;
+}
+
 typedef struct trickle_captured_s {
 	int called;
 	int last_mline;
@@ -331,26 +359,90 @@ FCT_BGN()
 		}
 		FCT_TEARDOWN_END();
 
-		FCT_TEST_BGN(restart_ice_rearms_unchanged_media)
+		FCT_TEST_BGN(same_generation_trickle_preserves_credentials)
+		{
+			switch_core_session_t *session = NULL;
+			switch_media_handle_t *smh = NULL;
+			switch_rtp_t *rtp = NULL;
+			switch_status_t status;
+			void *sdp_session = NULL;
+			sdp_parser_t *parser = NULL;
+			char initial_ice_user[256] = "";
+			char initial_local_pwd[256] = "";
+			char initial_remote_pwd[256] = "";
+			char trickled_ice_user[256] = "";
+			char trickled_local_pwd[256] = "";
+			char trickled_remote_pwd[256] = "";
+			switch_bool_t has_addr = SWITCH_FALSE;
+
+			status = make_session_and_rtp_with_sdp(&session, &rtp, &sdp_session, &parser);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && rtp && sdp_session && parser);
+			smh = switch_core_session_get_media_handle(session);
+			fst_requires(smh != NULL);
+
+			status = switch_core_media_trickle_remote_candidate_and_recheck(
+				session, smh, sdp_session, SDP_TYPE_REQUEST, "0", 0,
+				"candidate:265031753 1 udp 1685921533 50.114.144.39 18215 typ srflx raddr 100.69.211.204 rport 54081", 0);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				initial_ice_user, sizeof(initial_ice_user),
+				initial_local_pwd, sizeof(initial_local_pwd),
+				initial_remote_pwd, sizeof(initial_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(initial_ice_user[0] != '\0' && initial_local_pwd[0] != '\0' && initial_remote_pwd[0] != '\0');
+			fst_check(has_addr == SWITCH_TRUE);
+
+			status = switch_core_media_trickle_remote_candidate_and_recheck(
+				session, smh, sdp_session, SDP_TYPE_REQUEST, "0", 0,
+				"candidate:265031754 1 udp 1685921534 50.114.144.40 18216 typ srflx raddr 100.69.211.204 rport 54081", 0);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			has_addr = SWITCH_FALSE;
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				trickled_ice_user, sizeof(trickled_ice_user),
+				trickled_local_pwd, sizeof(trickled_local_pwd),
+				trickled_remote_pwd, sizeof(trickled_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_check_string_equals(trickled_ice_user, initial_ice_user);
+			fst_check_string_equals(trickled_local_pwd, initial_local_pwd);
+			fst_check_string_equals(trickled_remote_pwd, initial_remote_pwd);
+			fst_check(has_addr == SWITCH_TRUE);
+
+			cleanup_session_media_and_sdp(session, sdp_session, parser);
+		}
+		FCT_TEST_END();
+
+		FCT_TEST_BGN(restart_ice_rotates_credentials_and_rearms_unchanged_media)
 		{
 			switch_core_session_t *session = NULL;
 			switch_channel_t *channel = NULL;
+			switch_media_handle_t *smh = NULL;
 			switch_rtp_t *rtp = NULL;
 			switch_status_t status;
-			const char *err = NULL;
-			char ice_user[256] = "";
+			void *sdp_session = NULL;
+			sdp_parser_t *parser = NULL;
+			char initial_ice_user[256] = "";
+			char initial_local_pwd[256] = "";
+			char initial_remote_pwd[256] = "";
+			char restarted_ice_user[256] = "";
+			char restarted_local_pwd[256] = "";
+			char restarted_remote_pwd[256] = "";
+			char restarted_sdp_local_ufrag[256] = "";
+			char restarted_sdp_local_pwd[256] = "";
+			const char *initial_local_ufrag;
+			const char *restarted_local_ufrag;
+			const char *local_sdp;
 			switch_bool_t has_addr = SWITCH_FALSE;
-			ice_t old_ice;
 			uint8_t match;
 			uint8_t proceed = 0;
 			const char *restart_sdp =
 				"v=0\n"
-				"o=- 1683118194 1683118196 IN IP4 0.0.0.0\n"
+				"o=- 1683118194 1683118197 IN IP4 0.0.0.0\n"
 				"s=-\n"
 				"t=0 0\n"
 				"a=group:BUNDLE 0\n"
-				"m=audio 9 UDP/TLS/RTP/SAVPF 0\n"
-				"c=IN IP4 0.0.0.0\n"
+				"m=audio 18215 UDP/TLS/RTP/SAVPF 0\n"
+				"c=IN IP4 50.114.144.39\n"
 				"a=ice-ufrag:restartRemoteUfrag\n"
 				"a=ice-pwd:restartRemotePassword123456\n"
 				"a=ice-options:trickle\n"
@@ -361,25 +453,28 @@ FCT_BGN()
 				"a=fingerprint:sha-256 17:B5:C8:7F:AE:D0:32:C9:FF:58:80:3C:17:5A:45:2E:55:2D:D9:33:DD:2A:56:16:7D:AC:3B:3C:76:80:0C:D4\n"
 				"a=mid:0\n";
 
-			memset(&old_ice, 0, sizeof(old_ice));
-			old_ice.cands[0][IPR_RTP].priority = 1;
-			old_ice.cands[0][IPR_RTP].con_addr = "0.0.0.0";
-			old_ice.cands[0][IPR_RTP].con_port = 9;
-			old_ice.cands[0][IPR_RTP].ready = 1;
-
-			status = make_session_and_rtp_with_sdp(&session, &rtp, NULL, NULL);
-			fst_requires(status == SWITCH_STATUS_SUCCESS && session && rtp);
+			status = make_session_and_rtp_with_sdp(&session, &rtp, &sdp_session, &parser);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && rtp && sdp_session && parser);
 			channel = switch_core_session_get_channel(session);
-			fst_requires(channel != NULL);
+			smh = switch_core_session_get_media_handle(session);
+			fst_requires(channel != NULL && smh != NULL);
 
-			status = switch_rtp_set_remote_address(rtp, "0.0.0.0", 9, 0, SWITCH_FALSE, &err);
+			status = switch_core_media_trickle_remote_candidate_and_recheck(
+				session, smh, sdp_session, SDP_TYPE_REQUEST, "0", 0,
+				"candidate:265031753 1 udp 1685921533 50.114.144.39 18215 typ srflx raddr 100.69.211.204 rport 54081", 0);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
-			status = switch_rtp_activate_ice(rtp, "oldRemoteUfrag", "oldLocalUfrag",
-				"oldLocalPassword", "oldRemotePassword", IPR_RTP, ICE_VANILLA, &old_ice);
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				initial_ice_user, sizeof(initial_ice_user),
+				initial_local_pwd, sizeof(initial_local_pwd),
+				initial_remote_pwd, sizeof(initial_remote_pwd), &has_addr);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
-			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP, ice_user, sizeof(ice_user), &has_addr);
-			fst_requires(status == SWITCH_STATUS_SUCCESS);
-			fst_check_string_equals(ice_user, "oldRemoteUfrag:oldLocalUfrag");
+			initial_local_ufrag = strchr(initial_ice_user, ':');
+			fst_requires(initial_local_ufrag != NULL && initial_local_ufrag[1] != '\0');
+			initial_local_ufrag++;
+			fst_check(!strncmp(initial_ice_user, "aZJpsl00bYnjrOZtkCFMtKhFC/CHAfcv:",
+				strlen("aZJpsl00bYnjrOZtkCFMtKhFC/CHAfcv:")));
+			fst_check_string_equals(initial_remote_pwd, "aNniSnLLp43SSsJrz6TNPty1zPrxZNzh");
+			fst_check(initial_local_pwd[0] != '\0');
 			fst_check(has_addr == SWITCH_TRUE);
 
 			switch_core_media_clear_ice(session);
@@ -387,17 +482,33 @@ FCT_BGN()
 			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
 			match = switch_core_media_negotiate_sdp(session, restart_sdp, &proceed, SDP_OFFER);
 			fst_requires(match != 0);
+			switch_core_media_gen_local_sdp(session, SDP_ANSWER, NULL, 0, NULL, 0);
+			local_sdp = switch_channel_get_variable(channel, "rtp_local_sdp_str");
+			fst_requires(copy_sdp_attribute(local_sdp, "ice-ufrag", restarted_sdp_local_ufrag,
+				sizeof(restarted_sdp_local_ufrag)) == SWITCH_STATUS_SUCCESS);
+			fst_requires(copy_sdp_attribute(local_sdp, "ice-pwd", restarted_sdp_local_pwd,
+				sizeof(restarted_sdp_local_pwd)) == SWITCH_STATUS_SUCCESS);
 			status = switch_core_media_activate_rtp(session);
-			fst_check(status == SWITCH_STATUS_SUCCESS);
-
-			memset(ice_user, 0, sizeof(ice_user));
-			has_addr = SWITCH_TRUE;
-			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP, ice_user, sizeof(ice_user), &has_addr);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
-			fst_check(strstr(ice_user, "restartRemoteUfrag") != NULL);
+
+			has_addr = SWITCH_TRUE;
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				restarted_ice_user, sizeof(restarted_ice_user),
+				restarted_local_pwd, sizeof(restarted_local_pwd),
+				restarted_remote_pwd, sizeof(restarted_remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			restarted_local_ufrag = strchr(restarted_ice_user, ':');
+			fst_requires(restarted_local_ufrag != NULL && restarted_local_ufrag[1] != '\0');
+			restarted_local_ufrag++;
+			fst_check(!strncmp(restarted_ice_user, "restartRemoteUfrag:", strlen("restartRemoteUfrag:")));
+			fst_check_string_equals(restarted_remote_pwd, "restartRemotePassword123456");
+			fst_check(strcmp(restarted_local_ufrag, initial_local_ufrag) != 0);
+			fst_check(strcmp(restarted_local_pwd, initial_local_pwd) != 0);
+			fst_check_string_equals(restarted_sdp_local_ufrag, restarted_local_ufrag);
+			fst_check_string_equals(restarted_sdp_local_pwd, restarted_local_pwd);
 			fst_check(has_addr == SWITCH_FALSE);
 
-			cleanup_session_and_media(session);
+			cleanup_session_media_and_sdp(session, sdp_session, parser);
 		}
 		FCT_TEST_END();
 


### PR DESCRIPTION
## Summary

Harden WebRTC ICE/DTLS handling across initial nomination, trickle ICE, ICE restarts, and call recovery. This also adds an authenticated peer-reflexive bootstrap path for sessions where the advertised remote candidates are absent or unusable.

## Problems addressed

- `rready` was overloaded as both connectivity/readiness and remote end-of-candidates state, causing valid late trickled candidates to be rejected before explicit EOC.
- Generic STUN auto-adjust and late candidate traffic could move RTP/DTLS away from the peer-nominated tuple while DTLS was still handshaking.
- ICE could not start when credentials were present but no remote candidate was ready, even when an authenticated STUN request exposed a usable peer-reflexive tuple.
- Reoffers with new ICE credentials could leave unchanged RTP addresses on the previous ICE generation or fail to rotate local credentials.
- Call recovery could duplicate ICE activation, accept stale-generation tuple changes, or move ICE/DTLS away from the recovery tuple without current authenticated nomination proof.

## Implementation

### Nomination and trickle ICE

- Track explicit remote `end-of-candidates` separately from ICE responsiveness and reset it for each ICE activation/restart.
- Continue accepting trickled candidates until explicit EOC is received.
- Preserve the active DTLS handshake peer and peer-nominated candidate through DTLS setup.
- Track recent inbound media by candidate and tighten post-DTLS/mid-call retargeting to fresh, trusted nominations.

### Authenticated peer-reflexive bootstrap

- Add strict STUN authentication validation for MESSAGE-INTEGRITY and FINGERPRINT, including constant-time digest comparison and bounded attribute parsing.
- Require the current ICE username, PRIORITY, and—in the default configuration—authenticated `USE-CANDIDATE` before learning a peer-reflexive tuple.
- Install the learned tuple into ICE, RTP/RTCP, and DTLS state only inside a bounded bootstrap window.
- Support provisional RTP and non-mux RTCP ICE activation when credentials exist but no advertised candidate is ready.

### ICE restart and recovery

- Detect explicit ICE generation changes, rotate local credentials, and reactivate ICE even when the SDP media address is unchanged.
- Re-arm provisional peer-reflexive bootstrap for restarts without a ready candidate.
- Apply the same restart behavior to audio and unbundled video while respecting BUNDLE/RTCP mux.
- Avoid duplicate ICE activation during recovery-driven DTLS restarts when the existing candidate is already ready.
- Reject untrusted STUN/DTLS tuple changes during recovery and synchronize non-mux ICE state only after authenticated current-generation nomination.

## Configuration

Peer-reflexive bootstrap is default-off and uses existing channel variables:

- `rtp_ice_prflx_bootstrap=true` enables it.
- `rtp_ice_prflx_bootstrap_ms` controls the bootstrap window and defaults to 10000 ms.
- `rtp_ice_prflx_bootstrap_require_use_candidate` defaults to `true`.

## Test coverage

- STUN MESSAGE-INTEGRITY/FINGERPRINT validation and malformed/tampered packets.
- Explicit bootstrap enablement, username matching, and authenticated nomination requirements.
- DTLS tuple preservation and authenticated recovery nomination policy.
- Same-generation clears, ICE credential rotation, and unchanged-address reactivation.
- Ready-candidate and provisional recovery paths for audio and unbundled video.
- Trickle candidate ordering, component-2 candidates, and explicit end-of-candidates behavior.
