### PR TITLE
TELCORE-255: add ICE-controlling mid-call failover

### DIFF
--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -1,6 +1,14 @@
 #ifndef __SWITCH_RTP_PVT_H__
 #define __SWITCH_RTP_PVT_H__
 
+typedef enum {
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE = 0,
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING,
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING
+} switch_rtp_ice_controlling_failover_state_t;
+
+#define SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY 4
+
 typedef struct {
 		char *ice_user;
 		char *user_ice;
@@ -33,6 +41,19 @@ typedef struct {
 		uint32_t mid_call_failover_ms;
 		int mid_call_nominated_idx;
 		switch_time_t mid_call_nominated_us;
+		uint8_t controlling_failover_cached;
+		uint8_t controlling_failover_enabled;
+		uint32_t controlling_failover_ms;
+		switch_rtp_ice_controlling_failover_state_t controlling_failover_state;
+		int controlling_failover_idx;
+		switch_time_t controlling_failover_candidate_us;
+		switch_time_t controlling_failover_sent_us;
+		char controlling_failover_probe_id[13];
+		char controlling_failover_nomination_id[13];
+		char selected_pair_check_ids[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY][13];
+		uint8_t selected_pair_check_pos;
+		uint8_t selected_pair_check_count;
+		switch_time_t selected_pair_last_response_us;
 		int inbound_media_idx;
 		switch_time_t inbound_media_us;
 		uint8_t prflx_bootstrap_cached;
@@ -72,6 +93,9 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ic
 	switch_bool_t got_message_integrity, switch_bool_t got_fingerprint, switch_bool_t got_use_candidate,
 	switch_bool_t got_use_candidate_covered, switch_bool_t has_priority, switch_bool_t within_bootstrap_window,
 	uint32_t bootstrap_ms, switch_time_t now);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_matches(switch_rtp_ice_t *ice,
+	switch_rtp_ice_controlling_failover_state_t expected_state, int candidate_idx, const char *transaction_id,
+	switch_bool_t authenticated);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -7,6 +7,12 @@ typedef enum {
 	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING
 } switch_rtp_ice_controlling_failover_state_t;
 
+typedef enum {
+	SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE = 0,
+	SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT,
+	SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE
+} switch_rtp_ice_controlling_timer_action_t;
+
 #define SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY 4
 
 typedef struct {
@@ -47,12 +53,22 @@ typedef struct {
 		switch_rtp_ice_controlling_failover_state_t controlling_failover_state;
 		int controlling_failover_idx;
 		switch_time_t controlling_failover_candidate_us;
+		switch_time_t controlling_failover_started_us;
 		switch_time_t controlling_failover_sent_us;
+		uint8_t controlling_failover_attempts;
 		char controlling_failover_probe_id[13];
 		char controlling_failover_nomination_id[13];
+		switch_socket_t *controlling_failover_socket;
+		switch_port_t controlling_failover_local_port;
+		int controlling_failover_local_family;
 		char selected_pair_check_ids[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY][13];
+		uint8_t selected_pair_check_controlling[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY];
+		switch_sockaddr_t *selected_pair_check_remote_addr[SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY];
 		uint8_t selected_pair_check_pos;
 		uint8_t selected_pair_check_count;
+		switch_socket_t *selected_pair_check_socket;
+		switch_port_t selected_pair_check_local_port;
+		int selected_pair_check_local_family;
 		switch_time_t selected_pair_last_response_us;
 		int inbound_media_idx;
 		switch_time_t inbound_media_us;
@@ -95,7 +111,17 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_restart_prflx_allowed(switch_rtp_ic
 	uint32_t bootstrap_ms, switch_time_t now);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_matches(switch_rtp_ice_t *ice,
 	switch_rtp_ice_controlling_failover_state_t expected_state, int candidate_idx, const char *transaction_id,
-	switch_bool_t authenticated);
+	switch_bool_t authenticated, switch_socket_t *local_socket, switch_port_t local_port, int local_family);
+SWITCH_DECLARE(switch_rtp_ice_controlling_timer_action_t) switch_rtp_pvt_controlling_failover_timer_action(
+	switch_rtp_ice_controlling_failover_state_t state, switch_time_t started_us, switch_time_t sent_us,
+	uint8_t attempts, switch_time_t now);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_role_conflict_response_matches(switch_rtp_ice_t *ice,
+	switch_sockaddr_t *from_addr, int candidate_idx, const char *transaction_id, switch_bool_t authenticated,
+	switch_socket_t *local_socket, switch_port_t local_port, int local_family, switch_bool_t *sent_controlling);
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_apply(switch_rtp_ice_t *ice, switch_bool_t sent_controlling);
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_cancel(switch_rtp_ice_t *ice);
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(char tie_breaker[8]);
+SWITCH_DECLARE(uint32_t) switch_rtp_pvt_ice_local_prflx_priority(switch_bool_t is_rtcp, switch_bool_t rtcp_mux);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -4,7 +4,8 @@
 typedef enum {
 	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE = 0,
 	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING,
-	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING
+	SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING,
+	SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING
 } switch_rtp_ice_controlling_failover_state_t;
 
 typedef enum {
@@ -122,6 +123,8 @@ SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_apply(switch_rtp_ice_t *ic
 SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_cancel(switch_rtp_ice_t *ice);
 SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(char tie_breaker[8]);
 SWITCH_DECLARE(uint32_t) switch_rtp_pvt_ice_local_prflx_priority(switch_bool_t is_rtcp, switch_bool_t rtcp_mux);
+SWITCH_DECLARE(int) switch_rtp_pvt_reuse_pending_startup_prflx_candidate(switch_rtp_t *rtp_session,
+	switch_rtp_ice_t *ice, const char *host, switch_port_t port, uint32_t priority);
 
 #endif /* __SWITCH_RTP_PVT_H__ */
 

--- a/src/include/switch_stun.h
+++ b/src/include/switch_stun.h
@@ -253,6 +253,8 @@ SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_fingerprint(switch_stun
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_use_candidate(switch_stun_packet_t *packet);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling(switch_stun_packet_t *packet);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled(switch_stun_packet_t *packet);
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling_value(switch_stun_packet_t *packet, const char *tie_breaker);
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled_value(switch_stun_packet_t *packet, const char *tie_breaker);
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_priority(switch_stun_packet_t *packet, uint32_t priority);
 
 /*!

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -79,6 +79,8 @@
 #define RTP_STUN_FREQ 1000000
 #define DEFAULT_ICE_NOMINATION_FALLBACK_MS 10000
 #define DEFAULT_ICE_MID_CALL_FAILOVER_MS 5000
+#define DEFAULT_ICE_CONTROLLING_FAILOVER_MS 5000
+#define ICE_CONTROLLING_FAILOVER_TRANSACTION_MS 3000
 #define DEFAULT_ICE_PRFLX_BOOTSTRAP_MS 10000
 #define rtp_header_len 12
 #define RTP_START_PORT 16384
@@ -1305,6 +1307,225 @@ static uint32_t ice_mid_call_failover_ms(switch_rtp_t *rtp_session, switch_rtp_i
 	return ice->mid_call_failover_enabled ? ice->mid_call_failover_ms : 0;
 }
 
+static void ice_controlling_failover_reset(switch_rtp_ice_t *ice, switch_bool_t clear_candidate)
+{
+	if (!ice) {
+		return;
+	}
+
+	ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE;
+	ice->controlling_failover_sent_us = 0;
+	memset(ice->controlling_failover_probe_id, 0, sizeof(ice->controlling_failover_probe_id));
+	memset(ice->controlling_failover_nomination_id, 0, sizeof(ice->controlling_failover_nomination_id));
+
+	if (clear_candidate) {
+		ice->controlling_failover_idx = -1;
+		ice->controlling_failover_candidate_us = 0;
+	}
+}
+
+static uint32_t ice_controlling_failover_ms(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
+{
+	if (!ice->controlling_failover_cached) {
+		switch_channel_t *channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+
+		if (channel) {
+			const char *failover_var = switch_channel_get_variable(channel, "rtp_ice_controlling_mid_call_failover");
+			int raw = switch_safe_atoi(
+				switch_channel_get_variable(channel, "rtp_ice_controlling_mid_call_failover_ms"),
+				DEFAULT_ICE_CONTROLLING_FAILOVER_MS);
+
+			ice->controlling_failover_enabled = failover_var && switch_true(failover_var);
+			ice->controlling_failover_ms = (raw > 0) ? (uint32_t)raw : 0;
+		} else {
+			ice->controlling_failover_enabled = 0;
+			ice->controlling_failover_ms = 0;
+		}
+
+		ice->controlling_failover_cached = 1;
+	}
+
+	return ice->controlling_failover_enabled ? ice->controlling_failover_ms : 0;
+}
+
+static switch_bool_t ice_controlling_failover_ready(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
+{
+	switch_channel_t *channel;
+
+	if (!rtp_session || !ice || ice != &rtp_session->ice || !ice->ice_params || !ice->addr ||
+		!(ice->type & ICE_VANILLA) || (ice->type & (ICE_CONTROLLED | ICE_LITE | ICE_LITE_INBOUND)) ||
+		ice->initializing || !ice->ready || !rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ||
+		!rtp_session->dtls || rtp_session->dtls->state != DS_READY ||
+		!ice_controlling_failover_ms(rtp_session, ice)) {
+		return SWITCH_FALSE;
+	}
+
+	channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+	if (channel && switch_channel_test_flag(channel, CF_RECOVERING)) {
+		return SWITCH_FALSE;
+	}
+
+	return SWITCH_TRUE;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_matches(switch_rtp_ice_t *ice,
+	switch_rtp_ice_controlling_failover_state_t expected_state, int candidate_idx, const char *transaction_id,
+	switch_bool_t authenticated)
+{
+	const char *expected_id;
+
+	if (!ice || !transaction_id || !authenticated || candidate_idx < 0 ||
+		ice->controlling_failover_state != expected_state || ice->controlling_failover_idx != candidate_idx) {
+		return SWITCH_FALSE;
+	}
+
+	if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING) {
+		expected_id = ice->controlling_failover_probe_id;
+	} else if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING) {
+		expected_id = ice->controlling_failover_nomination_id;
+	} else {
+		return SWITCH_FALSE;
+	}
+
+	return memcmp(transaction_id, expected_id, 12) ? SWITCH_FALSE : SWITCH_TRUE;
+}
+
+static void ice_selected_pair_check_record(switch_rtp_ice_t *ice, const char *transaction_id)
+{
+	uint8_t pos;
+
+	if (!ice || !transaction_id) {
+		return;
+	}
+
+	pos = ice->selected_pair_check_pos % SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY;
+	memcpy(ice->selected_pair_check_ids[pos], transaction_id, 12);
+	ice->selected_pair_check_ids[pos][12] = '\0';
+	ice->selected_pair_check_pos = (uint8_t)((pos + 1) % SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY);
+	if (ice->selected_pair_check_count < SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY) {
+		ice->selected_pair_check_count++;
+	}
+}
+
+static switch_bool_t ice_selected_pair_response_matches(switch_rtp_ice_t *ice, const char *transaction_id)
+{
+	int i;
+
+	if (!ice || !transaction_id) {
+		return SWITCH_FALSE;
+	}
+
+	for (i = 0; i < ice->selected_pair_check_count; ++i) {
+		if (!memcmp(transaction_id, ice->selected_pair_check_ids[i], 12)) {
+			return SWITCH_TRUE;
+		}
+	}
+
+	return SWITCH_FALSE;
+}
+
+static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	int candidate_idx, switch_bool_t use_candidate, char *transaction_id)
+{
+	uint8_t buf[256] = { 0 };
+	char sw[128] = "";
+	switch_stun_packet_t *packet;
+	switch_sockaddr_t *candidate_addr = NULL;
+	switch_socket_t *sock_output;
+	switch_size_t bytes;
+	switch_status_t status;
+	icand_t *candidate;
+
+	if (!rtp_session || !ice || !ice->ice_params || candidate_idx < 0 ||
+		candidate_idx >= ice->ice_params->cand_idx[ice->proto] || !transaction_id) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	if (zstr(candidate->con_addr) || !candidate->con_port ||
+		switch_sockaddr_info_get(&candidate_addr, candidate->con_addr, SWITCH_UNSPEC, candidate->con_port, 0,
+			rtp_session->pool) != SWITCH_STATUS_SUCCESS || !candidate_addr) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	sock_output = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output ?
+		rtp_session->rtcp_sock_output : rtp_session->sock_output;
+	if (!sock_output) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
+	switch_stun_packet_attribute_add_priority(packet, candidate->priority);
+	switch_snprintf(sw, sizeof(sw), "FreeSWITCH (%s)", switch_version_revision_human());
+	switch_stun_packet_attribute_add_software(packet, sw, (uint16_t)strlen(sw));
+	switch_stun_packet_attribute_add_controlling(packet);
+	if (use_candidate) {
+		switch_stun_packet_attribute_add_use_candidate(packet);
+	}
+	switch_stun_packet_attribute_add_integrity(packet, ice->rpass);
+	switch_stun_packet_attribute_add_fingerprint(packet);
+	bytes = switch_stun_packet_length(packet);
+	memcpy(transaction_id, packet->header.id, 12);
+	transaction_id[12] = '\0';
+
+	switch_mutex_lock(rtp_session->ice_mutex);
+	status = switch_socket_sendto(sock_output, candidate_addr, 0, (void *)packet, &bytes);
+	switch_mutex_unlock(rtp_session->ice_mutex);
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session),
+		status == SWITCH_STATUS_SUCCESS ? SWITCH_LOG_DEBUG : SWITCH_LOG_WARNING,
+		"ICE controlling failover: sent %s check to %s:%u idx:%d\n",
+		use_candidate ? "nomination" : "probe", candidate->con_addr, candidate->con_port, candidate_idx);
+
+	return status;
+}
+
+static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_time_t now)
+{
+	uint32_t failover_ms;
+	uint64_t selected_age_ms;
+	uint64_t candidate_age_ms;
+
+	if (!ice_controlling_failover_ready(rtp_session, ice)) {
+		if (ice && ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		}
+		return;
+	}
+
+	failover_ms = ice_controlling_failover_ms(rtp_session, ice);
+	if (!ice->selected_pair_last_response_us) {
+		ice->selected_pair_last_response_us = now;
+		return;
+	}
+
+	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		if (!ice->controlling_failover_sent_us || now < ice->controlling_failover_sent_us ||
+			(uint64_t)(now - ice->controlling_failover_sent_us) / 1000 > ICE_CONTROLLING_FAILOVER_TRANSACTION_MS) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		}
+		return;
+	}
+
+	if (ice->controlling_failover_idx < 0 || !ice->controlling_failover_candidate_us ||
+		now < ice->controlling_failover_candidate_us) {
+		return;
+	}
+
+	selected_age_ms = (uint64_t)(now - ice->selected_pair_last_response_us) / 1000;
+	candidate_age_ms = (uint64_t)(now - ice->controlling_failover_candidate_us) / 1000;
+	if (selected_age_ms < failover_ms || candidate_age_ms > ((uint64_t)failover_ms * 2)) {
+		return;
+	}
+
+	if (ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx, SWITCH_FALSE,
+		ice->controlling_failover_probe_id) == SWITCH_STATUS_SUCCESS) {
+		ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice->controlling_failover_sent_us = now;
+	}
+}
+
 static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_bool_t force)
 {
 	uint8_t buf[256] = { 0 };
@@ -1326,6 +1547,9 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	}
 
 	ice->next_run = now + RTP_STUN_FREQ;
+	if (!force) {
+		ice_controlling_failover_tick(rtp_session, ice, now);
+	}
 
 	/* Non-DTLS ICE-CONTROLLED peers that never send USE-CANDIDATE hang media
 	 * forever. After the fallback window since first responsive STUN,
@@ -1400,6 +1624,7 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
 
 	memcpy(ice->last_sent_id, packet->header.id, 12);
+	ice_selected_pair_check_record(ice, packet->header.id);
 
 	//if (ice->pass && ice->type == ICE_GOOGLE_JINGLE) {
 	//	switch_stun_packet_attribute_add_password(packet, ice->pass, (uint16_t)strlen(ice->pass));
@@ -1454,6 +1679,7 @@ SWITCH_DECLARE(void) switch_rtp_prepare_ice_restart(switch_rtp_t *rtp_session, i
 
 	switch_mutex_lock(rtp_session->ice_mutex);
 	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
 	ice->restart_pending = explicit_restart ? 1 : 0;
 	if (!explicit_restart) {
 		ice->restart_provisional = 0;
@@ -1524,6 +1750,175 @@ int icecmp(const char *them, switch_rtp_ice_t *ice)
 	return strcmp(them, ice->luser_ice);
 }
 
+static int ice_controlling_failover_note_alternative(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
+	switch_time_t now)
+{
+	int candidate_idx = -1;
+	int candidate_family = AF_UNSPEC;
+	int i;
+
+	if (!authenticated_current_request || !ice_controlling_failover_ready(rtp_session, ice) || zstr(host) || !port) {
+		return -1;
+	}
+
+	if (ice->addr) {
+		char active_buf[80] = "";
+		const char *active_host = switch_get_addr(active_buf, sizeof(active_buf), ice->addr);
+
+		if (active_host && !strcmp(active_host, host) && switch_sockaddr_get_port(ice->addr) == port) {
+			return -1;
+		}
+	}
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], host, port)) {
+			candidate_idx = i;
+			break;
+		}
+	}
+
+	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		if (candidate_idx == ice->controlling_failover_idx) {
+			ice->controlling_failover_candidate_us = now;
+			return candidate_idx;
+		}
+		return -1;
+	}
+
+	if (candidate_idx < 0 && priority && ice_remote_ip_is_acceptable(rtp_session, host, "udp", &candidate_family)) {
+		candidate_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, host, port, priority, SWITCH_FALSE);
+		if (candidate_idx > -1) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+				"ICE controlling failover: learned authenticated peer-reflexive alternative %s:%u idx:%d\n",
+				host, port, candidate_idx);
+		}
+	}
+
+	if (candidate_idx < 0 || candidate_idx == ice->ice_params->chosen[ice->proto]) {
+		return -1;
+	}
+
+	ice->controlling_failover_idx = candidate_idx;
+	ice->controlling_failover_candidate_us = now;
+	return candidate_idx;
+}
+
+static void ice_controlling_failover_commit(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	int candidate_idx, switch_time_t now)
+{
+	char old_buf[80] = "";
+	const char *old_host;
+	icand_t *candidate;
+	int i;
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	old_host = switch_get_addr(old_buf, sizeof(old_buf), ice->addr);
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		ice->ice_params->cands[i][ice->proto].use_candidate = 0;
+	}
+	ice->ice_params->cands[candidate_idx][ice->proto].use_candidate = 1;
+	ice->ice_params->chosen[ice->proto] = candidate_idx;
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+		"ICE controlling failover: nomination succeeded, switching %s from %s:%u to %s:%u idx:%d\n",
+		rtp_type(rtp_session), old_host, switch_sockaddr_get_port(ice->addr),
+		candidate->con_addr, candidate->con_port, candidate_idx);
+
+	switch_rtp_change_ice_dest(rtp_session, ice, candidate->con_addr, candidate->con_port);
+	if (rtp_session->dtls && rtp_session->dtls->remote_addr) {
+		if (switch_sockaddr_info_get(&rtp_session->dtls->remote_addr, candidate->con_addr, SWITCH_UNSPEC,
+			candidate->con_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"ICE controlling failover: failed to update DTLS remote addr to %s:%u\n",
+				candidate->con_addr, candidate->con_port);
+		}
+	}
+
+	ice->missed_count = 0;
+	ice->rready = 1;
+	ice->cand_responsive = 1;
+	ice->initializing = 0;
+	ice->last_ok = now;
+	ice->selected_pair_last_response_us = now;
+	memset(ice->selected_pair_check_ids, 0, sizeof(ice->selected_pair_check_ids));
+	ice->selected_pair_check_pos = 0;
+	ice->selected_pair_check_count = 0;
+	rtp_session->last_adj = now;
+	if (rtp_session->session) {
+		switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+		switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
+		switch_core_media_gen_key_frame(rtp_session->session);
+	}
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+}
+
+static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	switch_sockaddr_t *from_addr, int candidate_idx, const char *transaction_id,
+	switch_bool_t authenticated_response, switch_time_t now)
+{
+	uint32_t failover_ms;
+	uint64_t selected_age_ms;
+	switch_bool_t current_tuple;
+
+	current_tuple = ice->addr && switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
+	if (current_tuple && authenticated_response && ice_selected_pair_response_matches(ice, transaction_id)) {
+		ice->selected_pair_last_response_us = now;
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return SWITCH_FALSE;
+	}
+
+	if (!ice_controlling_failover_ready(rtp_session, ice)) {
+		switch_bool_t suppress_alternative = ice->controlling_failover_cached &&
+			ice->controlling_failover_enabled && !current_tuple && candidate_idx > -1 ? SWITCH_TRUE : SWITCH_FALSE;
+
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return suppress_alternative;
+	}
+
+	if (current_tuple || candidate_idx < 0 || candidate_idx == ice->ice_params->chosen[ice->proto]) {
+		return SWITCH_FALSE;
+	}
+
+	/* With the feature enabled, an alternative response is never allowed to fall through to the
+	 * legacy responsive-candidate auto-adjust path. Only this transaction state machine may commit it. */
+	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		return SWITCH_TRUE;
+	}
+
+	failover_ms = ice_controlling_failover_ms(rtp_session, ice);
+	selected_age_ms = ice->selected_pair_last_response_us && now >= ice->selected_pair_last_response_us ?
+		(uint64_t)(now - ice->selected_pair_last_response_us) / 1000 : 0;
+	if (selected_age_ms < failover_ms) {
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return SWITCH_TRUE;
+	}
+
+	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING) {
+		if (!switch_rtp_pvt_controlling_failover_response_matches(ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, candidate_idx, transaction_id, authenticated_response)) {
+			return SWITCH_TRUE;
+		}
+
+		if (ice_send_controlling_check(rtp_session, ice, candidate_idx, SWITCH_TRUE,
+			ice->controlling_failover_nomination_id) == SWITCH_STATUS_SUCCESS) {
+			ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING;
+			ice->controlling_failover_sent_us = now;
+		} else {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		}
+		return SWITCH_TRUE;
+	}
+
+	if (switch_rtp_pvt_controlling_failover_response_matches(ice,
+		SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, candidate_idx, transaction_id, authenticated_response)) {
+		ice_controlling_failover_commit(rtp_session, ice, candidate_idx, now);
+	}
+
+	return SWITCH_TRUE;
+}
+
 void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len)
 {
 	switch_stun_packet_t *packet;
@@ -1551,11 +1946,15 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	uint16_t raw_packet_type = 0;
 	switch_bool_t provisional_ice = SWITCH_FALSE;
 	switch_bool_t stun_auth_valid = SWITCH_FALSE;
+	switch_bool_t stun_response_auth_valid = SWITCH_FALSE;
 	switch_bool_t trusted_use_candidate = SWITCH_FALSE;
 	switch_bool_t authenticated_vanilla_use_candidate = SWITCH_FALSE;
+	switch_bool_t authenticated_current_request = SWITCH_FALSE;
 	switch_bool_t direct_username_match = SWITCH_FALSE;
 	switch_bool_t recovering = SWITCH_FALSE;
 	switch_rtp_recovery_nomination_proof_t nomination_proof = SWITCH_RTP_RECOVERY_NOMINATION_NONE;
+	switch_time_t packet_now = switch_micro_time_now();
+	int response_candidate_idx = -1;
 
 	if (is_rtcp) {
 		from_addr = rtp_session->rtcp_from_addr;
@@ -1590,6 +1989,9 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	}
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && (ice->type & ICE_VANILLA)) {
 		stun_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->pass) ? SWITCH_TRUE : SWITCH_FALSE;
+	}
+	if (raw_packet_type == SWITCH_STUN_BINDING_RESPONSE && (ice->type & ICE_VANILLA)) {
+		stun_response_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->rpass) ? SWITCH_TRUE : SWITCH_FALSE;
 	}
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST) {
 		prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
@@ -1655,6 +2057,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 								  );
 
 				if ((ice->type & ICE_VANILLA) && code == 487) {
+					ice_controlling_failover_reset(ice, SWITCH_TRUE);
 					/* Three role-conflict cases:
 					 *   1. We self-promoted (fallback) and peer rejects -> revert to CONTROLLED, disable fallback.
 					 *   2. We were CONTROLLED and peer 487s us -> RFC role-conflict flip to CONTROLLING.
@@ -1727,6 +2130,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && !zstr(username) && !icecmp(username, ice)) {
 		direct_username_match = SWITCH_TRUE;
 	}
+	authenticated_current_request = raw_packet_type == SWITCH_STUN_BINDING_REQUEST && direct_username_match &&
+		got_message_integrity && got_fingerprint && stun_auth_valid ? SWITCH_TRUE : SWITCH_FALSE;
 	nomination_proof = switch_rtp_pvt_recovery_dtls_nomination_proof(authenticated_vanilla_use_candidate, direct_username_match);
 
 	if ((ice->type & ICE_GOOGLE_JINGLE) && ok) {
@@ -1741,6 +2146,20 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		if (!ok) ok = !memcmp(packet->header.id, ice->last_sent_id, 12);
 
 		if (packet->header.type == SWITCH_STUN_BINDING_RESPONSE) {
+			if (ice->ice_params) {
+				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+					if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
+						response_candidate_idx = i;
+						break;
+					}
+				}
+			}
+			if (ice_controlling_failover_handle_response(rtp_session, ice, from_addr, response_candidate_idx,
+				packet->header.id, (stun_response_auth_valid && got_message_integrity && got_fingerprint) ?
+					SWITCH_TRUE : SWITCH_FALSE, packet_now)) {
+				goto end;
+			}
+
 			ok = 1;
 
 			if (rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX]) {
@@ -1962,6 +2381,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			int cmp = 0;
 			int same_host = 0;
 			int cur_idx = -1, is_relay = 0, is_responsive = 0, use_candidate = 0;
+			int failover_candidate_idx = -1;
 			uint32_t mid_call_failover_ms = 0;
 			uint32_t nomination_age_ms = 0;
 			uint32_t nomination_fresh_ms = 0;
@@ -2062,6 +2482,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					ice->type |= ICE_CONTROLLED;
 					ice->promoted_to_controlling = 0;
 					ice->nomination_fallback_enabled = 0;
+					ice_controlling_failover_reset(ice, SWITCH_TRUE);
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
 						"%s late peer USE-CANDIDATE after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
 				}
@@ -2162,6 +2583,17 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 					if (ice->ice_params->cands[i][ice->proto].use_candidate) {
 						use_candidate = 1;
 					}
+				}
+			}
+
+			if (!cmp && pri && authenticated_current_request) {
+				failover_candidate_idx = ice_controlling_failover_note_alternative(rtp_session, ice,
+					from_host, from_port, prflx_priority, authenticated_current_request, now);
+				if (failover_candidate_idx > -1) {
+					cur_idx = failover_candidate_idx;
+					is_relay = ice_candidate_is_relay(&ice->ice_params->cands[cur_idx][ice->proto]) ? 1 : 0;
+					is_responsive = ice->ice_params->cands[cur_idx][ice->proto].responsive ? 1 : 0;
+					use_candidate = ice->ice_params->cands[cur_idx][ice->proto].use_candidate ? 1 : 0;
 				}
 			}
 
@@ -2321,6 +2753,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				do_adj = 0;
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
 					"ICE preserving recovery DTLS restart tuple, ignoring non-nominated auto-adjust from %s:%d\n",
+					from_host, from_port);
+			} else if (!provisional_ice && failover_candidate_idx > -1 &&
+				ice_controlling_failover_ready(rtp_session, ice)) {
+				do_adj = 0;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5,
+					"ICE controlling failover: authenticated alternative %s:%d is pending FS nomination; suppressing legacy auto-adjust\n",
 					from_host, from_port);
 			} else if (!provisional_ice && !do_adj && !rtp_session->ice.dtls_handshake) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "ICE %d/%d dt:%d i:%d i2:%d cmp:%d\n", rtp_session->elapsed_stun, rtp_session->elapsed_media, (rtp_session->dtls && rtp_session->dtls->state != DS_READY), !ice->ready, !ice->rready, same_host);
@@ -6855,6 +7293,16 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	ice->mid_call_failover_ms = 0;
 	ice->mid_call_nominated_idx = -1;
 	ice->mid_call_nominated_us = 0;
+	ice->controlling_failover_cached = 0;
+	ice->controlling_failover_enabled = 0;
+	ice->controlling_failover_ms = 0;
+	ice->controlling_failover_idx = -1;
+	ice->controlling_failover_candidate_us = 0;
+	ice->selected_pair_last_response_us = switch_micro_time_now();
+	memset(ice->selected_pair_check_ids, 0, sizeof(ice->selected_pair_check_ids));
+	ice->selected_pair_check_pos = 0;
+	ice->selected_pair_check_count = 0;
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
 	ice->inbound_media_idx = -1;
 	ice->inbound_media_us = 0;
 	ice->prflx_bootstrap_cached = 0;
@@ -12104,7 +12552,9 @@ SWITCH_DECLARE(switch_sockaddr_t*) switch_rtp_session_get_remote_addr(switch_rtp
 
 rtp_extension_t *switch_rtp_find_extension(switch_rtp_t *rtp_session, uint8_t id) 
 {
-	for (int i = 0; i < rtp_session->num_remote_extensions; i++) {
+	int i;
+
+	for (i = 0; i < rtp_session->num_remote_extensions; i++) {
 		if (rtp_session->remote_extensions[i].id == id) {
 			return &rtp_session->remote_extensions[i];
 		}
@@ -12362,7 +12812,10 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 
 	{
 		uint32_t existing = ice->ice_params->cand_idx[ice->proto];
-		for (uint32_t i = 0; i < existing; i++) {
+		uint32_t i;
+		uint32_t j;
+
+		for (i = 0; i < existing; i++) {
 			const char *e_addr = ice->ice_params->cands[i][ice->proto].con_addr;
 			switch_port_t e_port = ice->ice_params->cands[i][ice->proto].con_port;
 			const char *e_found = ice->ice_params->cands[i][ice->proto].foundation;
@@ -12404,7 +12857,7 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 		}
 
 		if (existing > insert_at) {
-			for (uint32_t j = existing; j > insert_at; j--) {
+			for (j = existing; j > insert_at; j--) {
 				ice->ice_params->cands[j][ice->proto] = ice->ice_params->cands[j-1][ice->proto];
 			}
 
@@ -12414,6 +12867,10 @@ static switch_status_t switch_rtp_internal_add_remote_candidate(switch_rtp_t *rt
 
 			if (ice->mid_call_nominated_idx >= (int)insert_at) {
 				ice->mid_call_nominated_idx++;
+			}
+
+			if (ice->controlling_failover_idx >= (int)insert_at) {
+				ice->controlling_failover_idx++;
 			}
 
 			if (ice->inbound_media_idx >= (int)insert_at) {
@@ -12892,8 +13349,10 @@ static inline switch_bool_t cand_channel_bool(const switch_rtp_t *rtp_session, c
 
 static inline int addr_family_guess(const char *ip)
 {
+	const char *p;
+
 	if (!ip || !*ip) return AF_UNSPEC;
-	for (const char *p = ip; *p; ++p) {
+	for (p = ip; *p; ++p) {
 		if (*p == ':') return AF_INET6;
 		if (*p == '.') return AF_INET;
 	}
@@ -12906,9 +13365,10 @@ static inline switch_bool_t ipv4_is_linklocal(const char *ip)  { return !strncmp
 static inline switch_bool_t ipv4_is_multicast(const char *ip)
 {
 	int o1 = 0;
+	const char *p;
 	
 	if (!ip || !*ip) return SWITCH_FALSE;
-	for (const char *p = ip; *p && *p != '.'; ++p) {
+	for (p = ip; *p && *p != '.'; ++p) {
 		if (*p < '0' || *p > '9') return SWITCH_FALSE;
 		o1 = o1*10 + (*p - '0');
 		if (o1 > 255) return SWITCH_FALSE;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -925,7 +925,8 @@ static int switch_rtp_find_prflx_candidate(switch_rtp_ice_t *ice)
 	return -1;
 }
 
-static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, const char *host, switch_port_t port, uint32_t priority, switch_bool_t use_candidate)
+static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, const char *host,
+	switch_port_t port, uint32_t priority, switch_bool_t use_candidate, switch_bool_t mark_ready)
 {
 	icand_t *cand;
 	int idx;
@@ -937,6 +938,14 @@ static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_
 
 	for (idx = 0; idx < ice->ice_params->cand_idx[ice->proto]; ++idx) {
 		if (ice_candidate_matches_addr(&ice->ice_params->cands[idx][ice->proto], host, port)) {
+			cand = &ice->ice_params->cands[idx][ice->proto];
+			if (mark_ready) {
+				cand->responsive = 1;
+				cand->ready = 1;
+			}
+			if (use_candidate) {
+				cand->use_candidate = 1;
+			}
 			return idx;
 		}
 	}
@@ -960,8 +969,8 @@ static int switch_rtp_add_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_
 	cand->con_addr = switch_core_strdup(rtp_session->pool, host);
 	cand->con_port = port;
 	cand->cand_type = switch_core_strdup(rtp_session->pool, "prflx");
-	cand->responsive = 1;
-	cand->ready = 1;
+	cand->responsive = mark_ready ? 1 : 0;
+	cand->ready = mark_ready ? 1 : 0;
 	cand->use_candidate = use_candidate ? 1 : 0;
 
 	return idx;
@@ -1450,7 +1459,8 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_match
 
 	if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING) {
 		expected_id = ice->controlling_failover_probe_id;
-	} else if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING) {
+	} else if (expected_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING ||
+		expected_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
 		expected_id = ice->controlling_failover_nomination_id;
 	} else {
 		return SWITCH_FALSE;
@@ -1467,7 +1477,8 @@ SWITCH_DECLARE(switch_rtp_ice_controlling_timer_action_t) switch_rtp_pvt_control
 	uint64_t sent_elapsed_ms;
 
 	if ((state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING &&
-		 state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING) ||
+		 state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING &&
+		 state != SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) ||
 		!started_us || !sent_us || now < started_us || now < sent_us) {
 		return state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE ?
 			SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE : SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE;
@@ -1560,7 +1571,8 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_role_conflict_response_matches(
 	}
 
 	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING ||
-		ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING) {
+		ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING ||
+		ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
 		if (!switch_rtp_pvt_controlling_failover_response_matches(ice,
 			ice->controlling_failover_state, candidate_idx, transaction_id, authenticated,
 			local_socket, local_port, local_family)) {
@@ -1592,6 +1604,7 @@ static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, swi
 	switch_size_t bytes;
 	switch_status_t status;
 	icand_t *candidate;
+	const char *context;
 
 	if (!rtp_session || !ice || !ice->ice_params || candidate_idx < 0 ||
 		candidate_idx >= ice->ice_params->cand_idx[ice->proto] || !transaction_id) {
@@ -1599,6 +1612,7 @@ static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, swi
 	}
 
 	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	context = !ice->addr && ice->initializing ? "startup" : "failover";
 	if (zstr(candidate->con_addr) || !candidate->con_port ||
 		switch_sockaddr_info_get(&candidate_addr, candidate->con_addr, SWITCH_UNSPEC, candidate->con_port, 0,
 			rtp_session->pool) != SWITCH_STATUS_SUCCESS || !candidate_addr) {
@@ -1644,11 +1658,23 @@ static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, swi
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session),
 		status == SWITCH_STATUS_SUCCESS ? SWITCH_LOG_DEBUG : SWITCH_LOG_WARNING,
-		"ICE controlling failover: sent %s%s check to %s:%u idx:%d\n",
+		"ICE controlling %s: sent %s%s check to %s:%u idx:%d\n", context,
 		new_transaction ? "" : "retransmitted ", use_candidate ? "nomination" : "probe",
 		candidate->con_addr, candidate->con_port, candidate_idx);
 
 	return status;
+}
+
+static switch_bool_t ice_controlling_startup_ready(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
+{
+	if (!rtp_session || !ice || ice->proto != IPR_RTP || !ice->ice_params || ice->addr ||
+		!(ice->type & ICE_VANILLA) || (ice->type & (ICE_CONTROLLED | ICE_LITE | ICE_LITE_INBOUND)) ||
+		!ice->initializing || ice->ready || ice->cand_responsive ||
+		!rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] || !ice_prflx_bootstrap_ms(rtp_session, ice)) {
+		return SWITCH_FALSE;
+	}
+
+	return SWITCH_TRUE;
 }
 
 static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, switch_time_t now)
@@ -1661,6 +1687,37 @@ static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_
 	switch_socket_t *local_socket;
 	char *transaction_id;
 	switch_bool_t use_candidate;
+
+	if (ice && ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
+		if (!ice_controlling_startup_ready(rtp_session, ice)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+
+		local_addr = rtp_session->local_addr;
+		local_socket = rtp_session->sock_output;
+		if (!local_addr || !local_socket || ice->controlling_failover_socket != local_socket ||
+			ice->controlling_failover_local_port != switch_sockaddr_get_port(local_addr) ||
+			ice->controlling_failover_local_family != switch_sockaddr_get_family(local_addr)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+
+		timer_action = switch_rtp_pvt_controlling_failover_timer_action(ice->controlling_failover_state,
+			ice->controlling_failover_started_us, ice->controlling_failover_sent_us,
+			ice->controlling_failover_attempts, now);
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT &&
+			ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx, SWITCH_TRUE,
+				ice->controlling_failover_nomination_id, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS) {
+			ice->controlling_failover_sent_us = now;
+			ice->controlling_failover_attempts++;
+		}
+		return;
+	}
 
 	if (!ice_controlling_failover_ready(rtp_session, ice)) {
 		if (ice && ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
@@ -1969,13 +2026,84 @@ int icecmp(const char *them, switch_rtp_ice_t *ice)
 	return strcmp(them, ice->luser_ice);
 }
 
+static int ice_find_candidate_by_addr(switch_rtp_ice_t *ice, const char *host, switch_port_t port)
+{
+	int i;
+
+	if (!ice || !ice->ice_params || zstr(host) || !port) {
+		return -1;
+	}
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], host, port)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static int ice_note_authenticated_prflx_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
+	switch_bool_t mark_ready)
+{
+	int candidate_family = AF_UNSPEC;
+	int candidate_idx = -1;
+
+	if (!rtp_session || !ice || !ice->ice_params || !authenticated_current_request ||
+		zstr(host) || !port || !priority) {
+		return -1;
+	}
+
+	candidate_idx = ice_find_candidate_by_addr(ice, host, port);
+
+	if (candidate_idx < 0 && ice_remote_ip_is_acceptable(rtp_session, host, "udp", &candidate_family)) {
+		candidate_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, host, port, priority,
+			SWITCH_FALSE, mark_ready);
+		if (candidate_idx > -1) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+				"ICE learned authenticated peer-reflexive candidate %s:%u idx:%d\n",
+				host, port, candidate_idx);
+		}
+	}
+
+	return candidate_idx;
+}
+
+SWITCH_DECLARE(int) switch_rtp_pvt_reuse_pending_startup_prflx_candidate(switch_rtp_t *rtp_session,
+	switch_rtp_ice_t *ice, const char *host, switch_port_t port, uint32_t priority)
+{
+	icand_t *candidate;
+	int candidate_idx;
+
+	if (!rtp_session || !ice || !ice->ice_params || zstr(host) || !port || !priority ||
+		ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		return -1;
+	}
+
+	candidate_idx = ice->prflx_bootstrap_idx;
+	if (candidate_idx < 0 || candidate_idx >= ice->ice_params->cand_idx[ice->proto] ||
+		candidate_idx == ice->ice_params->chosen[ice->proto]) {
+		return -1;
+	}
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	if (zstr(candidate->cand_type) || strcasecmp(candidate->cand_type, "prflx") ||
+		candidate->use_candidate || candidate->responsive || candidate->ready) {
+		return -1;
+	}
+
+	candidate->con_addr = switch_core_strdup(rtp_session->pool, host);
+	candidate->con_port = port;
+	candidate->priority = priority;
+	return candidate_idx;
+}
+
 static int ice_controlling_failover_note_alternative(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
 	switch_time_t now)
 {
 	int candidate_idx = -1;
-	int candidate_family = AF_UNSPEC;
-	int i;
 
 	if (!authenticated_current_request || !ice_controlling_failover_ready(rtp_session, ice) || zstr(host) || !port) {
 		return -1;
@@ -1990,14 +2118,8 @@ static int ice_controlling_failover_note_alternative(switch_rtp_t *rtp_session, 
 		}
 	}
 
-	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
-		if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], host, port)) {
-			candidate_idx = i;
-			break;
-		}
-	}
-
 	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		candidate_idx = ice_find_candidate_by_addr(ice, host, port);
 		if (candidate_idx == ice->controlling_failover_idx) {
 			ice->controlling_failover_candidate_us = now;
 			return candidate_idx;
@@ -2005,14 +2127,8 @@ static int ice_controlling_failover_note_alternative(switch_rtp_t *rtp_session, 
 		return -1;
 	}
 
-	if (candidate_idx < 0 && priority && ice_remote_ip_is_acceptable(rtp_session, host, "udp", &candidate_family)) {
-		candidate_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, host, port, priority, SWITCH_FALSE);
-		if (candidate_idx > -1) {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
-				"ICE controlling failover: learned authenticated peer-reflexive alternative %s:%u idx:%d\n",
-				host, port, candidate_idx);
-		}
-	}
+	candidate_idx = ice_note_authenticated_prflx_candidate(rtp_session, ice, host, port, priority,
+		authenticated_current_request, SWITCH_TRUE);
 
 	if (candidate_idx < 0 || candidate_idx == ice->ice_params->chosen[ice->proto]) {
 		return -1;
@@ -2020,6 +2136,45 @@ static int ice_controlling_failover_note_alternative(switch_rtp_t *rtp_session, 
 
 	ice->controlling_failover_idx = candidate_idx;
 	ice->controlling_failover_candidate_us = now;
+	return candidate_idx;
+}
+
+static int ice_controlling_startup_note_candidate(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	const char *host, switch_port_t port, uint32_t priority, switch_bool_t authenticated_current_request,
+	switch_time_t now)
+{
+	int candidate_family = AF_UNSPEC;
+	int candidate_idx;
+
+	if (!authenticated_current_request || !ice_controlling_startup_ready(rtp_session, ice) ||
+		!ice_remote_ip_is_acceptable(rtp_session, host, "udp", &candidate_family)) {
+		return -1;
+	}
+
+	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+		candidate_idx = ice_find_candidate_by_addr(ice, host, port);
+		if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING &&
+			candidate_idx == ice->controlling_failover_idx) {
+			ice->controlling_failover_candidate_us = now;
+			return candidate_idx;
+		}
+		return -1;
+	}
+
+	candidate_idx = ice_note_authenticated_prflx_candidate(rtp_session, ice, host, port, priority,
+		authenticated_current_request, SWITCH_FALSE);
+	if (candidate_idx < 0) {
+		candidate_idx = switch_rtp_pvt_reuse_pending_startup_prflx_candidate(rtp_session, ice,
+			host, port, priority);
+	}
+	if (candidate_idx < 0) {
+		return -1;
+	}
+
+	ice->controlling_failover_idx = candidate_idx;
+	ice->controlling_failover_candidate_us = now;
+	ice->prflx_bootstrap_idx = candidate_idx;
+	ice->prflx_bootstrap_us = now;
 	return candidate_idx;
 }
 
@@ -2072,6 +2227,80 @@ static void ice_controlling_failover_commit(switch_rtp_t *rtp_session, switch_rt
 	ice_controlling_failover_reset(ice, SWITCH_TRUE);
 }
 
+static void ice_controlling_startup_commit(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
+	int candidate_idx, switch_time_t now)
+{
+	switch_sockaddr_t *candidate_addr = NULL;
+	switch_sockaddr_t *dtls_addr = NULL;
+	switch_channel_t *channel;
+	icand_t *candidate;
+	int i;
+
+	if (!rtp_session || !ice || !ice->ice_params || candidate_idx < 0 ||
+		candidate_idx >= ice->ice_params->cand_idx[ice->proto]) {
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return;
+	}
+
+	candidate = &ice->ice_params->cands[candidate_idx][ice->proto];
+	if (zstr(candidate->con_addr) || !candidate->con_port ||
+		switch_sockaddr_info_get(&candidate_addr, candidate->con_addr, SWITCH_UNSPEC,
+			candidate->con_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS || !candidate_addr ||
+		(rtp_session->dtls &&
+		 switch_sockaddr_info_get(&dtls_addr, candidate->con_addr, SWITCH_UNSPEC,
+			candidate->con_port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+			"ICE controlling startup: failed to resolve nominated tuple %s:%u\n",
+			ice_candidate_addr_safe(candidate), candidate->con_port);
+		ice_controlling_failover_reset(ice, SWITCH_TRUE);
+		return;
+	}
+
+	for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+		ice->ice_params->cands[i][ice->proto].use_candidate = 0;
+	}
+	candidate->use_candidate = 1;
+	candidate->responsive = 1;
+	candidate->ready = 1;
+	ice->ice_params->chosen[ice->proto] = candidate_idx;
+	ice->ice_params->is_chosen[ice->proto] = 1;
+
+	switch_rtp_change_ice_dest(rtp_session, ice, candidate->con_addr, candidate->con_port);
+	ice->addr = candidate_addr;
+	if (rtp_session->dtls) {
+		rtp_session->dtls->remote_addr = dtls_addr;
+	}
+
+	ice->missed_count = 0;
+	ice->ready = 1;
+	ice->rready = 1;
+	ice->cand_responsive = 1;
+	ice->initializing = 0;
+	ice->prflx_bootstrap_idx = candidate_idx;
+	ice->prflx_bootstrap_us = now;
+	ice->restart_provisional = 0;
+	ice->restart_provisional_us = 0;
+	ice->last_ok = now;
+	ice->selected_pair_last_response_us = now;
+	if (!ice->first_responsive_us) {
+		ice->first_responsive_us = now;
+	}
+	ice_selected_pair_check_reset(ice);
+	rtp_session->last_adj = now;
+
+	channel = rtp_session->session ? switch_core_session_get_channel(rtp_session->session) : NULL;
+	if (channel) {
+		switch_channel_clear_flag(channel, CF_NO_ICE);
+		switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);
+		switch_core_media_gen_key_frame(rtp_session->session);
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+		"ICE controlling startup: nomination succeeded, selected %s candidate %s:%u idx:%d\n",
+		rtp_type(rtp_session), candidate->con_addr, candidate->con_port, candidate_idx);
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+}
+
 static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_sockaddr_t *from_addr, int candidate_idx, const char *transaction_id,
 	switch_bool_t authenticated_response, switch_socket_t *local_socket, switch_port_t local_port,
@@ -2080,6 +2309,20 @@ static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_
 	uint32_t failover_ms;
 	uint64_t selected_age_ms;
 	switch_bool_t current_tuple;
+
+	if (ice && ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING) {
+		if (!ice_controlling_startup_ready(rtp_session, ice)) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return SWITCH_TRUE;
+		}
+
+		if (switch_rtp_pvt_controlling_failover_response_matches(ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, candidate_idx, transaction_id,
+			authenticated_response, local_socket, local_port, local_family)) {
+			ice_controlling_startup_commit(rtp_session, ice, candidate_idx, now);
+		}
+		return SWITCH_TRUE;
+	}
 
 	current_tuple = ice->addr && switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
 	/* A selected pair is live only after an authenticated response matches a
@@ -2173,6 +2416,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	int got_use_candidate_covered = 0;
 	int got_message_integrity = 0;
 	int got_fingerprint = 0;
+	int got_ice_controlled = 0;
+	int got_ice_controlling = 0;
 	uint32_t prflx_bootstrap_ms = 0;
 	uint32_t stun_packet_len = 0;
 	uint16_t raw_packet_type = 0;
@@ -2182,6 +2427,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_bool_t trusted_use_candidate = SWITCH_FALSE;
 	switch_bool_t authenticated_vanilla_use_candidate = SWITCH_FALSE;
 	switch_bool_t authenticated_current_request = SWITCH_FALSE;
+	switch_bool_t controlling_startup_request = SWITCH_FALSE;
 	switch_bool_t direct_username_match = SWITCH_FALSE;
 	switch_bool_t recovering = SWITCH_FALSE;
 	switch_rtp_recovery_nomination_proof_t nomination_proof = SWITCH_RTP_RECOVERY_NOMINATION_NONE;
@@ -2238,10 +2484,15 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST) {
 		prflx_bootstrap_ms = ice_prflx_bootstrap_ms(rtp_session, ice);
 	}
-	if (provisional_ice && (raw_packet_type != SWITCH_STUN_BINDING_REQUEST || !prflx_bootstrap_ms || !stun_auth_valid)) {
+	if (provisional_ice &&
+		!((raw_packet_type == SWITCH_STUN_BINDING_REQUEST && prflx_bootstrap_ms && stun_auth_valid) ||
+		  ((raw_packet_type == SWITCH_STUN_BINDING_RESPONSE ||
+		    raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) && stun_response_auth_valid &&
+		   ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING))) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
-			"ICE peer-reflexive bootstrap: rejected unvalidated %s STUN packet from %s:%d (bootstrap:%u auth:%d)\n",
-			rtp_type(rtp_session), from_host, from_port, prflx_bootstrap_ms, stun_auth_valid);
+			"ICE peer-reflexive bootstrap: rejected unvalidated %s STUN packet from %s:%d (bootstrap:%u request_auth:%d response_auth:%d state:%d)\n",
+			rtp_type(rtp_session), from_host, from_port, prflx_bootstrap_ms, stun_auth_valid,
+			stun_response_auth_valid, ice->controlling_failover_state);
 		goto end;
 	}
 
@@ -2286,6 +2537,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			break;
 		case SWITCH_STUN_ATTR_FINGERPRINT:
 			got_fingerprint = 1;
+			break;
+		case SWITCH_STUN_ATTR_CONTROLLED:
+			got_ice_controlled = 1;
+			break;
+		case SWITCH_STUN_ATTR_CONTROLLING:
+			got_ice_controlling = 1;
 			break;
 		case SWITCH_STUN_ATTR_ERROR_CODE:
 			{
@@ -2403,6 +2660,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	}
 	authenticated_current_request = raw_packet_type == SWITCH_STUN_BINDING_REQUEST && direct_username_match &&
 		got_message_integrity && got_fingerprint && stun_auth_valid ? SWITCH_TRUE : SWITCH_FALSE;
+	controlling_startup_request = provisional_ice && authenticated_current_request && pri &&
+		got_ice_controlled && !got_ice_controlling &&
+		rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice_controlling_startup_ready(rtp_session, ice) ?
+		SWITCH_TRUE : SWITCH_FALSE;
 	nomination_proof = switch_rtp_pvt_recovery_dtls_nomination_proof(authenticated_vanilla_use_candidate, direct_username_match);
 
 	if ((ice->type & ICE_GOOGLE_JINGLE) && ok) {
@@ -2514,7 +2775,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		}
 		if (provisional_ice) {
 			ok = direct_username_match && pri &&
-				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate);
+				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate || controlling_startup_request);
 		}
 
 		if (ok && !provisional_ice) {
@@ -2646,6 +2907,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 			int same_host = 0;
 			int cur_idx = -1, is_relay = 0, is_responsive = 0, use_candidate = 0;
 			int failover_candidate_idx = -1;
+			int startup_nomination_idx = -1;
 			uint32_t mid_call_failover_ms = 0;
 			uint32_t nomination_age_ms = 0;
 			uint32_t nomination_fresh_ms = 0;
@@ -2876,7 +3138,23 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				 (!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) ? SWITCH_TRUE : SWITCH_FALSE,
 				prflx_bootstrap_ms, now);
 
-			if (prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok && !guard_recovery_dtls_tuple &&
+			if (controlling_startup_request && !cmp && ok && !guard_recovery_dtls_tuple &&
+				(!dtls || dtls->state < DS_READY) &&
+				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
+				startup_nomination_idx = ice_controlling_startup_note_candidate(rtp_session, ice,
+					from_host, from_port, prflx_priority, authenticated_current_request, now);
+				if (startup_nomination_idx > -1) {
+					cur_idx = startup_nomination_idx;
+					is_relay = ice_candidate_is_relay(&ice->ice_params->cands[cur_idx][ice->proto]) ? 1 : 0;
+					is_responsive = 1;
+					use_candidate = 0;
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
+						"ICE controlling startup: learned authenticated %s candidate %s:%d idx:%d priority:%u; pending FS nomination\n",
+						rtp_type(rtp_session), from_host, from_port, startup_nomination_idx, prflx_priority);
+				}
+			}
+
+			if (!controlling_startup_request && prflx_bootstrap_ms > 0 && pri && cur_idx < 0 && rtp_session->elapsed_stun <= prflx_bootstrap_ms && ice->initializing && !ice->cand_responsive && !cmp && ok && !guard_recovery_dtls_tuple &&
 				(!dtls || dtls->state < DS_READY || restart_prflx_allowed) && stun_auth_valid &&
 				(!ice->prflx_bootstrap_require_use_candidate || got_use_candidate) &&
 				(!ice->prflx_bootstrap_us || prflx_age_ms <= prflx_bootstrap_ms)) {
@@ -2890,7 +3168,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
 							"ICE peer-reflexive bootstrap: failed to resolve learned tuple %s:%d\n", from_host, from_port);
 					} else {
-						prflx_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, from_host, from_port, prflx_priority, got_use_candidate ? SWITCH_TRUE : SWITCH_FALSE);
+						prflx_idx = switch_rtp_add_prflx_candidate(rtp_session, ice, from_host, from_port,
+							prflx_priority, got_use_candidate ? SWITCH_TRUE : SWITCH_FALSE, SWITCH_TRUE);
 					}
 				}
 
@@ -3125,9 +3404,21 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 				ice->last_ok = now;
 			}
 
-			if (!switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED) || cmp || do_adj) {
+			if (startup_nomination_idx > -1 || !switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_ICE_NO_RESPONSE_IGNORED) || cmp || do_adj) {
 				switch_socket_sendto(sock_output, from_addr, 0, (void *) rpacket, &bytes);
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG6, "Send %s STUN Binding Response to %s:%u\n", rtp_type(rtp_session), from_host, from_port);
+				if (startup_nomination_idx > -1 &&
+					ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
+					if (ice_send_controlling_check(rtp_session, ice, startup_nomination_idx, SWITCH_TRUE,
+						ice->controlling_failover_nomination_id, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
+						ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING;
+						ice->controlling_failover_started_us = now;
+						ice->controlling_failover_sent_us = now;
+						ice->controlling_failover_attempts = 1;
+					} else {
+						ice_controlling_failover_reset(ice, SWITCH_TRUE);
+					}
+				}
 				if (!(rtp_session->ice.type & ICE_LITE) && ice->initializing && !is_responsive) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "Send %s STUN Binding Request on ICE candidate still unresponsive to %s:%u\n", rtp_type(rtp_session), from_host, from_port);
 					if (ice_out(rtp_session, ice, SWITCH_TRUE) != SWITCH_STATUS_SUCCESS)

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -80,7 +80,10 @@
 #define DEFAULT_ICE_NOMINATION_FALLBACK_MS 10000
 #define DEFAULT_ICE_MID_CALL_FAILOVER_MS 5000
 #define DEFAULT_ICE_CONTROLLING_FAILOVER_MS 5000
-#define ICE_CONTROLLING_FAILOVER_TRANSACTION_MS 3000
+#define ICE_CONTROLLING_FAILOVER_TRANSACTION_MS 5000
+#define ICE_CONTROLLING_FAILOVER_RTO_MS 1000
+#define ICE_CONTROLLING_FAILOVER_MAX_ATTEMPTS 4
+#define ICE_LOCAL_PRFLX_PRIORITY 0x6effffffU
 #define DEFAULT_ICE_PRFLX_BOOTSTRAP_MS 10000
 #define rtp_header_len 12
 #define RTP_START_PORT 16384
@@ -443,6 +446,7 @@ struct switch_rtp {
 	switch_port_t rx_port;
 	switch_rtp_ice_t ice;
 	switch_rtp_ice_t rtcp_ice;
+	char ice_tie_breaker[8];
 	char *timer_name;
 	char *local_host_str;
 	char *remote_host_str;
@@ -1314,7 +1318,12 @@ static void ice_controlling_failover_reset(switch_rtp_ice_t *ice, switch_bool_t 
 	}
 
 	ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE;
+	ice->controlling_failover_started_us = 0;
 	ice->controlling_failover_sent_us = 0;
+	ice->controlling_failover_attempts = 0;
+	ice->controlling_failover_socket = NULL;
+	ice->controlling_failover_local_port = 0;
+	ice->controlling_failover_local_family = SWITCH_UNSPEC;
 	memset(ice->controlling_failover_probe_id, 0, sizeof(ice->controlling_failover_probe_id));
 	memset(ice->controlling_failover_nomination_id, 0, sizeof(ice->controlling_failover_nomination_id));
 
@@ -1322,6 +1331,62 @@ static void ice_controlling_failover_reset(switch_rtp_ice_t *ice, switch_bool_t 
 		ice->controlling_failover_idx = -1;
 		ice->controlling_failover_candidate_us = 0;
 	}
+}
+
+static void ice_selected_pair_check_reset(switch_rtp_ice_t *ice)
+{
+	if (!ice) {
+		return;
+	}
+
+	memset(ice->selected_pair_check_ids, 0, sizeof(ice->selected_pair_check_ids));
+	memset(ice->selected_pair_check_controlling, 0, sizeof(ice->selected_pair_check_controlling));
+	memset(ice->selected_pair_check_remote_addr, 0, sizeof(ice->selected_pair_check_remote_addr));
+	ice->selected_pair_check_pos = 0;
+	ice->selected_pair_check_count = 0;
+	ice->selected_pair_check_socket = NULL;
+	ice->selected_pair_check_local_port = 0;
+	ice->selected_pair_check_local_family = SWITCH_UNSPEC;
+}
+
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_cancel(switch_rtp_ice_t *ice)
+{
+	if (!ice) {
+		return;
+	}
+
+	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+	ice_selected_pair_check_reset(ice);
+	memset(ice->last_sent_id, 0, sizeof(ice->last_sent_id));
+}
+
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_apply(switch_rtp_ice_t *ice, switch_bool_t sent_controlling)
+{
+	if (!ice || !(ice->type & ICE_VANILLA)) {
+		return;
+	}
+
+	if (sent_controlling) {
+		ice->type |= ICE_CONTROLLED;
+		if (ice->promoted_to_controlling) {
+			ice->nomination_fallback_enabled = 0;
+		}
+	} else {
+		ice->type &= ~ICE_CONTROLLED;
+	}
+	ice->promoted_to_controlling = 0;
+}
+
+SWITCH_DECLARE(void) switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(char tie_breaker[8])
+{
+	if (tie_breaker) {
+		switch_stun_random_string(tie_breaker, 8, NULL);
+	}
+}
+
+SWITCH_DECLARE(uint32_t) switch_rtp_pvt_ice_local_prflx_priority(switch_bool_t is_rtcp, switch_bool_t rtcp_mux)
+{
+	return is_rtcp && !rtcp_mux ? ICE_LOCAL_PRFLX_PRIORITY - 1 : ICE_LOCAL_PRFLX_PRIORITY;
 }
 
 static uint32_t ice_controlling_failover_ms(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice)
@@ -1370,12 +1435,16 @@ static switch_bool_t ice_controlling_failover_ready(switch_rtp_t *rtp_session, s
 
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_matches(switch_rtp_ice_t *ice,
 	switch_rtp_ice_controlling_failover_state_t expected_state, int candidate_idx, const char *transaction_id,
-	switch_bool_t authenticated)
+	switch_bool_t authenticated, switch_socket_t *local_socket, switch_port_t local_port, int local_family)
 {
 	const char *expected_id;
 
 	if (!ice || !transaction_id || !authenticated || candidate_idx < 0 ||
-		ice->controlling_failover_state != expected_state || ice->controlling_failover_idx != candidate_idx) {
+		ice->controlling_failover_state != expected_state || ice->controlling_failover_idx != candidate_idx ||
+		!local_socket || ice->controlling_failover_socket != local_socket ||
+		!ice->controlling_failover_local_port || ice->controlling_failover_local_port != local_port ||
+		ice->controlling_failover_local_family == SWITCH_UNSPEC ||
+		ice->controlling_failover_local_family != local_family) {
 		return SWITCH_FALSE;
 	}
 
@@ -1390,33 +1459,88 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_controlling_failover_response_match
 	return memcmp(transaction_id, expected_id, 12) ? SWITCH_FALSE : SWITCH_TRUE;
 }
 
-static void ice_selected_pair_check_record(switch_rtp_ice_t *ice, const char *transaction_id)
+SWITCH_DECLARE(switch_rtp_ice_controlling_timer_action_t) switch_rtp_pvt_controlling_failover_timer_action(
+	switch_rtp_ice_controlling_failover_state_t state, switch_time_t started_us, switch_time_t sent_us,
+	uint8_t attempts, switch_time_t now)
+{
+	uint64_t elapsed_ms;
+	uint64_t sent_elapsed_ms;
+
+	if ((state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING &&
+		 state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING) ||
+		!started_us || !sent_us || now < started_us || now < sent_us) {
+		return state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE ?
+			SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE : SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE;
+	}
+
+	elapsed_ms = (uint64_t)(now - started_us) / 1000;
+	sent_elapsed_ms = (uint64_t)(now - sent_us) / 1000;
+	if (elapsed_ms >= ICE_CONTROLLING_FAILOVER_TRANSACTION_MS ||
+		(attempts >= ICE_CONTROLLING_FAILOVER_MAX_ATTEMPTS && sent_elapsed_ms >= ICE_CONTROLLING_FAILOVER_RTO_MS)) {
+		return SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE;
+	}
+
+	if (attempts < ICE_CONTROLLING_FAILOVER_MAX_ATTEMPTS && sent_elapsed_ms >= ICE_CONTROLLING_FAILOVER_RTO_MS) {
+		return SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT;
+	}
+
+	return SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE;
+}
+
+static void ice_selected_pair_check_record(switch_rtp_ice_t *ice, const char *transaction_id,
+	switch_bool_t sent_controlling, switch_socket_t *local_socket, switch_sockaddr_t *local_addr,
+	switch_sockaddr_t *remote_addr)
 {
 	uint8_t pos;
 
-	if (!ice || !transaction_id) {
+	if (!ice || !transaction_id || !local_socket || !local_addr || !remote_addr) {
 		return;
 	}
+
+	if (ice->selected_pair_check_socket != local_socket ||
+		ice->selected_pair_check_local_port != switch_sockaddr_get_port(local_addr) ||
+		ice->selected_pair_check_local_family != switch_sockaddr_get_family(local_addr)) {
+		ice_selected_pair_check_reset(ice);
+	}
+	ice->selected_pair_check_socket = local_socket;
+	ice->selected_pair_check_local_port = switch_sockaddr_get_port(local_addr);
+	ice->selected_pair_check_local_family = switch_sockaddr_get_family(local_addr);
 
 	pos = ice->selected_pair_check_pos % SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY;
 	memcpy(ice->selected_pair_check_ids[pos], transaction_id, 12);
 	ice->selected_pair_check_ids[pos][12] = '\0';
+	ice->selected_pair_check_controlling[pos] = sent_controlling ? 1 : 0;
+	ice->selected_pair_check_remote_addr[pos] = remote_addr;
 	ice->selected_pair_check_pos = (uint8_t)((pos + 1) % SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY);
 	if (ice->selected_pair_check_count < SWITCH_RTP_ICE_SELECTED_PAIR_CHECK_HISTORY) {
 		ice->selected_pair_check_count++;
 	}
 }
 
-static switch_bool_t ice_selected_pair_response_matches(switch_rtp_ice_t *ice, const char *transaction_id)
+static switch_bool_t ice_selected_pair_response_matches(switch_rtp_ice_t *ice, const char *transaction_id,
+	switch_sockaddr_t *from_addr, switch_socket_t *local_socket, switch_port_t local_port, int local_family,
+	switch_bool_t consume, switch_bool_t *sent_controlling)
 {
 	int i;
 
-	if (!ice || !transaction_id) {
+	if (!ice || !transaction_id || !from_addr || !local_socket || ice->selected_pair_check_socket != local_socket ||
+		ice->selected_pair_check_local_port != local_port ||
+		ice->selected_pair_check_local_family != local_family) {
 		return SWITCH_FALSE;
 	}
 
 	for (i = 0; i < ice->selected_pair_check_count; ++i) {
-		if (!memcmp(transaction_id, ice->selected_pair_check_ids[i], 12)) {
+		if (!memcmp(transaction_id, ice->selected_pair_check_ids[i], 12) &&
+			ice->selected_pair_check_remote_addr[i] &&
+			switch_cmp_addr(from_addr, ice->selected_pair_check_remote_addr[i], SWITCH_FALSE)) {
+			if (sent_controlling) {
+				*sent_controlling = ice->selected_pair_check_controlling[i] ? SWITCH_TRUE : SWITCH_FALSE;
+			}
+			if (consume) {
+				memset(ice->selected_pair_check_ids[i], 0, sizeof(ice->selected_pair_check_ids[i]));
+				ice->selected_pair_check_controlling[i] = 0;
+				ice->selected_pair_check_remote_addr[i] = NULL;
+			}
 			return SWITCH_TRUE;
 		}
 	}
@@ -1424,13 +1548,46 @@ static switch_bool_t ice_selected_pair_response_matches(switch_rtp_ice_t *ice, c
 	return SWITCH_FALSE;
 }
 
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_role_conflict_response_matches(switch_rtp_ice_t *ice,
+	switch_sockaddr_t *from_addr,
+	int candidate_idx, const char *transaction_id, switch_bool_t authenticated,
+	switch_socket_t *local_socket, switch_port_t local_port, int local_family, switch_bool_t *sent_controlling)
+{
+	char *matched_id;
+
+	if (!ice || !from_addr || !transaction_id || !authenticated || !sent_controlling) {
+		return SWITCH_FALSE;
+	}
+
+	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING ||
+		ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING) {
+		if (!switch_rtp_pvt_controlling_failover_response_matches(ice,
+			ice->controlling_failover_state, candidate_idx, transaction_id, authenticated,
+			local_socket, local_port, local_family)) {
+			return SWITCH_FALSE;
+		}
+
+		*sent_controlling = SWITCH_TRUE;
+		matched_id = ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING ?
+			ice->controlling_failover_probe_id : ice->controlling_failover_nomination_id;
+		memset(matched_id, 0, 13);
+		return SWITCH_TRUE;
+	}
+
+	return ice_selected_pair_response_matches(ice, transaction_id, from_addr,
+		local_socket, local_port, local_family,
+			SWITCH_TRUE, sent_controlling) ?
+		SWITCH_TRUE : SWITCH_FALSE;
+}
+
 static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
-	int candidate_idx, switch_bool_t use_candidate, char *transaction_id)
+	int candidate_idx, switch_bool_t use_candidate, char *transaction_id, switch_bool_t new_transaction)
 {
 	uint8_t buf[256] = { 0 };
 	char sw[128] = "";
 	switch_stun_packet_t *packet;
 	switch_sockaddr_t *candidate_addr = NULL;
+	switch_sockaddr_t *local_addr;
 	switch_socket_t *sock_output;
 	switch_size_t bytes;
 	switch_status_t status;
@@ -1450,24 +1607,36 @@ static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, swi
 
 	sock_output = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output ?
 		rtp_session->rtcp_sock_output : rtp_session->sock_output;
-	if (!sock_output) {
+	local_addr = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_local_addr ?
+		rtp_session->rtcp_local_addr : rtp_session->local_addr;
+	if (!sock_output || !local_addr) {
 		return SWITCH_STATUS_FALSE;
 	}
 
-	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST,
+		new_transaction ? NULL : transaction_id, buf);
 	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
-	switch_stun_packet_attribute_add_priority(packet, candidate->priority);
+	/* RFC 8445 PRIORITY describes the local peer-reflexive candidate that this
+	 * check could create at the peer, not the remote candidate being checked. */
+	switch_stun_packet_attribute_add_priority(packet,
+		switch_rtp_pvt_ice_local_prflx_priority(ice == &rtp_session->rtcp_ice,
+			rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ? SWITCH_TRUE : SWITCH_FALSE));
 	switch_snprintf(sw, sizeof(sw), "FreeSWITCH (%s)", switch_version_revision_human());
 	switch_stun_packet_attribute_add_software(packet, sw, (uint16_t)strlen(sw));
-	switch_stun_packet_attribute_add_controlling(packet);
+	switch_stun_packet_attribute_add_controlling_value(packet, rtp_session->ice_tie_breaker);
 	if (use_candidate) {
 		switch_stun_packet_attribute_add_use_candidate(packet);
 	}
 	switch_stun_packet_attribute_add_integrity(packet, ice->rpass);
 	switch_stun_packet_attribute_add_fingerprint(packet);
 	bytes = switch_stun_packet_length(packet);
-	memcpy(transaction_id, packet->header.id, 12);
-	transaction_id[12] = '\0';
+	if (new_transaction) {
+		memcpy(transaction_id, packet->header.id, 12);
+		transaction_id[12] = '\0';
+		ice->controlling_failover_local_port = switch_sockaddr_get_port(local_addr);
+		ice->controlling_failover_local_family = switch_sockaddr_get_family(local_addr);
+		ice->controlling_failover_socket = sock_output;
+	}
 
 	switch_mutex_lock(rtp_session->ice_mutex);
 	status = switch_socket_sendto(sock_output, candidate_addr, 0, (void *)packet, &bytes);
@@ -1475,8 +1644,9 @@ static switch_status_t ice_send_controlling_check(switch_rtp_t *rtp_session, swi
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session),
 		status == SWITCH_STATUS_SUCCESS ? SWITCH_LOG_DEBUG : SWITCH_LOG_WARNING,
-		"ICE controlling failover: sent %s check to %s:%u idx:%d\n",
-		use_candidate ? "nomination" : "probe", candidate->con_addr, candidate->con_port, candidate_idx);
+		"ICE controlling failover: sent %s%s check to %s:%u idx:%d\n",
+		new_transaction ? "" : "retransmitted ", use_candidate ? "nomination" : "probe",
+		candidate->con_addr, candidate->con_port, candidate_idx);
 
 	return status;
 }
