### PR TITLE
TELCORE-321: make a stop raised during a queued command durable

### DIFF
--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -1163,6 +1163,15 @@ SWITCH_DECLARE(void) switch_core_session_video_reset(switch_core_session_t *sess
 SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_get_flags(_In_ switch_core_session_t *session,
 																				  _In_ const char *app, _In_opt_z_ const char *arg, _Out_opt_ int32_t *flags);
 
+/*! \brief Execute an application on a session from a private event (preserves CF_BREAK)
+ *  \param session the current session
+ *  \param app the application's name
+ *  \param arg application arguments
+ *  \return the application's return value
+ */
+SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_event(_In_ switch_core_session_t *session,
+																			      _In_ const char *app, _In_opt_z_ const char *arg);
+
 SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_async(switch_core_session_t *session, const char *app, const char *arg);
 
 SWITCH_DECLARE(switch_status_t) switch_core_session_get_app_flags(const char *app, int32_t *flags);

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -2919,8 +2919,14 @@ SWITCH_DECLARE(void) switch_core_session_video_reset(switch_core_session_t *sess
 	switch_core_session_request_video_refresh(session);
 }
 
-SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_get_flags(switch_core_session_t *session, const char *app,
-																				  const char *arg, int32_t *flags)
+/* forward declaration -- execute_application_impl calls exec_impl
+ * before its own definition later in this file. */
+static switch_status_t switch_core_session_exec_impl(switch_core_session_t *session,
+								     const switch_application_interface_t *application_interface,
+								     const char *arg, switch_bool_t clear_break);
+
+static switch_status_t switch_core_session_execute_application_impl(switch_core_session_t *session, const char *app,
+																				  const char *arg, int32_t *flags, switch_bool_t from_event)
 {
 	switch_application_interface_t *application_interface;
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -3020,7 +3026,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_get_flag
 
  exec:
 
-	switch_core_session_exec(session, application_interface, arg);
+	switch_core_session_exec_impl(session, application_interface, arg, !from_event);
 
   done:
 
@@ -3029,8 +3035,20 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_get_flag
 	return status;
 }
 
-SWITCH_DECLARE(switch_status_t) switch_core_session_exec(switch_core_session_t *session,
-														 const switch_application_interface_t *application_interface, const char *arg)
+SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_get_flags(switch_core_session_t *session, const char *app,
+										  const char *arg, int32_t *flags)
+{
+	return switch_core_session_execute_application_impl(session, app, arg, flags, SWITCH_FALSE);
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_session_execute_application_event(switch_core_session_t *session, const char *app,
+						      const char *arg)
+{
+	return switch_core_session_execute_application_impl(session, app, arg, NULL, SWITCH_TRUE);
+}
+
+static switch_status_t switch_core_session_exec_impl(switch_core_session_t *session,
+														 const switch_application_interface_t *application_interface, const char *arg, switch_bool_t clear_break)
 {
 	switch_app_log_t *log, *lp;
 	switch_event_t *event;
@@ -3148,7 +3166,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_exec(switch_core_session_t *
 		switch_event_fire(&event);
 	}
 
-	switch_channel_clear_flag(session->channel, CF_BREAK);
+	/* Only clear stale CF_BREAK for direct (dialplan) execution.
+	 * For private-event execution, a break raised after the event was queued
+	 * (e.g. telnyx_break during file-open) must survive into the app. */
+	if (clear_break) {
+		switch_channel_clear_flag(session->channel, CF_BREAK);
+	}
 
 	switch_assert(application_interface->application_function);
 
@@ -3185,6 +3208,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_exec(switch_core_session_t *
 	}
 
 	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_session_exec(switch_core_session_t *session,
+									 const switch_application_interface_t *application_interface, const char *arg)
+{
+	return switch_core_session_exec_impl(session, application_interface, arg, SWITCH_TRUE);
 }
 
 SWITCH_DECLARE(uint32_t) switch_core_session_stack_count(switch_core_session_t *session, int x)

--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -530,6 +530,20 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_parse_event(switch_core_session_t *se
 
 	switch_channel_set_flag_recursive(channel, CF_EVENT_PARSE);
 
+	/* Clear stale break flags before the lead-frames wait so any break
+	 * raised after this point (during the wait, file_open, or playback)
+	 * is durable. Previously, CF_STOP_BROADCAST was cleared after the wait and
+	 * CF_BREAK was cleared by switch_core_session_exec, making any stop
+	 * arriving during the lead-frames wait silently discarded.
+	 *
+	 * This must stay ahead of the lead-frames wait below. Moving it later --
+	 * into the app_name block, or into the loops iteration -- reinstates the
+	 * bug, because the wait is where most stops land. */
+	if (cmd_hash == CMD_EXECUTE) {
+		switch_channel_clear_flag(channel, CF_STOP_BROADCAST);
+		switch_channel_clear_flag(channel, CF_BREAK);
+	}
+
 	if (switch_true(event_lock)) {
 		switch_channel_set_flag_recursive(channel, CF_EVENT_LOCK);
 		el = 1;
@@ -579,8 +593,6 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_parse_event(switch_core_session_t *se
 			int x;
 			const char *b_uuid = NULL;
 			switch_core_session_t *b_session = NULL;
-
-			switch_channel_clear_flag(channel, CF_STOP_BROADCAST);
 
 			if (!switch_channel_test_flag(channel, CF_BRIDGED) || switch_channel_test_flag(channel, CF_HOLD_BLEG)) {
 				inner++;
@@ -632,6 +644,16 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_parse_event(switch_core_session_t *se
 			for (x = 0; x < loops || loops < 0; x++) {
 				switch_time_t b4, aftr;
 
+				/* Reset the break between iterations only. The application no
+				 * longer clears CF_BREAK for us, so a break raised late in
+				 * iteration N and never consumed would otherwise abort N+1 and
+				 * terminate the whole loop (e.g. silencing looped hold music).
+				 * Iteration 0 must NOT be cleared: a break raised while this
+				 * command was waiting on lead-frames belongs to it. */
+				if (x > 0) {
+					switch_channel_clear_flag(channel, CF_BREAK);
+				}
+
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%s Command Execute [depth=%d] %s(%s)\n",
 								  switch_channel_get_name(channel), switch_core_session_stack_count(session, 0), app_name, switch_str_nil(app_arg));
 				b4 = switch_micro_time_now();
@@ -646,7 +668,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_parse_event(switch_core_session_t *se
 				switch_channel_set_variable_printf(channel, "current_loop", "%d", x + 1);
 				switch_channel_set_variable_printf(channel, "total_loops", "%d", loops);
 
-				if (switch_core_session_execute_application(session, app_name, app_arg) != SWITCH_STATUS_SUCCESS) {
+				if (switch_core_session_execute_application_event(session, app_name, app_arg) != SWITCH_STATUS_SUCCESS) {
 					if (!inner || switch_channel_test_flag(channel, CF_STOP_BROADCAST)) switch_channel_clear_flag(channel, CF_BROADCAST);
 					break;
 				}

--- a/tests/unit/switch_core_session.c
+++ b/tests/unit/switch_core_session.c
@@ -38,6 +38,7 @@ FST_CORE_BEGIN("./conf")
 	{
 		FST_SETUP_BEGIN()
 		{
+			fst_requires_module("mod_dptools");
 		}
 		FST_SETUP_END()
 
@@ -69,6 +70,177 @@ FST_CORE_BEGIN("./conf")
 			switch_channel_hangup(fst_channel, SWITCH_CAUSE_NORMAL_CLEARING);
 			session = switch_core_session_locate("bar");
 			fst_check(session == NULL);
+		}
+		FST_SESSION_END()
+
+		/*
+		 * exec_clears_break_direct_path: switch_core_session_exec (the
+		 * direct/dialplan wrapper) must clear CF_BREAK before running the
+		 * app -- this is the original behaviour, preserved by the exec_impl
+		 * refactor. If this regresses, a stale break from a prior app in a
+		 * dialplan chain kills the next one.
+		 */
+		FST_SESSION_BEGIN(exec_clears_break_direct_path)
+		{
+			switch_application_interface_t *app_interface =
+				switch_loadable_module_get_application_interface("set");
+			fst_requires(app_interface);
+
+			switch_channel_set_flag(fst_channel, CF_BREAK);
+			switch_core_session_exec(fst_session, app_interface, "break_test_a=1");
+			fst_check(!switch_channel_test_flag(fst_channel, CF_BREAK));
+			/* the app must actually have run, not just left the flag alone */
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "break_test_a")), "1");
+
+			UNPROTECT_INTERFACE(app_interface);
+		}
+		FST_SESSION_END()
+
+		/*
+		 * exec_preserves_break_event_path: switch_core_session_execute_application_event
+		 * (used when a command was dequeued from a private event, e.g.
+		 * uuid_broadcast / ESL sendmsg) must NOT clear CF_BREAK. A break
+		 * raised after the event was queued (e.g. telnyx_break during the
+		 * lead-frames wait or file-open) must survive into the app.
+		 */
+		FST_SESSION_BEGIN(exec_preserves_break_event_path)
+		{
+			switch_status_t status;
+
+			/*
+			 * Value 2 specifically: telnyx_break/uuid_break use it for
+			 * "all"/"media" and switch_ivr_play_file only ends a whole
+			 * delimited file list when it sees 2. Preserving the flag but
+			 * downgrading it to 1 would silently change that, so assert the
+			 * value rather than mere truthiness.
+			 */
+			switch_channel_set_flag_value(fst_channel, CF_BREAK, 2);
+			status = switch_core_session_execute_application_event(fst_session, "set", "break_test_b=2");
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_test_flag(fst_channel, CF_BREAK) == 2);
+			/* and the preserved break must not have suppressed the app itself */
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "break_test_b")), "2");
+
+			/* don't leave a live break feeding the read loop at teardown */
+			switch_channel_clear_flag(fst_channel, CF_BREAK);
+		}
+		FST_SESSION_END()
+
+		/*
+		 * exec_get_flags_clears_break: the direct-path execute_application_get_flags
+		 * wrapper must still clear CF_BREAK -- it delegates to the same impl with
+		 * clear_break=TRUE, preserving the original behaviour for all non-event
+		 * callers (dialplan, phrase, menu, httapi, etc.).
+		 */
+		FST_SESSION_BEGIN(exec_get_flags_clears_break)
+		{
+			switch_status_t status;
+
+			switch_channel_set_flag(fst_channel, CF_BREAK);
+			status = switch_core_session_execute_application_get_flags(fst_session, "set", "break_test_c=3", NULL);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(!switch_channel_test_flag(fst_channel, CF_BREAK));
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "break_test_c")), "3");
+		}
+		FST_SESSION_END()
+
+		/*
+		 * nested_chain_does_not_leak_break: simulates an app chain
+		 * (execute_extension / lua / phrase) where each app is dispatched via
+		 * the direct exec path. A break set during one app must be cleared
+		 * before the next app runs, regardless of CF_EVENT_PARSE refcount.
+		 * This is why C2 threads clear_break as a function parameter rather
+		 * than keying on the channel-global CF_EVENT_PARSE flag.
+		 */
+		FST_SESSION_BEGIN(nested_chain_does_not_leak_break)
+		{
+			switch_application_interface_t *app_interface =
+				switch_loadable_module_get_application_interface("set");
+			fst_requires(app_interface);
+
+			/*
+			 * Stand in for being inside switch_ivr_parse_event executing a
+			 * queued command: CF_EVENT_PARSE is set on the channel for the
+			 * whole of that window, including any app the queued app itself
+			 * dispatches. Those nested apps go through the direct path and
+			 * must STILL clear CF_BREAK, or one break would skip every
+			 * remaining app in the chain. Deciding this from CF_EVENT_PARSE
+			 * rather than the clear_break parameter fails here.
+			 */
+			switch_channel_set_flag_recursive(fst_channel, CF_EVENT_PARSE);
+
+			/* first app in chain -- break set, then cleared by exec */
+			switch_channel_set_flag(fst_channel, CF_BREAK);
+			switch_core_session_exec(fst_session, app_interface, "chain_a=1");
+			fst_check(!switch_channel_test_flag(fst_channel, CF_BREAK));
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "chain_a")), "1");
+
+			/* second app in chain -- independently set and cleared */
+			switch_channel_set_flag(fst_channel, CF_BREAK);
+			switch_core_session_exec(fst_session, app_interface, "chain_b=2");
+			fst_check(!switch_channel_test_flag(fst_channel, CF_BREAK));
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "chain_b")), "2");
+
+			switch_channel_clear_flag_recursive(fst_channel, CF_EVENT_PARSE);
+
+			UNPROTECT_INTERFACE(app_interface);
+		}
+		FST_SESSION_END()
+
+		/*
+		 * parse_event_clears_stale_break_flags: switch_ivr_parse_event must
+		 * clear stale CF_STOP_BROADCAST and CF_BREAK at the top (before the
+		 * lead-frames wait) for CMD_EXECUTE commands. This covers the ESL
+		 * sync-sendmsg path, where mod_event_socket calls parse_event directly
+		 * -- siting the clear in dequeue_private_event instead would leave
+		 * CF_STOP_BROADCAST permanently sticky and wedge the session.
+		 */
+		FST_SESSION_BEGIN(parse_event_clears_stale_break_flags)
+		{
+			switch_event_t *event = NULL;
+			switch_status_t status;
+
+			fst_requires(switch_event_create(&event, SWITCH_EVENT_COMMAND) == SWITCH_STATUS_SUCCESS);
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "call-command", "execute");
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "execute-app-name", "set");
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "execute-app-arg", "parse_event_test=1");
+
+			/* set stale flags that should be cleared at the top of parse_event */
+			switch_channel_set_flag(fst_channel, CF_STOP_BROADCAST);
+			switch_channel_set_flag(fst_channel, CF_BREAK);
+
+			status = switch_ivr_parse_event(fst_session, event);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			fst_check(!switch_channel_test_flag(fst_channel, CF_STOP_BROADCAST));
+			fst_check(!switch_channel_test_flag(fst_channel, CF_BREAK));
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "parse_event_test")), "1");
+
+			switch_event_destroy(&event);
+
+			/*
+			 * Second command on the same session, with both flags raised again
+			 * in between. This is the ESL sync-sendmsg failure mode: siting the
+			 * clear in dequeue_private_event would never run here (parse_event
+			 * is called directly, nothing is dequeued), leaving
+			 * CF_STOP_BROADCAST sticky and breaking every later command.
+			 */
+			fst_requires(switch_event_create(&event, SWITCH_EVENT_COMMAND) == SWITCH_STATUS_SUCCESS);
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "call-command", "execute");
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "execute-app-name", "set");
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "execute-app-arg", "parse_event_test2=2");
+
+			switch_channel_set_flag(fst_channel, CF_STOP_BROADCAST);
+			switch_channel_set_flag(fst_channel, CF_BREAK);
+
+			status = switch_ivr_parse_event(fst_session, event);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			fst_check(!switch_channel_test_flag(fst_channel, CF_STOP_BROADCAST));
+			fst_check(!switch_channel_test_flag(fst_channel, CF_BREAK));
+			fst_check_string_equals(switch_str_nil(switch_channel_get_variable(fst_channel, "parse_event_test2")), "2");
+
+			switch_event_destroy(&event);
 		}
 		FST_SESSION_END()
 	}

