### PR TITLE
TELCORE-355: propagate concrete recorder open-error detail on record_session_error

### DIFF
--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -2330,7 +2330,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 			char ebuf[255] = "";
 			get_error_text(ret, ebuf, sizeof(ebuf));
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, ebuf);
-			/* TELCORE-355: stash the concrete open error on handle->event so the
+			/* Stash the concrete open error on handle->event so the
 			 * recording layer (switch_ivr_async.c send_record_error_event) can
 			 * distinguish an rw_timeout (recorder-server timeout) from other open
 			 * failures. handle->event is otherwise unused on this path; the

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -2328,7 +2328,20 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 
 		if (ret < 0) {
 			char ebuf[255] = "";
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
+			get_error_text(ret, ebuf, sizeof(ebuf));
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, ebuf);
+			/* TELCORE-355: stash the concrete open error on handle->event so the
+			 * recording layer (switch_ivr_async.c send_record_error_event) can
+			 * distinguish an rw_timeout (recorder-server timeout) from other open
+			 * failures. handle->event is otherwise unused on this path; the
+			 * recording layer consumes and destroys it. */
+			if (!handle->event) {
+				switch_event_create(&handle->event, SWITCH_EVENT_CLONE);
+			}
+			if (handle->event) {
+				switch_event_add_header_string(handle->event, SWITCH_STACK_BOTTOM, "Record-Open-Error-Detail", ebuf);
+				switch_event_add_header_string(handle->event, SWITCH_STACK_BOTTOM, "Record-Open-Timeout", (ret == AVERROR(ETIMEDOUT)) ? "true" : "false");
+			}
 			switch_goto_status(SWITCH_STATUS_GENERR, end);
 		}
 	} else {

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1400,7 +1400,7 @@ static void send_record_error_event(switch_channel_t *channel, const char* file,
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-File-Path", file);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-Error", error);
-		/* TELCORE-355: forward the concrete open-error detail stashed by the file
+		/* Forward the concrete open-error detail stashed by the file
 		 * format module (e.g. mod_av) so consumers can distinguish an rw_timeout
 		 * (recorder-server timeout) from other open failures. Absent for file
 		 * modules that don't populate it. */

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1393,13 +1393,27 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 	rh->start_event_sent = 0;
 }
 
-static void send_record_error_event(switch_channel_t *channel, const char* file, const char* error)
+static void send_record_error_event(switch_channel_t *channel, const char* file, const char* error, switch_file_handle_t *fh)
 {
 	switch_event_t *event;
 	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, "record_session_error") == SWITCH_STATUS_SUCCESS) {
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-File-Path", file);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-Error", error);
+		/* TELCORE-355: forward the concrete open-error detail stashed by the file
+		 * format module (e.g. mod_av) so consumers can distinguish an rw_timeout
+		 * (recorder-server timeout) from other open failures. Absent for file
+		 * modules that don't populate it. */
+		if (fh && fh->event) {
+			const char *detail = switch_event_get_header(fh->event, "Record-Open-Error-Detail");
+			const char *timeout = switch_event_get_header(fh->event, "Record-Open-Timeout");
+			if (detail) {
+				switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-Error-Detail", detail);
+			}
+			if (timeout) {
+				switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-Open-Timeout", timeout);
+			}
+		}
 		switch_event_fire(&event);
 	}
 }
@@ -3737,7 +3751,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			send_record_error_event(channel, file_open_path, "Error opening file");
+			send_record_error_event(channel, file_open_path, "Error opening file", fh);
+			if (fh->event) {
+				switch_event_destroy(&fh->event);
+			}
 			set_completion_cause(rh, "uri-failure");
 			switch_goto_status(SWITCH_STATUS_GENERR, err);
 		}
@@ -3791,7 +3808,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			send_record_error_event(channel, in_file, "Error opening file");
+			send_record_error_event(channel, in_file, "Error opening file", &rh->in_fh);
+			if (rh->in_fh.event) {
+				switch_event_destroy(&rh->in_fh.event);
+			}
 			set_completion_cause(rh, "uri-failure");
 			switch_goto_status(SWITCH_STATUS_GENERR, err);
 		}