@@ -1486,6 +1656,11 @@ static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_
 	uint32_t failover_ms;
 	uint64_t selected_age_ms;
 	uint64_t candidate_age_ms;
+	switch_rtp_ice_controlling_timer_action_t timer_action;
+	switch_sockaddr_t *local_addr;
+	switch_socket_t *local_socket;
+	char *transaction_id;
+	switch_bool_t use_candidate;
 
 	if (!ice_controlling_failover_ready(rtp_session, ice)) {
 		if (ice && ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
@@ -1501,9 +1676,34 @@ static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_
 	}
 
 	if (ice->controlling_failover_state != SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE) {
-		if (!ice->controlling_failover_sent_us || now < ice->controlling_failover_sent_us ||
-			(uint64_t)(now - ice->controlling_failover_sent_us) / 1000 > ICE_CONTROLLING_FAILOVER_TRANSACTION_MS) {
+		local_addr = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_local_addr ?
+			rtp_session->rtcp_local_addr : rtp_session->local_addr;
+		local_socket = ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output ?
+			rtp_session->rtcp_sock_output : rtp_session->sock_output;
+		if (!local_addr || !local_socket || ice->controlling_failover_socket != local_socket ||
+			ice->controlling_failover_local_port != switch_sockaddr_get_port(local_addr) ||
+			ice->controlling_failover_local_family != switch_sockaddr_get_family(local_addr)) {
 			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+
+		timer_action = switch_rtp_pvt_controlling_failover_timer_action(ice->controlling_failover_state,
+			ice->controlling_failover_started_us, ice->controlling_failover_sent_us,
+			ice->controlling_failover_attempts, now);
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE) {
+			ice_controlling_failover_reset(ice, SWITCH_TRUE);
+			return;
+		}
+		if (timer_action == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT) {
+			use_candidate = ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING ?
+				SWITCH_TRUE : SWITCH_FALSE;
+			transaction_id = use_candidate ? ice->controlling_failover_nomination_id :
+				ice->controlling_failover_probe_id;
+			if (ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx,
+				use_candidate, transaction_id, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS) {
+				ice->controlling_failover_sent_us = now;
+				ice->controlling_failover_attempts++;
+			}
 		}
 		return;
 	}
@@ -1520,9 +1720,11 @@ static void ice_controlling_failover_tick(switch_rtp_t *rtp_session, switch_rtp_
 	}
 
 	if (ice_send_controlling_check(rtp_session, ice, ice->controlling_failover_idx, SWITCH_FALSE,
-		ice->controlling_failover_probe_id) == SWITCH_STATUS_SUCCESS) {
+		ice->controlling_failover_probe_id, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
 		ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice->controlling_failover_started_us = now;
 		ice->controlling_failover_sent_us = now;
+		ice->controlling_failover_attempts = 1;
 	}
 }
 
@@ -1535,7 +1737,10 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	//switch_sockaddr_t *remote_addr = rtp_session->remote_addr;
 	switch_socket_t *sock_output = rtp_session->sock_output;
+	switch_sockaddr_t *local_addr = rtp_session->local_addr;
 	switch_time_t now = switch_micro_time_now();
+	switch_bool_t sent_controlling = SWITCH_FALSE;
+	char tie_breaker[8] = { 0 };
 
 	if (ice->type & ICE_LITE) {
 		// no connectivity checks for ICE-Lite
@@ -1604,9 +1809,10 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	if (ice == &rtp_session->rtcp_ice && rtp_session->rtcp_sock_output) {
 		sock_output = rtp_session->rtcp_sock_output;
+		local_addr = rtp_session->rtcp_local_addr;
 	}
 
-	if (!sock_output) {
+	if (!sock_output || !local_addr) {
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -1630,9 +1836,8 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
 
 	switch_mutex_lock(rtp_session->ice_mutex);
-	memcpy(ice->last_sent_id, packet->header.id, 12);
-	ice_selected_pair_check_record(ice, packet->header.id);
-	switch_mutex_unlock(rtp_session->ice_mutex);
+	sent_controlling = ice->type & ICE_CONTROLLED ? SWITCH_FALSE : SWITCH_TRUE;
+	memcpy(tie_breaker, rtp_session->ice_tie_breaker, sizeof(tie_breaker));
 
 	//if (ice->pass && ice->type == ICE_GOOGLE_JINGLE) {
 	//	switch_stun_packet_attribute_add_password(packet, ice->pass, (uint16_t)strlen(ice->pass));
@@ -1641,15 +1846,19 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if ((ice->type & ICE_VANILLA)) {
 		char sw[128] = "";
 
-		switch_stun_packet_attribute_add_priority(packet, ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].priority);
+		/* PRIORITY identifies the local peer-reflexive candidate that the check
+		 * could create at the peer, not the selected remote candidate. */
+		switch_stun_packet_attribute_add_priority(packet,
+			switch_rtp_pvt_ice_local_prflx_priority(ice == &rtp_session->rtcp_ice,
+				rtp_session->flags[SWITCH_RTP_FLAG_RTCP_MUX] ? SWITCH_TRUE : SWITCH_FALSE));
 
 		switch_snprintf(sw, sizeof(sw), "FreeSWITCH (%s)", switch_version_revision_human());
 		switch_stun_packet_attribute_add_software(packet, sw, (uint16_t)strlen(sw));
 
-		if ((ice->type & ICE_CONTROLLED)) {
-			switch_stun_packet_attribute_add_controlled(packet);
+		if (!sent_controlling) {
+			switch_stun_packet_attribute_add_controlled_value(packet, tie_breaker);
 		} else {
-			switch_stun_packet_attribute_add_controlling(packet);
+			switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker);
 			switch_stun_packet_attribute_add_use_candidate(packet);
 		}
 
@@ -1660,10 +1869,12 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	bytes = switch_stun_packet_length(packet);
 
-	switch_mutex_lock(rtp_session->ice_mutex);
 	if (ice->addr) {
 		char buf_host[16];
 		const char *tx_host = switch_get_addr(buf_host, sizeof(buf_host), ice->addr);
+		memcpy(ice->last_sent_id, packet->header.id, 12);
+		ice_selected_pair_check_record(ice, packet->header.id, sent_controlling,
+			sock_output, local_addr, ice->addr);
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG5, "%s send %s STUN to %s:%d\n", rtp_session_name(rtp_session), rtp_type(rtp_session), tx_host, switch_sockaddr_get_port(ice->addr));             
 		switch_socket_sendto(sock_output, ice->addr, 0, (void *) packet, &bytes);
 	}
@@ -1687,7 +1898,7 @@ SWITCH_DECLARE(void) switch_rtp_prepare_ice_restart(switch_rtp_t *rtp_session, i
 
 	switch_mutex_lock(rtp_session->ice_mutex);
 	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
-	ice_controlling_failover_reset(ice, SWITCH_TRUE);
+	switch_rtp_pvt_ice_role_conflict_cancel(ice);
 	ice->restart_pending = explicit_restart ? 1 : 0;
 	if (!explicit_restart) {
 		ice->restart_provisional = 0;
@@ -1851,9 +2062,7 @@ static void ice_controlling_failover_commit(switch_rtp_t *rtp_session, switch_rt
 	ice->initializing = 0;
 	ice->last_ok = now;
 	ice->selected_pair_last_response_us = now;
-	memset(ice->selected_pair_check_ids, 0, sizeof(ice->selected_pair_check_ids));
-	ice->selected_pair_check_pos = 0;
-	ice->selected_pair_check_count = 0;
+	ice_selected_pair_check_reset(ice);
 	rtp_session->last_adj = now;
 	if (rtp_session->session) {
 		switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
@@ -1865,7 +2074,8 @@ static void ice_controlling_failover_commit(switch_rtp_t *rtp_session, switch_rt
 
 static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_sockaddr_t *from_addr, int candidate_idx, const char *transaction_id,
-	switch_bool_t authenticated_response, switch_time_t now)
+	switch_bool_t authenticated_response, switch_socket_t *local_socket, switch_port_t local_port,
+	int local_family, switch_time_t now)
 {
 	uint32_t failover_ms;
 	uint64_t selected_age_ms;
@@ -1876,18 +2086,16 @@ static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_
 	 * check that we sent to that pair.  RTP or an unauthenticated STUN packet
 	 * proves neither bidirectional consent nor current-generation ownership and
 	 * must not suppress a controlling-side failover attempt. */
-	if (current_tuple && authenticated_response && ice_selected_pair_response_matches(ice, transaction_id)) {
+	if (current_tuple && authenticated_response && ice_selected_pair_response_matches(ice, transaction_id,
+		from_addr, local_socket, local_port, local_family, SWITCH_FALSE, NULL)) {
 		ice->selected_pair_last_response_us = now;
 		ice_controlling_failover_reset(ice, SWITCH_TRUE);
 		return SWITCH_FALSE;
 	}
 
 	if (!ice_controlling_failover_ready(rtp_session, ice)) {
-		switch_bool_t suppress_alternative = ice->controlling_failover_cached &&
-			ice->controlling_failover_enabled && !current_tuple && candidate_idx > -1 ? SWITCH_TRUE : SWITCH_FALSE;
-
 		ice_controlling_failover_reset(ice, SWITCH_TRUE);
-		return suppress_alternative;
+		return SWITCH_FALSE;
 	}
 
 	if (current_tuple || candidate_idx < 0 || candidate_idx == ice->ice_params->chosen[ice->proto]) {
@@ -1910,14 +2118,17 @@ static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_
 
 	if (ice->controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING) {
 		if (!switch_rtp_pvt_controlling_failover_response_matches(ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, candidate_idx, transaction_id, authenticated_response)) {
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, candidate_idx, transaction_id,
+			authenticated_response, local_socket, local_port, local_family)) {
 			return SWITCH_TRUE;
 		}
 
 		if (ice_send_controlling_check(rtp_session, ice, candidate_idx, SWITCH_TRUE,
-			ice->controlling_failover_nomination_id) == SWITCH_STATUS_SUCCESS) {
+			ice->controlling_failover_nomination_id, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
 			ice->controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING;
+			ice->controlling_failover_started_us = now;
 			ice->controlling_failover_sent_us = now;
+			ice->controlling_failover_attempts = 1;
 		} else {
 			ice_controlling_failover_reset(ice, SWITCH_TRUE);
 		}
@@ -1925,7 +2136,11 @@ static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_
 	}
 
 	if (switch_rtp_pvt_controlling_failover_response_matches(ice,
-		SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, candidate_idx, transaction_id, authenticated_response)) {
+		SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, candidate_idx, transaction_id,
+		authenticated_response, local_socket, local_port, local_family)) {
+		/* handle_ice acquired the nested write mutex before ice_mutex.  The
+		 * destination update re-enters write_mutex and therefore preserves the
+		 * established write -> ICE lock order. */
 		ice_controlling_failover_commit(rtp_session, ice, candidate_idx, now);
 	}
 
@@ -1947,8 +2162,12 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_channel_t *channel;
 	int i;
 	switch_sockaddr_t *from_addr = rtp_session->from_addr;
+	switch_sockaddr_t *response_local_addr = rtp_session->local_addr;
+	switch_socket_t *response_local_socket = rtp_session->sock_input;
 	const char *from_host = NULL;
 	switch_port_t from_port = 0;
+	switch_port_t response_local_port = 0;
+	int response_local_family = SWITCH_UNSPEC;
 	char faddr_buf[80] = "";
 	int got_use_candidate = 0;
 	int got_use_candidate_covered = 0;
@@ -1968,13 +2187,22 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_rtp_recovery_nomination_proof_t nomination_proof = SWITCH_RTP_RECOVERY_NOMINATION_NONE;
 	switch_time_t packet_now = switch_micro_time_now();
 	int response_candidate_idx = -1;
+	int role_conflict_487 = 0;
+	switch_bool_t role_conflict_sent_controlling = SWITCH_FALSE;
+	switch_bool_t role_conflict_was_promoted = SWITCH_FALSE;
 
 	if (is_rtcp) {
 		from_addr = rtp_session->rtcp_from_addr;
+		response_local_addr = rtp_session->rtcp_local_addr;
+		response_local_socket = rtp_session->rtcp_sock_input;
 	}
 
 	from_host = switch_get_addr(faddr_buf, sizeof(faddr_buf), from_addr);
 	from_port = switch_sockaddr_get_port(from_addr);
+	if (response_local_addr) {
+		response_local_port = switch_sockaddr_get_port(response_local_addr);
+		response_local_family = switch_sockaddr_get_family(response_local_addr);
+	}
 
 	if (!switch_rtp_ready(rtp_session) || zstr(ice->user_ice) || zstr(ice->ice_user)) {
 		return;
@@ -2003,7 +2231,8 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && (ice->type & ICE_VANILLA)) {
 		stun_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->pass) ? SWITCH_TRUE : SWITCH_FALSE;
 	}
-	if (raw_packet_type == SWITCH_STUN_BINDING_RESPONSE && (ice->type & ICE_VANILLA)) {
+	if ((raw_packet_type == SWITCH_STUN_BINDING_RESPONSE ||
+		raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) && (ice->type & ICE_VANILLA)) {
 		stun_response_auth_valid = switch_stun_packet_validate_auth(data, (uint32_t)cpylen, ice->rpass) ? SWITCH_TRUE : SWITCH_FALSE;
 	}
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST) {
@@ -2070,25 +2299,7 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 								  );
 
 				if ((ice->type & ICE_VANILLA) && code == 487) {
-					ice_controlling_failover_reset(ice, SWITCH_TRUE);
-					/* Three role-conflict cases:
-					 *   1. We self-promoted (fallback) and peer rejects -> revert to CONTROLLED, disable fallback.
-					 *   2. We were CONTROLLED and peer 487s us -> RFC role-conflict flip to CONTROLLING.
-					 *   3. We were CONTROLLING and peer 487s us -> RFC role-conflict flip to CONTROLLED. */
-					if (ice->promoted_to_controlling && !(ice->type & ICE_CONTROLLED)) {
-						/* Peer rejected our self-promotion: it is legitimately controlling. Revert and stand down. */
-						ice->type |= ICE_CONTROLLED;
-						ice->promoted_to_controlling = 0;
-						ice->nomination_fallback_enabled = 0;
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN got role-conflict 487 after fallback promotion; reverting to CONTROLLED\n", rtp_type(rtp_session));
-					} else if ((ice->type & ICE_CONTROLLED)) {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN Changing role to CONTROLLING\n", rtp_type(rtp_session));
-						ice->type &= ~ICE_CONTROLLED;
-					} else {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING, "%s STUN Changing role to CONTROLLED\n", rtp_type(rtp_session));
-						ice->type |= ICE_CONTROLLED;
-					}
-					packet->header.type = SWITCH_STUN_BINDING_RESPONSE;
+					role_conflict_487 = 1;
 				}
 
 			}
@@ -2134,6 +2345,53 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		xlen += 4 + switch_stun_attribute_padded_length(attr);
 	} while (xlen <= packet->header.length);
 
+	if ((raw_packet_type == SWITCH_STUN_BINDING_RESPONSE ||
+		raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) && ice->ice_params) {
+		for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
+			if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
+				response_candidate_idx = i;
+				break;
+			}
+		}
+	}
+
+	if (raw_packet_type == SWITCH_STUN_BINDING_ERROR_RESPONSE) {
+		switch_bool_t authenticated_error = stun_response_auth_valid && got_message_integrity && got_fingerprint ?
+			SWITCH_TRUE : SWITCH_FALSE;
+
+		if (!role_conflict_487 || !switch_rtp_pvt_ice_role_conflict_response_matches(ice, from_addr,
+			response_candidate_idx, packet->header.id, authenticated_error,
+			response_local_socket, response_local_port, response_local_family,
+			&role_conflict_sent_controlling)) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"Ignoring unauthenticated or unmatched %s STUN error response from %s:%u\n",
+				rtp_type(rtp_session), from_host, from_port);
+			goto end;
+		}
+
+		role_conflict_was_promoted = ice->promoted_to_controlling ? SWITCH_TRUE : SWITCH_FALSE;
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_session->ice);
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_session->rtcp_ice);
+		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(rtp_session->ice_tie_breaker);
+		switch_rtp_pvt_ice_role_conflict_apply(&rtp_session->ice, role_conflict_sent_controlling);
+		switch_rtp_pvt_ice_role_conflict_apply(&rtp_session->rtcp_ice, role_conflict_sent_controlling);
+		/* A role-conflict response is allowed to mutate role state only after
+		 * authentication and exact transaction/transport matching above.  Apply
+		 * the role carried by the matched request, not mutable current state. */
+		if (role_conflict_sent_controlling && role_conflict_was_promoted) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"%s STUN got authenticated role-conflict 487 after fallback promotion; reverting to CONTROLLED\n",
+				rtp_type(rtp_session));
+		} else if (!role_conflict_sent_controlling) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"%s STUN authenticated role-conflict 487; changing role to CONTROLLING\n", rtp_type(rtp_session));
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
+				"%s STUN authenticated role-conflict 487; changing role to CONTROLLED\n", rtp_type(rtp_session));
+		}
+		goto end;
+	}
+
 	if (raw_packet_type == SWITCH_STUN_BINDING_REQUEST && got_use_candidate) {
 		authenticated_vanilla_use_candidate = ((ice->type & ICE_VANILLA) && got_use_candidate_covered &&
 			got_message_integrity && got_fingerprint && stun_auth_valid) ? SWITCH_TRUE : SWITCH_FALSE;
@@ -2159,17 +2417,10 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 		if (!ok) ok = !memcmp(packet->header.id, ice->last_sent_id, 12);
 
 		if (packet->header.type == SWITCH_STUN_BINDING_RESPONSE) {
-			if (ice->ice_params) {
-				for (i = 0; i < ice->ice_params->cand_idx[ice->proto]; ++i) {
-					if (ice_candidate_matches_addr(&ice->ice_params->cands[i][ice->proto], from_host, from_port)) {
-						response_candidate_idx = i;
-						break;
-					}
-				}
-			}
 			if (ice_controlling_failover_handle_response(rtp_session, ice, from_addr, response_candidate_idx,
 				packet->header.id, (stun_response_auth_valid && got_message_integrity && got_fingerprint) ?
-					SWITCH_TRUE : SWITCH_FALSE, packet_now)) {
+					SWITCH_TRUE : SWITCH_FALSE, response_local_socket, response_local_port,
+				response_local_family, packet_now)) {
 				goto end;
 			}
 
@@ -7311,10 +7562,11 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	ice->controlling_failover_ms = 0;
 	ice->controlling_failover_idx = -1;
 	ice->controlling_failover_candidate_us = 0;
+	if (!rtp_session->ice_tie_breaker[0]) {
+		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(rtp_session->ice_tie_breaker);
+	}
 	ice->selected_pair_last_response_us = switch_micro_time_now();
-	memset(ice->selected_pair_check_ids, 0, sizeof(ice->selected_pair_check_ids));
-	ice->selected_pair_check_pos = 0;
-	ice->selected_pair_check_count = 0;
+	ice_selected_pair_check_reset(ice);
 	ice_controlling_failover_reset(ice, SWITCH_TRUE);
 	ice->inbound_media_idx = -1;
 	ice->inbound_media_us = 0;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1548,7 +1548,13 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 
 	ice->next_run = now + RTP_STUN_FREQ;
 	if (!force) {
+		/* RTP read, write, and ping paths can all drive the periodic ICE timer.
+		 * Serialize the controlling-side failover state machine independently of
+		 * the pre-existing next_run best-effort gate.  The mutex is nested because
+		 * the tick may send a probe through ice_send_controlling_check(). */
+		switch_mutex_lock(rtp_session->ice_mutex);
 		ice_controlling_failover_tick(rtp_session, ice, now);
+		switch_mutex_unlock(rtp_session->ice_mutex);
 	}
 
 	/* Non-DTLS ICE-CONTROLLED peers that never send USE-CANDIDATE hang media
@@ -1623,8 +1629,10 @@ static switch_status_t ice_out(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
 	switch_stun_packet_attribute_add_username(packet, ice->ice_user, (uint16_t)strlen(ice->ice_user));
 
+	switch_mutex_lock(rtp_session->ice_mutex);
 	memcpy(ice->last_sent_id, packet->header.id, 12);
 	ice_selected_pair_check_record(ice, packet->header.id);
+	switch_mutex_unlock(rtp_session->ice_mutex);
 
 	//if (ice->pass && ice->type == ICE_GOOGLE_JINGLE) {
 	//	switch_stun_packet_attribute_add_password(packet, ice->pass, (uint16_t)strlen(ice->pass));
@@ -1820,6 +1828,7 @@ static void ice_controlling_failover_commit(switch_rtp_t *rtp_session, switch_rt
 	}
 	ice->ice_params->cands[candidate_idx][ice->proto].use_candidate = 1;
 	ice->ice_params->chosen[ice->proto] = candidate_idx;
+	ice->ice_params->is_chosen[ice->proto] = 1;
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_NOTICE,
 		"ICE controlling failover: nomination succeeded, switching %s from %s:%u to %s:%u idx:%d\n",
@@ -1863,6 +1872,10 @@ static switch_bool_t ice_controlling_failover_handle_response(switch_rtp_t *rtp_
 	switch_bool_t current_tuple;
 
 	current_tuple = ice->addr && switch_cmp_addr(from_addr, ice->addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
+	/* A selected pair is live only after an authenticated response matches a
+	 * check that we sent to that pair.  RTP or an unauthenticated STUN packet
+	 * proves neither bidirectional consent nor current-generation ownership and
+	 * must not suppress a controlling-side failover attempt. */
 	if (current_tuple && authenticated_response && ice_selected_pair_response_matches(ice, transaction_id)) {
 		ice->selected_pair_last_response_us = now;
 		ice_controlling_failover_reset(ice, SWITCH_TRUE);

--- a/src/switch_stun.c
+++ b/src/switch_stun.c
@@ -703,30 +703,48 @@ SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_use_candidate(switch_st
 
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling(switch_stun_packet_t *packet)
 {
-	switch_stun_packet_attribute_t *attribute;
 	char buf[8];
 
 	switch_stun_random_string(buf, 8, NULL);
+	return switch_stun_packet_attribute_add_controlling_value(packet, buf);
+}
+
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlling_value(switch_stun_packet_t *packet, const char *tie_breaker)
+{
+	switch_stun_packet_attribute_t *attribute;
+
+	if (!packet || !tie_breaker) {
+		return 0;
+	}
 
 	attribute = (switch_stun_packet_attribute_t *) ((uint8_t *) & packet->first_attribute + ntohs(packet->header.length));
 	attribute->type = htons(SWITCH_STUN_ATTR_CONTROLLING);
 	attribute->length = htons(8);
-	memcpy(attribute->value, buf, 8);
+	memcpy(attribute->value, tie_breaker, 8);
 	packet->header.length += htons(sizeof(switch_stun_packet_attribute_t)) + attribute->length;
 	return 1;
 }
 
 SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled(switch_stun_packet_t *packet)
 {
-	switch_stun_packet_attribute_t *attribute;
 	char buf[8];
 
 	switch_stun_random_string(buf, 8, NULL);
+	return switch_stun_packet_attribute_add_controlled_value(packet, buf);
+}
+
+SWITCH_DECLARE(uint8_t) switch_stun_packet_attribute_add_controlled_value(switch_stun_packet_t *packet, const char *tie_breaker)
+{
+	switch_stun_packet_attribute_t *attribute;
+
+	if (!packet || !tie_breaker) {
+		return 0;
+	}
 
 	attribute = (switch_stun_packet_attribute_t *) ((uint8_t *) & packet->first_attribute + ntohs(packet->header.length));
 	attribute->type = htons(SWITCH_STUN_ATTR_CONTROLLED);
 	attribute->length = htons(8);
-	memcpy(attribute->value, buf, 8);
+	memcpy(attribute->value, tie_breaker, 8);
 	packet->header.length += htons(sizeof(switch_stun_packet_attribute_t)) + attribute->length;
 	return 1;
 }

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -127,6 +127,36 @@ FST_TEARDOWN_END()
 		fst_check(!switch_stun_packet_validate_auth(late_use_candidate, (uint32_t)late_use_candidate_len, generated_password));
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_controlling_failover_requires_exact_authenticated_response)
+	{
+		switch_rtp_ice_t ice = { 0 };
+		static const char probe_id[13] = "probe-id-123";
+		static const char nomination_id[13] = "nominate-123";
+		static const char wrong_id[13] = "wrong-id-123";
+
+		ice.controlling_failover_idx = 3;
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		memcpy(ice.controlling_failover_probe_id, probe_id, 12);
+		memcpy(ice.controlling_failover_nomination_id, nomination_id, 12);
+
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_FALSE));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 2, probe_id, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, wrong_id, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE));
+		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE));
+
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING;
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, probe_id, SWITCH_TRUE));
+		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE));
+	}
+	FST_TEST_END()
 	FST_TEST_BEGIN(test_restart_prflx_requires_explicit_authenticated_current_generation)
 	{
 		switch_rtp_ice_t ice = { 0 };

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -133,28 +133,204 @@ FST_TEARDOWN_END()
 		static const char probe_id[13] = "probe-id-123";
 		static const char nomination_id[13] = "nominate-123";
 		static const char wrong_id[13] = "wrong-id-123";
+		switch_socket_t *local_socket = (switch_socket_t *)&ice;
+		switch_socket_t *other_socket = (switch_socket_t *)&probe_id;
 
 		ice.controlling_failover_idx = 3;
 		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice.controlling_failover_local_port = 27018;
+		ice.controlling_failover_local_family = AF_INET;
+		ice.controlling_failover_socket = local_socket;
 		memcpy(ice.controlling_failover_probe_id, probe_id, 12);
 		memcpy(ice.controlling_failover_nomination_id, nomination_id, 12);
 
 		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_FALSE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_FALSE,
+			local_socket, 27018, AF_INET));
 		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 2, probe_id, SWITCH_TRUE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 2, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
 		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, wrong_id, SWITCH_TRUE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, wrong_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
 		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			other_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27019, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET6));
 		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
 
 		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING;
 		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, probe_id, SWITCH_TRUE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, probe_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
 		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