--- a/tests/unit/switch_ivr_play_say.c
+++ b/tests/unit/switch_ivr_play_say.c
@@ -471,6 +471,83 @@ FST_CORE_BEGIN("./conf_playsay")
 			unlink(record_filename);
 		}
 		FST_SESSION_END()
+
+		/*
+		 * break_during_lead_frames_stops_playback: end-to-end guard for the
+		 * playback_stop race. A queued broadcast waits out its lead-frames
+		 * before the app runs; a break raised inside that wait must survive
+		 * into switch_ivr_play_file and stop the file.
+		 *
+		 * Before the fix, switch_ivr_parse_event cleared CF_STOP_BROADCAST
+		 * after the wait and switch_core_session_exec cleared CF_BREAK just
+		 * before the app, so the stop was discarded and the whole 20s file
+		 * played. The duration assertion is what detects that: ~3-6s of
+		 * lead-frames plus an immediate break, versus 20s+ of playback.
+		 */
+		FST_SESSION_BEGIN(break_during_lead_frames_stops_playback)
+		{
+			switch_event_t *event = NULL;
+			switch_stream_handle_t stream = { 0 };
+			switch_status_t status;
+			char cmd[256];
+
+			fst_requires_module("mod_commands");
+
+			/*
+			 * The lead-frames wait is gated on media being up, and both
+			 * assertions below depend on that wait actually running. Assert it
+			 * rather than letting the test quietly measure something else.
+			 */
+			fst_requires(switch_channel_media_ready(fst_channel));
+
+			fst_requires(switch_event_create(&event, SWITCH_EVENT_COMMAND) == SWITCH_STATUS_SUCCESS);
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "call-command", "execute");
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "execute-app-name", "playback");
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "execute-app-arg", "silence_stream://20000");
+			/* same header switch_ivr_broadcast stamps on every queued command */
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "lead-frames", "150");
+
+			/* fire the break ~2s from now, i.e. inside the lead-frames wait */
+			switch_snprintf(cmd, sizeof(cmd), "+2 none uuid_break %s", switch_core_session_get_uuid(fst_session));
+			SWITCH_STANDARD_STREAM(stream);
+			fst_requires(switch_api_execute("sched_api", cmd, NULL, &stream) == SWITCH_STATUS_SUCCESS);
+			switch_safe_free(stream.data);
+
+			fst_time_mark();
+			status = switch_ivr_parse_event(fst_session, event);
+
+			/*
+			 * SUCCESS, not BREAK. Two things have to line up for that.
+			 *
+			 * switch_ivr_play_file consumes the flag -- it clears CF_BREAK
+			 * before returning -- and parse_event's return expression is
+			 * "test_flag(CF_BREAK) ? BREAK : status", so the flag is already
+			 * gone by then. Nothing re-raises it, because CF_STOP_BROADCAST is
+			 * never set: parse_event raises CF_BROADCAST itself, but only
+			 * after the lead-frames wait, and uuid_break fires during the
+			 * wait. Seeing CF_BROADCAST still clear, uuid_break takes its else
+			 * branch and sets CF_BREAK alone.
+			 *
+			 * That ordering is exactly what the media_ready guard above
+			 * protects. Without media the wait is skipped, CF_BROADCAST is
+			 * already up when uuid_break fires, it calls stop_broadcast
+			 * instead, and the post-loop CF_STOP_BROADCAST branch re-raises
+			 * CF_BREAK -- parse_event would return BREAK and this would fail.
+			 */
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			/*
+			 * Duration is the real assertion. With media up the wait runs 150
+			 * non-CNG frames, a 3000ms floor capped at 6000ms by max_frames,
+			 * then the surviving break cuts playback immediately. 1500-7500
+			 * covers that range with margin and still fails hard on the
+			 * regression, which is 20s+ of audio.
+			 */
+			fst_check_duration(4500, 3000);
+
+			switch_event_destroy(&event);
+		}
+		FST_SESSION_END()
 	}
 	FST_SUITE_END()
 }


