### PR TITLE
AFK-Coder: TELCORE-322 add observability for silent proxy_media frame drops

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -226,7 +226,7 @@ struct switch_rtp_engine_s {
 	switch_thread_rwlock_t *dtls_init_rwlock;
 	rtp_extension_t rtp_recv_extensions[MAX_RTP_EXTENSIONS];
 	rtp_extension_t rtp_send_extensions[MAX_RTP_EXTENSIONS];
-	/* TELCORE-322: observability counter for audio frames dropped in
+	/* observability counter for audio frames dropped in
 	 * switch_core_media_write_frame() because the leg's media flow is not
 	 * send-capable. Observability only - does not gate any RTP behavior. */
 	uint32_t audio_flow_write_drops;
@@ -4394,7 +4394,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_write_frame(switch_core_sessio
 		switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
 
 		if (audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
-			/* TELCORE-322: audio frame dropped because the leg's media flow is not
+			/* audio frame dropped because the leg's media flow is not
 			 * send-capable (e.g. RECVONLY/INACTIVE/DISABLED). The early-return is
 			 * preserved exactly as-is (still unlocks and returns SUCCESS so callers
 			 * treat it as a no-op, matching historic behavior). The counter and

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -226,6 +226,10 @@ struct switch_rtp_engine_s {
 	switch_thread_rwlock_t *dtls_init_rwlock;
 	rtp_extension_t rtp_recv_extensions[MAX_RTP_EXTENSIONS];
 	rtp_extension_t rtp_send_extensions[MAX_RTP_EXTENSIONS];
+	/* TELCORE-322: observability counter for audio frames dropped in
+	 * switch_core_media_write_frame() because the leg's media flow is not
+	 * send-capable. Observability only - does not gate any RTP behavior. */
+	uint32_t audio_flow_write_drops;
 };
 
 #define MAX_REJ_STREAMS 10
@@ -4390,6 +4394,19 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_write_frame(switch_core_sessio
 		switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
 
 		if (audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
+			/* TELCORE-322: audio frame dropped because the leg's media flow is not
+			 * send-capable (e.g. RECVONLY/INACTIVE/DISABLED). The early-return is
+			 * preserved exactly as-is (still unlocks and returns SUCCESS so callers
+			 * treat it as a no-op, matching historic behavior). The counter and
+			 * rate-limited WARNING below are observability only. No RTP behavior
+			 * change. */
+			engine->audio_flow_write_drops++;
+			if (engine->audio_flow_write_drops == 1 || engine->audio_flow_write_drops % 1000 == 1) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+									  "%s audio write dropped due to media flow=%d (cumulative drops=%u)\n",
+									  switch_channel_get_name(switch_core_session_get_channel(session)),
+									  (int)audio_flow, engine->audio_flow_write_drops);
+			}
 			switch_thread_rwlock_unlock(engine->dtls_init_rwlock);
 			return SWITCH_STATUS_SUCCESS;
 		}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -542,6 +542,10 @@ struct switch_rtp {
 	uint8_t ext_total_len;
 	ext_mid_t ext_mid;
 	struct trickle_cb_ctx trickle;
+	/* TELCORE-322: observability counter for non-proxy frames silently dropped
+	 * on a proxy_media/UDPTL session in switch_rtp_write_frame(). Observability
+	 * only - does not gate any RTP behavior. */
+	uint32_t proxy_media_write_drops;
 };
 
 #if 0
@@ -11079,6 +11083,20 @@ SWITCH_DECLARE(int) switch_rtp_write_frame(switch_rtp_t *rtp_session, switch_fra
 
 		/* Fast PASS! */
 		if (!switch_test_flag(frame, SFF_PROXY_PACKET) && !switch_test_flag(frame, SFF_UDPTL_PACKET)) {
+			/* TELCORE-322: a non-proxy/non-UDPTL frame reached a proxy_media (or
+			 * UDPTL) RTP session and is silently dropped here. This is by design
+			 * (proxy mode forwards raw SFF_PROXY_PACKET/SFF_UDPTL_PACKET frames
+			 * only); the drop is preserved exactly as-is. The counter and
+			 * rate-limited WARNING below are observability only so a 0-out leg
+			 * is no longer indistinguishable from a successful send. No RTP
+			 * behavior change. */
+			rtp_session->proxy_media_write_drops++;
+			if (rtp_session->proxy_media_write_drops == 1 || rtp_session->proxy_media_write_drops % 1000 == 1) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+									  "%s PROXY_MEDIA silent drop: non-proxy frame on proxy/UDPTL session (cumulative drops=%u)\n",
+									  rtp_session->session ? switch_channel_get_name(switch_core_session_get_channel(rtp_session->session)) : "NoName",
+									  rtp_session->proxy_media_write_drops);
+			}
 #if DEBUG_RTP
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE, "RTP: write frame !UDPTL %p/%p\n", (void*)rtp_session->session, (void*)rtp_session); 
 #endif

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -542,7 +542,7 @@ struct switch_rtp {
 	uint8_t ext_total_len;
 	ext_mid_t ext_mid;
 	struct trickle_cb_ctx trickle;
-	/* TELCORE-322: observability counter for non-proxy frames silently dropped
+	/* observability counter for non-proxy frames silently dropped
 	 * on a proxy_media/UDPTL session in switch_rtp_write_frame(). Observability
 	 * only - does not gate any RTP behavior. */
 	uint32_t proxy_media_write_drops;
@@ -11083,7 +11083,7 @@ SWITCH_DECLARE(int) switch_rtp_write_frame(switch_rtp_t *rtp_session, switch_fra
 
 		/* Fast PASS! */
 		if (!switch_test_flag(frame, SFF_PROXY_PACKET) && !switch_test_flag(frame, SFF_UDPTL_PACKET)) {
-			/* TELCORE-322: a non-proxy/non-UDPTL frame reached a proxy_media (or
+			/* a non-proxy/non-UDPTL frame reached a proxy_media (or
 			 * UDPTL) RTP session and is silently dropped here. This is by design
 			 * (proxy mode forwards raw SFF_PROXY_PACKET/SFF_UDPTL_PACKET frames
 			 * only); the drop is preserved exactly as-is. The counter and


### PR DESCRIPTION
## TELCORE-322 — Observability for silent proxy_media frame drops (DRAFT)

**Linear issue:** https://linear.app/telnyx/issue/TELCORE-322/investigate-proxy-mode-and-g729-zero-audio-behavior

**Verified-against SHA:** `e391ae8b48ec95f7f731fef6d072a21a09ac7944` (HEAD of `telnyx/telephony/master` at branch creation; sites located by pattern, line numbers recorded at this SHA)

---

### What this is

A **minimal, observability-only** patch that adds a session-level drop counter and a rate-limited `SWITCH_LOG_WARNING` at the two sites where FreeSWITCH silently drops media frames with **zero observability** when Media Handling Mode = Proxy. This is the diagnostic instrument to confirm or refute the silent-drop hypothesis for the TELCORE-322 zero-audio call (5292 packets in / 0 out) observed on `b2bua-canary`.

### Sites patched (file:line at the verified SHA)

**Site 1 — `src/switch_rtp.c`**
- New counter field on the private `struct switch_rtp`: `uint32_t proxy_media_write_drops;` at `src/switch_rtp.c:548`.
- In `switch_rtp_write_frame()`, the proxy_media/UDPTL "Fast PASS" block. A non-proxy/non-UDPTL frame written to a `SWITCH_RTP_FLAG_PROXY_MEDIA` (or UDPTL) session is silently dropped via `return 0` (`src/switch_rtp.c:11103`). The only pre-existing log there is behind `#if DEBUG_RTP` (compiled out in production), and the caller (`switch_core_media_write_frame()`) treats `return 0` as success — so the drop is indistinguishable from a successful send. Added counter increment + rate-limited WARNING (first drop, then every 1000th) inside the `if (!SFF_PROXY_PACKET && !SFF_UDPTL_PACKET)` block at `src/switch_rtp.c:11085`, before the existing `#if DEBUG_RTP` block and the `return 0;`.

**Site 2 — `src/switch_core_media.c`**
- New counter field on the private `struct switch_rtp_engine_s`: `uint32_t audio_flow_write_drops;` at `src/switch_core_media.c:232`.
- In `switch_core_media_write_frame()`, when the leg's audio media flow is not send-capable (`audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && != SWITCH_MEDIA_FLOW_SENDONLY`), the function silently unlocks and returns `SWITCH_STATUS_SUCCESS` (`src/switch_core_media.c:4396` / unlock at `:4410` / return at `:4411`). Added counter increment + rate-limited WARNING (first drop, then every 1000th) before the existing unlock and return.

### Critical guarantees

- **This is observability-only. There is NO RTP behavior change of any kind.** The drops **still occur**. Every `return` value is unchanged (`return 0;` at Site 1; `switch_thread_rwlock_unlock()` + `return SWITCH_STATUS_SUCCESS;` at Site 2). The `#if DEBUG_RTP` block at Site 1 is untouched.
- Two files changed, 35 insertions, 0 deletions, no refactors, no whitespace churn. The counters live on the existing private structs (both `struct switch_rtp` in `switch_rtp.c` and `struct switch_rtp_engine_s` in `switch_core_media.c` are already zero-initialized by the FS memory pool allocators, so counters start at 0).
- G.729 codec modules are **not touched** (G.729 was exonerated — co-occurring, not causal). AUTOADJ code is **not touched** (the AUTOADJ→send propagation gap was independently disproven by source). Scope is strictly the two silent-drop sites above.

### Why a draft / what this does NOT prove

- **The silent-drop-as-root-cause is still UNVERIFIED.** This patch exists to confirm or refute it on canary, not to fix it. If `b2bua-canary` shows **zero** drops at these two sites after this patch, the conclusion is "proxy_media is working as designed" → document and **STOP**. Do **not** escalate into an RTP-behavior change based on this PR alone.
- All three failing calls ran on `b2bua-canary`, not prod `b2bua`. The silent-drop may be an asymmetric leg media config on canary rather than a fundamental FS defect. Prod behavior must be confirmed separately before generalizing.

### Scope boundary (sub-mode A only)

This addresses **only sub-mode A**: one-way audio, NAT'd endpoint advertising a private SDP `c=` IP (the TELCORE-322 MicroSIP test, `5292-in / 0-out`, on `b2bua-canary`).

This PR does **NOT** fix **TELOPS-473** (Brazil DID `0/0` on both legs, public carrier IPs, DATAWAIT deadlock). That is an ops/firewall/ACL issue on RTP relay IPs for the Datara/NEWCOM carriers + a product question about whether Proxy mode stays customer-selectable. It is **not** a FreeSWITCH code fix and is **not** represented as fixed here.

### Customer workaround (independent of this PR)

Media Handling Mode **Proxy → Default** removes `proxy_media=true`, restores media anchoring and the AUTOADJ NAT latch. This remains a verified-sound customer-side workaround and is independent of merging this PR.

### Verification

What I ran:
- Read `AGENTS.md` (none present at repo root), `README.md`, `.llm-repo-instructions`, `Makefile.am`, `.drone.yml`, and the unit test harness (`tests/unit/`).
- Located both silent-drop sites at the verified SHA **by pattern** (not hardcoded line numbers), per the retry guidance — `SFF_PROXY_PACKET` + `return 0` inside the `SWITCH_RTP_FLAG_PROXY_MEDIA` Fast-PASS in `switch_rtp.c`; the `audio_flow != SENDRECV/SENDONLY` early-return in `switch_core_media.c`.
- Confirmed both enclosing structs (`struct switch_rtp` in `switch_rtp.c:350`, `struct switch_rtp_engine_s` in `switch_core_media.c:130`) are allocated through the FS pool allocators that `memset` the memory to zero (`switch_core_perform_alloc` / `switch_core_perform_session_alloc` in `switch_core_memory.c`), so the new counters start at 0 with no explicit init needed.
- Re-read the full diff for correctness: C89-clean (no new block-local variable declarations — only struct-member increments and function calls), correct format specifiers (`%u` for `uint32_t`, `(int)` cast for the `switch_media_flow_t` enum printed with `%d`), NULL-guarded channel-name access matching the immediately-adjacent DEBUG_RTP log, tabs + brace placement + continuation indentation matching the surrounding `switch_log_printf` convention (verified against existing multiline logs e.g. `switch_rtp.c:2376`).
- Confirmed `return 0;` (Site 1) and `switch_thread_rwlock_unlock()` + `return SWITCH_STATUS_SUCCESS;` (Site 2) are byte-for-byte unchanged, and the `#if DEBUG_RTP` block at Site 1 is untouched.

What I could **not** run (and why):
- **No syntax-only compile / full native build.** This environment has **no C compiler** (`gcc`/`cc`/`clang` all absent) and no `autoconf`/`automake`; the operator constraints forbid installing system packages (no sudo/apt). A FreeSWITCH build requires the full autotools toolchain plus system deps (fspr/APR, Sofia-SIP, SpanDSP, etc.), none of which are available here.
- **No unit test added.** The repo's test harness (`tests/unit/`) links each test against `libfreeswitch.la` and uses `FST_CORE_BEGIN("./conf")` to spin up a real FreeSWITCH core — i.e. it requires the full native build that is impossible in this sandbox. Per the operator guidance, skipping the test in this environment is explicitly acceptable. A focused test asserting the warning/counter fires when a non-proxy frame is written to a `proxy_media` session would be a sensible follow-up **after** canary confirms the counter actually increments (no point testing for behavior that may not be the root cause).

**Repository CI must cover the native build.** The Drone `unit-tests` pipeline (`.drone.yml`) runs `./bootstrap.sh` → `./configure` (ASan, sofia-sip, spandsp3) → `make -j` → `tests/unit/run-tests.sh`, which will compile both changed files and run the unit suite. That is the gating verification for this change.

### Do not merge

Draft PR only — for human review and canary validation. No merge, no deploy, no production mutation.