-			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE));
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_role_conflict_requires_authenticated_exact_transaction_and_tuple)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_addr = NULL;
+		switch_sockaddr_t *alternative_addr = NULL;
+		switch_rtp_ice_t ice = { 0 };
+		static const char selected_id[13] = "selected-123";
+		static const char probe_id[13] = "probe-id-123";
+		static const char wrong_id[13] = "wrong-id-123";
+		switch_socket_t *local_socket = (switch_socket_t *)&ice;
+		switch_bool_t sent_controlling = SWITCH_FALSE;
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_addr, "192.0.2.10", SWITCH_UNSPEC, 40000, 0, pool) ==
+			SWITCH_STATUS_SUCCESS, "current address");
+		fst_xcheck(switch_sockaddr_info_get(&alternative_addr, "192.0.2.20", SWITCH_UNSPEC, 50000, 0, pool) ==
+			SWITCH_STATUS_SUCCESS, "alternative address");
+
+		ice.addr = current_addr;
+		memcpy(ice.selected_pair_check_ids[0], selected_id, 12);
+		ice.selected_pair_check_controlling[0] = 1;
+		ice.selected_pair_check_remote_addr[0] = current_addr;
+		ice.selected_pair_check_count = 1;
+		ice.selected_pair_check_socket = local_socket;
+		ice.selected_pair_check_local_port = 27018;
+		ice.selected_pair_check_local_family = AF_INET;
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			selected_id, SWITCH_FALSE, local_socket, 27018, AF_INET, &sent_controlling));
+		/* A destination migration must not make the old transaction match the
+		 * new current tuple; it remains correlated to its request destination. */
+		ice.addr = alternative_addr;
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			selected_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			wrong_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			selected_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(sent_controlling);
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, current_addr, 0,
+			selected_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+
+		/* Apply the role carried by the matched request, even if current state
+		 * changed while that transaction was in flight. */
+		ice.type = ICE_VANILLA | ICE_CONTROLLED;
+		switch_rtp_pvt_ice_role_conflict_apply(&ice, SWITCH_TRUE);
+		fst_check(ice.type & ICE_CONTROLLED);
+		ice.type = ICE_VANILLA;
+		switch_rtp_pvt_ice_role_conflict_apply(&ice, SWITCH_FALSE);
+		fst_check(!(ice.type & ICE_CONTROLLED));
+
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		ice.controlling_failover_idx = 1;
+		ice.controlling_failover_local_port = 27018;
+		ice.controlling_failover_local_family = AF_INET;
+		ice.controlling_failover_socket = local_socket;
+		memcpy(ice.controlling_failover_probe_id, probe_id, 12);
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			probe_id, SWITCH_TRUE, local_socket, 27019, AF_INET, &sent_controlling));
+		fst_check(switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			probe_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+		fst_check(sent_controlling);
+		fst_check(!switch_rtp_pvt_ice_role_conflict_response_matches(&ice, alternative_addr, 1,
+			probe_id, SWITCH_TRUE, local_socket, 27018, AF_INET, &sent_controlling));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_role_conflict_cancels_transactions_and_rotates_tie_breaker)
+	{
+		switch_rtp_ice_t rtp_ice = { 0 };
+		switch_rtp_ice_t rtcp_ice = { 0 };
+		char tie_breaker[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+		char old_tie_breaker[8];
+
+		rtp_ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING;
+		rtp_ice.controlling_failover_idx = 2;
+		memcpy(rtp_ice.controlling_failover_probe_id, "probe-id-123", 12);
+		memcpy(rtp_ice.selected_pair_check_ids[0], "selected-123", 12);
+		rtp_ice.selected_pair_check_controlling[0] = 1;
+		rtp_ice.selected_pair_check_remote_addr[0] = (switch_sockaddr_t *)&rtp_ice;
+		rtp_ice.selected_pair_check_count = 1;
+		memcpy(rtp_ice.last_sent_id, "selected-123", 12);
+		memcpy(rtcp_ice.selected_pair_check_ids[0], "rtcp-check12", 12);
+		rtcp_ice.selected_pair_check_count = 1;
+
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_ice);
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtcp_ice);
+		fst_check(rtp_ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+		fst_check(rtp_ice.controlling_failover_idx == -1);
+		fst_check(!rtp_ice.selected_pair_check_count);
+		fst_check(!rtcp_ice.selected_pair_check_count);
+		fst_check(!rtp_ice.selected_pair_check_ids[0][0]);
+		fst_check(!rtp_ice.selected_pair_check_remote_addr[0]);
+		fst_check(!rtcp_ice.selected_pair_check_ids[0][0]);
+		fst_check(!rtp_ice.last_sent_id[0]);
+
+		memcpy(old_tie_breaker, tie_breaker, sizeof(tie_breaker));
+		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(tie_breaker);
+		fst_check(memcmp(tie_breaker, old_tie_breaker, sizeof(tie_breaker)));
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_local_prflx_priority_uses_component_id)
+	{
+		fst_check(switch_rtp_pvt_ice_local_prflx_priority(SWITCH_FALSE, SWITCH_FALSE) == 0x6effffffU);
+		fst_check(switch_rtp_pvt_ice_local_prflx_priority(SWITCH_TRUE, SWITCH_TRUE) == 0x6effffffU);
+		fst_check(switch_rtp_pvt_ice_local_prflx_priority(SWITCH_TRUE, SWITCH_FALSE) == 0x6efffffeU);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_controlling_failover_retransmission_timer)
+	{
+		switch_time_t started_us = 1000000;
+
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE, 0, 0, 0, started_us) ==
+			SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us, 1,
+			started_us + 999000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us, 1,
+			started_us + 1000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, started_us, started_us + 3000000, 4,
+			started_us + 3999000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_NONE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, started_us, started_us + 3000000, 4,
+			started_us + 4000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us + 4000000, 2,
+			started_us + 5000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE);
+	}
+	FST_TEST_END()
+	FST_TEST_BEGIN(test_ice_role_attributes_accept_stable_tie_breaker)
+	{
+		uint8_t buf[128] = { 0 };
+		static const char tie_breaker[8] = { 0x01, 0x23, 0x45, 0x67, 0x11, 0x22, 0x33, 0x44 };
+		switch_stun_packet_t *packet;
+		switch_stun_packet_attribute_t *attribute;
+
+		packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+		fst_check(switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker));
+		attribute = (switch_stun_packet_attribute_t *)&packet->first_attribute;
+		fst_check(ntohs(attribute->type) == SWITCH_STUN_ATTR_CONTROLLING);
+		fst_check(ntohs(attribute->length) == sizeof(tie_breaker));
+		fst_check(!memcmp(attribute->value, tie_breaker, sizeof(tie_breaker)));
+
+		memset(buf, 0, sizeof(buf));
+		packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+		fst_check(switch_stun_packet_attribute_add_controlled_value(packet, tie_breaker));
+		attribute = (switch_stun_packet_attribute_t *)&packet->first_attribute;
+		fst_check(ntohs(attribute->type) == SWITCH_STUN_ATTR_CONTROLLED);
+		fst_check(ntohs(attribute->length) == sizeof(tie_breaker));
+		fst_check(!memcmp(attribute->value, tie_breaker, sizeof(tie_breaker)));
 	}
 	FST_TEST_END()
 	FST_TEST_BEGIN(test_restart_prflx_requires_explicit_authenticated_current_generation)

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -9,9 +9,11 @@ static switch_port_t rx_port = 1234;
 static const char *tx_host = "127.0.0.1";
 static switch_port_t tx_port = 54320;
 