### PR DESCRIPTION
## Problem

`playback_stop` / `telnyx_break` returned `+OK` while the audio played through to completion, and no `COMMAND_INTERRUPTED` reached call control.

The stop had no durable representation. Once a command was dequeued the flush was a no-op, and both flags that could still stop it were wiped before the play loop ever looked:

- `switch_ivr_parse_event` cleared `CF_STOP_BROADCAST` *after* the lead-frames wait
- `switch_core_session_exec` cleared `CF_BREAK` immediately before the application ran

So any stop arriving in that window was silently discarded, and `switch_ivr_play_say.c` never saw a flag to act on.

Two corrections to the original report:

- The dominant widener is the `lead-frames` header stamped on every broadcast command (roughly 100-200ms), **not** the file download. This was never specific to HTTP-sourced audio and reproduces with local files.
- `CF_BREAK` does not "persist through the download" — it is cleared before the download starts.

## Fix

**`switch_core_session_execute_application_event()`** — a public entry point for the queued-command path. `switch_core_session_execute_application_get_flags` and `switch_core_session_exec` are split into internal implementations taking the `clear_break` decision as an explicit parameter. Every existing caller keeps the old behaviour of clearing `CF_BREAK`.

The decision is a parameter rather than a `CF_EVENT_PARSE` test on purpose: that flag is a channel-global refcount that stays set for the whole parse window, including nested apps dispatched by the queued app, so keying on it would let one break skip every remaining app in an `execute_extension` / `lua` / `phrase` chain.

