### PR TITLE
TELCORE-322: fix proxy_media one-way/zero outbound audio

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4389,7 +4389,19 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_write_frame(switch_core_sessio
 	if (type == SWITCH_MEDIA_TYPE_AUDIO) {
 		switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
 
-		if (audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
+		/* A proxy_media leg is a blind bidirectional RTP relay: its SDP direction is
+		 * never negotiated into an smode (switch_core_media_proxy_remote_addr() only
+		 * string-parses the c=/m= lines), so the engine smode stays at its init
+		 * default SWITCH_MEDIA_FLOW_DISABLED. The RFC 3264 send-direction gate below
+		 * was written for anchored legs whose smode reflects a real a= direction and
+		 * must NOT apply to a proxy_media relay leg -- otherwise every frame the peer
+		 * relays toward this leg is dropped here (SUCCESS no-op) before it can reach
+		 * switch_rtp_write_frame(), producing one-way / zero outbound audio even
+		 * though RTP auto-adjust has already latched the correct remote address.
+		 * Skip the gate for proxy_media so the relay keeps forwarding in both
+		 * directions, matching the pre-media-flow behavior for this channel class. */
+		if (!switch_channel_test_flag(session->channel, CF_PROXY_MEDIA) &&
+			audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
 			switch_thread_rwlock_unlock(engine->dtls_init_rwlock);
 			return SWITCH_STATUS_SUCCESS;
 		}


### PR DESCRIPTION
## TELCORE-322 — Fix proxy_media one-way / zero outbound audio (real fix)

**Linear:** https://linear.app/telnyx/issue/TELCORE-322/investigate-proxy-mode-and-g729-zero-audio-behavior

**Base:** `telnyx/telephony/deploy-development` · **Change:** `src/switch_core_media.c`, +13 / −1

### TL;DR
When **Media Handling Mode = Proxy** (`proxy_media=true`), a NAT'd inbound leg gets **zero outbound audio** (one-way audio). This is a **write-gate drop**, not an addressing problem, and not the G.729 codec. This PR is the actual behavior fix. The prior PR #631 was observability-only (a counter + warning log) and instrumented the *wrong* drop site; see "Relationship to #631" below.

### Root cause (source + prod CDR)
A `proxy_media` leg is a **blind bidirectional RTP relay**. Its SDP direction is never negotiated into an engine `smode` — `switch_core_media_proxy_remote_addr()` only string-parses the `c=`/`m=` lines — so the audio engine `smode` stays at its media-handle init default `SWITCH_MEDIA_FLOW_DISABLED`.

`switch_core_media_write_frame()` gates outbound audio on the RFC 3264 send direction:

```c
if (audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
    switch_thread_rwlock_unlock(engine->dtls_init_rwlock);
    return SWITCH_STATUS_SUCCESS;   /* silent no-op drop, BEFORE switch_rtp_write_frame() */
}
```

That gate is correct for **anchored** legs whose `smode` reflects a real `a=` direction. It is **wrong for a proxy_media relay leg** whose `smode` is `DISABLED` by construction: it drops *every* frame the peer relays toward that leg → one-way / zero outbound audio. The frame never reaches `switch_rtp_write_frame()`.

### Evidence (prod CDR, `sip_call_id 7bd6ce156b0a4800b4bbd1732832884f` — the ticket's sample call)

| Leg | `proxy_media` | `audio_media_flow` | rtp_audio_in | rtp_audio_out | auto-adjust |
|---|---|---|---|---|---|
| **A** (NAT'd caller `192.168.1.53`) | `true` | **`disabled`** | 5292 | **0** | `rtp_auto_adjust_audio=true`, `remote_audio_ip=171.250.44.234` (real public NAT addr **already latched**) |
| **B** (callee) | inherited | `sendrecv` | 5313 | 5292 |  |

Two facts this proves:
1. **The 0-out is a write-gate drop, not an addressing failure.** RTP auto-adjust had *already* learned the caller's real public source (`171.250.44.234`), so the classic "AUTOADJ-learned address never reaches the send path" hypothesis is **not** the cause here — `remote_addr` was correct and the send was still never attempted.
2. **The post-gate relay path works for proxy_media** — the B-leg (also `proxy_media`, `smode=sendrecv`) relays 5292 packets out through the *same* `switch_core_media_write_frame()` path. The **only** difference between the working B-leg and the broken A-leg is `smode`: `sendrecv` vs `disabled`. That makes the gate both necessary and sufficient as the fix point.

G.729 is exonerated: `mod_bcg729` has no media-plane / proxy handling; proxy_media passes the codec through untouched.

### The fix
Skip the send-direction gate when `CF_PROXY_MEDIA` is set, so a proxy_media relay forwards in **both** directions:

```c
if (!switch_channel_test_flag(session->channel, CF_PROXY_MEDIA) &&
    audio_flow != SWITCH_MEDIA_FLOW_SENDRECV && audio_flow != SWITCH_MEDIA_FLOW_SENDONLY) {
    switch_thread_rwlock_unlock(engine->dtls_init_rwlock);
    return SWITCH_STATUS_SUCCESS;
}
```

- **No behavior change for non-proxy legs.** The RFC 3264 gate is fully preserved for anchored legs, so hold (`RECVONLY`), `INACTIVE`, and one-way-announcement semantics are unchanged.
- `switch_channel_test_flag(session->channel, CF_PROXY_MEDIA)` is the idiomatic form (used 16× elsewhere in this file).
- C90-clean: no new block-local declarations, just an added guard on an existing condition. Lock discipline unchanged — `dtls_init_rwlock` is still released exactly once on this path.

### Verification
- **Logic proof** (standalone C89 harness, mirrors the exact expression + types, compiled `-std=c89 -Wall -Wextra -Werror -pedantic`):
  - `proxy_media + DISABLED` → **forwards** (was dropped → 0-out). ✅ the fix
  - `proxy_media + SENDRECV` (B-leg) → forwards (unchanged). ✅
  - anchored `RECVONLY` / `INACTIVE` → **still dropped** (gate preserved, no regression). ✅
  - anchored `SENDRECV` → forwards. ✅
- `git diff --check` clean.
- **Not run:** full native FreeSWITCH build (this environment lacks the autotools + Sofia-SIP/APR/SpanDSP toolchain). The Drone `unit-tests` pipeline compiles the change and is the gating native-build verification.

### Canary validation plan (before any prod rollout)
1. Deploy to `b2bua-canary`.
2. Repro the ticket call: NAT'd endpoint (private SDP `c=` IP), Media Handling Mode = Proxy.
3. Confirm the inbound leg now shows **`rtp_audio_out > 0`** (bidirectional audio) in the CDR, where it was `0` before.
4. Regression sanity: a normal Default-mode call and a held (RECVONLY) call — confirm no audio/hold regressions.

### Scope boundary
This fixes **sub-mode A** — one-way audio on a NAT'd proxy_media leg (the TELCORE-322 sample call). It does **not** address **TELOPS-473** (Brazil DID `0/0` both legs, public carrier IPs): that is a `DATAWAIT`/carrier-RTP-delivery (ops/firewall) + product question, not a FreeSWITCH code defect, and is not represented as fixed here. The customer workaround (Media Handling Mode **Proxy → Default**) remains valid and independent of this PR.

### Relationship to PR #631
#631 added a drop **counter + warning log** (observability only, no behavior change) at two sites. For this failure mode the relevant drop is the `switch_core_media_write_frame()` media-flow gate — #631's `switch_rtp.c` site is never even reached, because the frame is dropped one layer up first. This PR fixes the actual drop instead of only logging it. #631 can be closed in favor of this, or kept purely as diagnostics.

### Do not merge
Draft — for human review + canary validation. No merge, no deploy, no production mutation.