-static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buflen, const char *username,
-												 const char *password, switch_bool_t use_candidate)
+static switch_size_t build_authenticated_request_with_role(uint8_t *buf, switch_size_t buflen,
+	const char *username, const char *password, switch_bool_t use_candidate,
+	switch_bool_t peer_controlled, switch_bool_t peer_controlling)
 {
+	static const char tie_breaker[8] = { 0x01, 0x23, 0x45, 0x67, 0x11, 0x22, 0x33, 0x44 };
 	switch_stun_packet_t *packet;
 	switch_size_t bytes;
 
@@ -26,6 +28,38 @@ static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buf
 	if (use_candidate) {
 		switch_stun_packet_attribute_add_use_candidate(packet);
 	}
+	if (peer_controlled) {
+		switch_stun_packet_attribute_add_controlled_value(packet, tie_breaker);
+	}
+	if (peer_controlling) {
+		switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker);
+	}
+	switch_stun_packet_attribute_add_integrity(packet, password);
+	switch_stun_packet_attribute_add_fingerprint(packet);
+	bytes = switch_stun_packet_length(packet);
+	switch_assert(bytes <= buflen);
+
+	return bytes;
+}
+
+static switch_size_t build_authenticated_request(uint8_t *buf, switch_size_t buflen, const char *username,
+	const char *password, switch_bool_t use_candidate)
+{
+	return build_authenticated_request_with_role(buf, buflen, username, password, use_candidate,
+		SWITCH_FALSE, SWITCH_FALSE);
+}
+
+static switch_size_t build_authenticated_response(uint8_t *buf, switch_size_t buflen,
+	char *transaction_id, const char *password)
+{
+	switch_stun_packet_t *packet;
+	switch_size_t bytes;
+
+	switch_assert(buf);
+	switch_assert(buflen >= 128);
+	switch_assert(transaction_id);
+	memset(buf, 0, buflen);
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_RESPONSE, transaction_id, buf);
 	switch_stun_packet_attribute_add_integrity(packet, password);
 	switch_stun_packet_attribute_add_fingerprint(packet);
 	bytes = switch_stun_packet_length(packet);