**`switch_ivr_parse_event`** resets both flags at the top, ahead of the lead-frames wait, so anything raised from that point on reaches the application.

The reset must live in `parse_event` and not `dequeue_private_event`, because `mod_event_socket` calls `parse_event` directly for a synchronous `sendmsg`. A dequeue-sited reset would never run on that path and would leave `CF_STOP_BROADCAST` permanently set, wedging the session.

`CF_BREAK` is also reset between loop iterations, since the application no longer does it. A break left unconsumed by iteration N would otherwise abort N+1 and cut a looped broadcast short.

## Tests

Six regression tests. Five in `switch_core_session` pin both halves of the contract — the direct path still clears `CF_BREAK` before an application runs (including nested apps dispatched while `CF_EVENT_PARSE` is set), the private-event path preserves it with its value intact, and `parse_event` is driven twice over one session to guard the synchronous `sendmsg` path.

The `switch_ivr_play_say` test is end to end: a break scheduled inside the lead-frames wait of a queued 20 second playback must reach the play loop and cut the file. Duration carries the assertion, since the regression is the file running to completion. Measured 3.000s against a 20s file.

It asserts `SUCCESS` rather than `BREAK` because `play_file` consumes `CF_BREAK`, and `parse_event` only returns `BREAK` when the flag is still set on the way out. That in turn depends on `uuid_break` seeing `CF_BROADCAST` clear, which holds only while the lead-frames wait is running — hence the `media_ready` guard.

## Verification

Built clean, no warnings in any changed file. 42 tests green across five suites:

| suite | |
|---|---|
| `switch_core_session` | 6/6 |
| `switch_ivr_play_say` | 7/7 |
| `switch_ivr_originate` | 25/25 |
| `switch_hold` | 1/1 |
| `switch_ivr_async` | 3/3 |

## Related

Needs the companion changes in `mod_call_control` (unconditional `CF_BREAK` in `telnyx_break`) and `mod_telnyx` (publish `COMMAND_INTERRUPTED`).