@@ -3803,7 +3823,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			send_record_error_event(channel, out_file, "Error opening file");
+			send_record_error_event(channel, out_file, "Error opening file", &rh->out_fh);
+			if (rh->out_fh.event) {
+				switch_event_destroy(&rh->out_fh.event);
+			}
 			set_completion_cause(rh, "uri-failure");
 			switch_goto_status(SWITCH_STATUS_GENERR, err);
 		}


### PR DESCRIPTION
## What

Propagate the **concrete recorder open-error** (and an explicit timeout flag) on the `record_session_error` event, so downstream metrics/alerting can distinguish a **recorder-server timeout** from any other recording open failure.

Linear: https://linear.app/telnyx/issue/TELCORE-355/add-b2bua-alerting-for-recorder-server-timeouts

## Why

In the 2026-08-07 incident (~170k calls affected), recorder-server RTMP timeouts manifested as:

```
avformat.c:2331  Could not open 'rtmp://recorder.query.prod.telnyx.io:1935/...': Connection timed out
switch_ivr_async.c:3735  Error opening {stereo=false,rw_timeout=15000000,...}rtmp://recorder...
```

The `record_session_error` CUSTOM event fired, but it only carried `Record-Error = "Error opening file"` — the **specific** cause ("Connection timed out" vs connection-refused / DNS / other) lived only in the `mod_av/avformat.c` log line, never in the event. So `mod_telnyx` (the Prometheus scrape endpoint) could not build a timeout-specific counter/alert without a core change.

## Change

- **`mod_av` (`avformat.c`):** on `avio_open2`/`avio_open` failure, stash the concrete error text and an explicit timeout flag on the otherwise-unused `handle->event`:
  - `Record-Open-Error-Detail` = `av_strerror` text
  - `Record-Open-Timeout` = `true` iff `ret == AVERROR(ETIMEDOUT)` (exact code check — **not** string matching; `ETIMEDOUT` is precisely how the `rw_timeout` interrupt callback surfaces).
- **`switch_ivr_async.c`:** `send_record_error_event()` gains a `switch_file_handle_t *fh` param and forwards those as `Record-Error-Detail` / `Record-Open-Timeout` headers **when present**. The three `record_session` open-failure call sites pass the handle and `switch_event_destroy(&fh->event)` after use.

Headers are **absent** for file modules that don't populate them (WAV, sndfile, etc.) → fully backwards compatible; existing consumers see the same `Record-Error` they always did.

## Lifetime / safety notes

- `handle->event` is unused on the recording open path today (`git grep` confirms no reader in `switch_ivr_async.c` record_session). It is a `SWITCH_EVENT_CLONE` event with its own allocation, **not** tied to `fh->memory_pool` — so it survives `switch_core_file_open`'s `fail:` cleanup (which only destroys `fh->params` and, when it owns it, `fh->memory_pool`).
- Each open-failure call site destroys the event right after firing; `record_helper_destroy` only `switch_core_file_close`s the handles (which doesn't touch `fh->event`), so **no double-free** and **no leak**.
- C90: new declarations are at the top of their block scope.

## Paired PR (must land together)

- **`team-telnyx/mod_telnyx` PR #69** consumes `Record-Open-Timeout` to emit `freeswitch_record_session_error_total{reason="timeout|other|unknown"}` (and a separate `freeswitch_record_completion_total{cause}` from `RECORD_STOP` for the mid-recording write/timeout mode). It degrades to `reason="unknown"` on cores without this change, so **mod_telnyx can merge/deploy independently**; this PR just upgrades `unknown` → `timeout`/`other`.

## Testing / limitations

- **No local compile in this environment** (FreeSWITCH core requires the full autotools build tree). The compile gate is the standard FreeSWITCH / `telnyx_b2bua_builder` pipeline.
- Verification performed here: `git diff --check` clean; confirmed `handle->event` has no existing reader on this path; confirmed `AVERROR(EINVAL/ENOMEM)` are already used in `avformat.c` so `AVERROR(ETIMEDOUT)` resolves via the same libavutil includes; C90 decl placement checked.
- **Manual staging:** point a recording at an unreachable RTMP host with `rw_timeout` set, e.g. `uuid_record <uuid> start {rw_timeout=5000000}rtmp://unreachable:1935/x`, and confirm the `record_session_error` event now carries `Record-Open-Timeout: true` (`fs_cli` event trace or the mod_telnyx counter).