@@ -176,6 +210,29 @@ FST_TEARDOWN_END()
 		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
 			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_NOMINATING, 3, nomination_id, SWITCH_TRUE,
 			local_socket, 27018, AF_INET));
+
+		ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING;
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_FALSE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 2, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, wrong_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			other_socket, 27018, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27019, AF_INET));
+		fst_check(!switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET6));
+		fst_check(switch_rtp_pvt_controlling_failover_response_matches(&ice,
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, 3, nomination_id, SWITCH_TRUE,
+			local_socket, 27018, AF_INET));
 	}
 	FST_TEST_END()
 	FST_TEST_BEGIN(test_role_conflict_requires_authenticated_exact_transaction_and_tuple)
@@ -274,6 +331,14 @@ FST_TEARDOWN_END()
 		fst_check(!rtcp_ice.selected_pair_check_ids[0][0]);
 		fst_check(!rtp_ice.last_sent_id[0]);
 
+		rtp_ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING;
+		rtp_ice.controlling_failover_idx = 1;
+		memcpy(rtp_ice.controlling_failover_nomination_id, "nominate-123", 12);
+		switch_rtp_pvt_ice_role_conflict_cancel(&rtp_ice);
+		fst_check(rtp_ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+		fst_check(rtp_ice.controlling_failover_idx == -1);
+		fst_check(!rtp_ice.controlling_failover_nomination_id[0]);
+
 		memcpy(old_tie_breaker, tie_breaker, sizeof(tie_breaker));
 		switch_rtp_pvt_ice_role_conflict_rotate_tie_breaker(tie_breaker);
 		fst_check(memcmp(tie_breaker, old_tie_breaker, sizeof(tie_breaker)));
@@ -308,6 +373,9 @@ FST_TEARDOWN_END()
 		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
 			SWITCH_RTP_ICE_CONTROLLING_FAILOVER_PROBING, started_us, started_us + 4000000, 2,
 			started_us + 5000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_EXPIRE);
+		fst_check(switch_rtp_pvt_controlling_failover_timer_action(
+			SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING, started_us, started_us, 1,
+			started_us + 1000000) == SWITCH_RTP_ICE_CONTROLLING_TIMER_RETRANSMIT);
 	}
 	FST_TEST_END()
 	FST_TEST_BEGIN(test_ice_role_attributes_accept_stable_tie_breaker)
@@ -687,25 +755,33 @@ FST_TEARDOWN_END()
 			switch_status_t status;
 			switch_call_cause_t cause;
 			switch_rtp_ice_t ice = { 0 };
+			switch_rtp_ice_t timeout_ice = { 0 };
 			switch_memory_pool_t *pool = NULL;
 			static switch_rtp_t *rtp_session = NULL;
 			static switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
 			const char *err = NULL;
 			ice_t ice_params = { 0 };
+			ice_t timeout_params = { 0 };
 			uint8_t tampered[128];
 			uint8_t missing_username[128];
 			uint8_t wrong_username[128];
 			uint8_t successful_request[128];
+			uint8_t controlling_request[128];
+			uint8_t nomination_response[128];
 			char bootstrap_host[80] = { 0 };
 			char learned_host[80] = { 0 };
 			char remote_host[80] = { 0 };
+			char wrong_nomination_id[13] = "wrong-id-123";
 			switch_size_t missing_username_len;
 			switch_size_t wrong_username_len;
 			switch_size_t successful_request_len;
 			switch_size_t no_use_candidate_len;
+			switch_size_t controlling_request_len;
+			switch_size_t nomination_response_len;
 			switch_sockaddr_t *remote_addr;
 			int initial_cand_idx;
 			int initial_chosen;
+			int reused_idx;
 
 			switch_core_new_memory_pool(&pool);
 			status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
@@ -720,6 +796,7 @@ FST_TEARDOWN_END()
 			switch_core_memory_pool_set_data(pool, "__session", session);
 			fst_xcheck(switch_find_local_ip(bootstrap_host, sizeof(bootstrap_host), NULL, AF_INET) == SWITCH_STATUS_SUCCESS, "switch_find_local_ip()");
 			fst_xcheck(strncmp(bootstrap_host, "127.", 4), "non-loopback bootstrap host");
+			flags[SWITCH_RTP_FLAG_RTCP_MUX] = 1;
 			rtp_session = switch_rtp_new(bootstrap_host, rx_port, tx_host, tx_port, TEST_PT, 8000, 20 * 1000, flags, "soft", &err, pool);
 			fst_xcheck(rtp_session != NULL, "switch_rtp_new()");
 			fst_check(switch_rtp_ready(rtp_session));
@@ -825,6 +902,124 @@ FST_TEARDOWN_END()
 				fst_check(ice.ice_params->cands[1][ice.proto].ready);
 				fst_check(ice.ice_params->cands[1][ice.proto].use_candidate);
 			}
+
+			memset(&ice, 0, sizeof(ice));
+			memset(&ice_params, 0, sizeof(ice_params));
+			ice.ice_params = &ice_params;
+			ice.user_ice = "remoteUfrag:localUfrag";
+			ice.ice_user = "localUfrag:remoteUfrag";
+			ice.pass = "test-local-ice-password";
+			ice.rpass = "test-remote-ice-password";
+			ice.type = ICE_VANILLA;
+			ice.proto = IPR_RTP;
+			ice.prflx_bootstrap_require_use_candidate = 1;
+			ice.initializing = 1;
+			ice.controlling_failover_idx = -1;
+			ice.prflx_bootstrap_idx = -1;
+			ice.ice_params->chosen[ice.proto] = 0;
+			ice.ice_params->cand_idx[ice.proto] = 1;
+			ice.ice_params->cands[0][ice.proto].priority = 0x6e0001ff;
+
+			no_use_candidate_len = build_authenticated_request(tampered, sizeof(tampered),
+				ice.user_ice, ice.pass, SWITCH_FALSE);
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, no_use_candidate_len);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+
+			no_use_candidate_len = build_authenticated_request_with_role(tampered, sizeof(tampered),
+				ice.user_ice, ice.pass, SWITCH_FALSE, SWITCH_FALSE, SWITCH_TRUE);
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, tampered, no_use_candidate_len);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 1);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+
+			controlling_request_len = build_authenticated_request_with_role(controlling_request,
+				sizeof(controlling_request), ice.user_ice, ice.pass, SWITCH_FALSE,
+				SWITCH_TRUE, SWITCH_FALSE);
+			fst_check(switch_stun_packet_validate_auth(controlling_request,
+				(uint32_t)controlling_request_len, ice.pass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, controlling_request, controlling_request_len);
+
+			fst_check(!ice.ready);
+			fst_check(!ice.rready);
+			fst_check(!ice.cand_responsive);
+			fst_check(ice.addr == NULL);
+			fst_check(ice.ice_params->cand_idx[ice.proto] == 2);
+			fst_check(ice.ice_params->chosen[ice.proto] == 0);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING);
+			fst_check(ice.controlling_failover_idx == 1);
+			fst_check(ice.controlling_failover_nomination_id[0]);
+			fst_check(!ice.ice_params->cands[1][ice.proto].use_candidate);
+			fst_check(!ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(!ice.ice_params->cands[1][ice.proto].ready);
+
+			nomination_response_len = build_authenticated_response(nomination_response,
+				sizeof(nomination_response), ice.controlling_failover_nomination_id, "wrong-password");
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, nomination_response, nomination_response_len);
+			fst_check(!ice.ready);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING);
+			fst_check(!ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(!ice.ice_params->cands[1][ice.proto].ready);
+
+			nomination_response_len = build_authenticated_response(nomination_response,
+				sizeof(nomination_response), wrong_nomination_id, ice.rpass);
+			fst_check(switch_stun_packet_validate_auth(nomination_response,
+				(uint32_t)nomination_response_len, ice.rpass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, nomination_response, nomination_response_len);
+			fst_check(!ice.ready);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_STARTUP_NOMINATING);
+			fst_check(!ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(!ice.ice_params->cands[1][ice.proto].ready);
+
+			nomination_response_len = build_authenticated_response(nomination_response,
+				sizeof(nomination_response), ice.controlling_failover_nomination_id, ice.rpass);
+			fst_check(switch_stun_packet_validate_auth(nomination_response,
+				(uint32_t)nomination_response_len, ice.rpass));
+			switch_rtp_pvt_handle_ice(rtp_session, &ice, nomination_response, nomination_response_len);
+
+			fst_check(ice.ready);
+			fst_check(ice.rready);
+			fst_check(ice.cand_responsive);
+			fst_check(ice.addr != NULL);
+			fst_check(ice.ice_params->chosen[ice.proto] == 1);
+			fst_check(ice.ice_params->cands[1][ice.proto].use_candidate);
+			fst_check(ice.ice_params->cands[1][ice.proto].responsive);
+			fst_check(ice.ice_params->cands[1][ice.proto].ready);
+			fst_check(ice.controlling_failover_state == SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE);
+			fst_check(ice.controlling_failover_idx == -1);
+			if (ice.addr) {
+				fst_check(!strcmp(switch_get_addr(learned_host, sizeof(learned_host), ice.addr), bootstrap_host));
+				fst_check(switch_sockaddr_get_port(ice.addr) == rx_port);
+			}
+			remote_addr = switch_rtp_session_get_remote_addr(rtp_session);
+			fst_check(remote_addr != NULL);
+			if (remote_addr) {
+				fst_check(!strcmp(switch_get_addr(remote_host, sizeof(remote_host), remote_addr), bootstrap_host));
+				fst_check(switch_sockaddr_get_port(remote_addr) == rx_port);
+			}
+
+			/* A startup nomination timeout leaves the uncommitted prflx slot reusable,
+			 * so a changed authenticated NAT tuple can be nominated without growing
+			 * or blocking the candidate list. */
+			timeout_ice.ice_params = &timeout_params;
+			timeout_ice.proto = IPR_RTP;
+			timeout_ice.prflx_bootstrap_idx = 1;
+			timeout_ice.controlling_failover_idx = -1;
+			timeout_ice.controlling_failover_state = SWITCH_RTP_ICE_CONTROLLING_FAILOVER_IDLE;
+			timeout_ice.ice_params->chosen[timeout_ice.proto] = 0;
+			timeout_ice.ice_params->cand_idx[timeout_ice.proto] = 2;
+			timeout_ice.ice_params->cands[1][timeout_ice.proto].cand_type = (char *)"prflx";
+			timeout_ice.ice_params->cands[1][timeout_ice.proto].con_addr = (char *)"192.0.2.10";
+			timeout_ice.ice_params->cands[1][timeout_ice.proto].con_port = 40000;
+			reused_idx = switch_rtp_pvt_reuse_pending_startup_prflx_candidate(rtp_session,
+				&timeout_ice, "192.0.2.20", 50000, 0x6e0001fe);
+			fst_check(reused_idx == 1);
+			fst_check(timeout_ice.ice_params->cand_idx[timeout_ice.proto] == 2);
+			fst_check(!strcmp(timeout_ice.ice_params->cands[1][timeout_ice.proto].con_addr, "192.0.2.20"));
+			fst_check(timeout_ice.ice_params->cands[1][timeout_ice.proto].con_port == 50000);
+			fst_check(timeout_ice.ice_params->cands[1][timeout_ice.proto].priority == 0x6e0001fe);
+			fst_check(!timeout_ice.ice_params->cands[1][timeout_ice.proto].responsive);
+			fst_check(!timeout_ice.ice_params->cands[1][timeout_ice.proto].ready);
+			fst_check(!timeout_ice.ice_params->cands[1][timeout_ice.proto].use_candidate);
 
 			switch_rtp_destroy(&rtp_session);
 			switch_core_session_rwunlock(session);


### PR DESCRIPTION
## Summary

Extend the ICE-only mid-call failover work from #630 to support calls where FreeSWITCH is the ICE-controlling agent.

When the selected pair stops answering consent checks, FreeSWITCH now:

1. probes a recently authenticated alternative candidate without `USE-CANDIDATE`;
2. nominates that exact candidate with `USE-CANDIDATE` only after a matching authenticated probe response;
3. switches RTP/DTLS only after the nomination receives its matching authenticated success response.

## Motivation

#630 handles peer-driven renomination when FreeSWITCH is ICE-controlled. After reattach, FreeSWITCH can become ICE-controlling, so the controlled peer cannot nominate the replacement pair. In that role, FreeSWITCH must perform connectivity checking and nomination itself.

## Safety

- Does not relax the existing inbound `USE-CANDIDATE` gate.
- Alternative RTP or STUN traffic alone cannot switch the media path.
- Requires current-generation authenticated STUN requests and exact response transaction/tuple matches.
- Cancels pending failover on recovery, ICE restart, role change, DTLS state change, selected-pair recovery, or transaction timeout.
- Serializes state transitions and transaction history under the nested ICE mutex.
- Limited to vanilla ICE, RTP/RTCP mux, ICE-controlling, DTLS-ready calls.
- Disabled by default behind `rtp_ice_controlling_mid_call_failover=true`.

## Validation

- `switch_rtp.c` build with declaration-after-statement enforcement
- STUN unit suite: 13/13 passed
- Two independent reviewer passes; no blocking or should-fix findings remain

## Base

This is a stacked PR based on `linear-telcore-263-preserve-dtls-nomination` and includes all current #630 changes.
