### PR TITLE
TELCORE-303: keep AMR-WB codec selection and fmtp stable across re-INVITEs

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -5535,6 +5535,9 @@ static switch_call_cause_t sofia_outgoing_channel(switch_core_session_t *session
 
 	switch_channel_set_variable_printf(nchannel, "sip_local_network_addr", "%s", profile->extsipip ? profile->extsipip : profile->sipip);
 	switch_channel_set_variable(nchannel, "sip_profile_name", profile_name);
+	if (profile->strict_codec_match) {
+		switch_channel_set_variable(nchannel, "telnyx-strict-codec-match", profile->strict_codec_match);
+	}
 
 	if (switch_stristr("fs_path", tech_pvt->dest)) {
 		char *remote_host = NULL;

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -664,6 +664,9 @@ struct sofia_profile {
 	char *rtpip[MAX_RTPIP];
 	char *rtpip6[MAX_RTPIP];
 	char *jb_msec;
+	/* Value stamped on inbound channels as telnyx-strict-codec-match. NULL means the
+	   profile said nothing, leaving the global variable to decide. */
+	char *strict_codec_match;
 	switch_payload_t te;
 	switch_payload_t recv_te;
 	uint32_t rtpip_index;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -6011,6 +6011,8 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 							sofia_clear_media_flag(profile, SCMF_CODEC_SCROOGE);
 							sofia_clear_media_flag(profile, SCMF_CODEC_GREEDY);
 						}
+					} else if (!strcasecmp(var, "strict-codec-match")) {
+						profile->strict_codec_match = switch_core_strdup(profile->pool, switch_true(val) ? "true" : "false");
 					} else if (!strcasecmp(var, "disable-transcoding")) {
 						if (switch_true(val)) {
 							sofia_set_media_flag(profile, SCMF_DISABLE_TRANSCODING);
@@ -12130,6 +12132,9 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 		}
 
 		switch_channel_set_variable(channel, "sofia_profile_name", profile->name);
+		if (profile->strict_codec_match) {
+			switch_channel_set_variable(channel, "telnyx-strict-codec-match", profile->strict_codec_match);
+		}
 		switch_channel_set_variable(channel, "sofia_profile_url", profile->url);
 		switch_channel_set_variable(channel, "recovery_profile_name", profile->name);
 		switch_channel_set_variable(channel, "sofia_profile_domain_name", profile->domain_name);

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1720,12 +1720,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		switch_channel_set_variable(channel, "sofia_profile_url", tech_pvt->profile->url);
 	}
 
-	/* Outbound counterpart of the stamp sofia_handle_sip_i_invite() puts on inbound
-	   channels. The dialplan has already run here, so an explicit channel variable wins. */
-	if (tech_pvt->profile->strict_codec_match && !switch_channel_get_variable(channel, "telnyx-strict-codec-match")) {
-		switch_channel_set_variable(channel, "telnyx-strict-codec-match", tech_pvt->profile->strict_codec_match);
-	}
-
 	extra_headers = sofia_glue_get_extra_headers(channel, SOFIA_SIP_HEADER_PREFIX);
 
 	if ((val = switch_channel_get_variable(channel, SOFIA_SESSION_TIMEOUT))) {

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1720,6 +1720,12 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		switch_channel_set_variable(channel, "sofia_profile_url", tech_pvt->profile->url);
 	}
 
+	/* Outbound counterpart of the stamp sofia_handle_sip_i_invite() puts on inbound
+	   channels. The dialplan has already run here, so an explicit channel variable wins. */
+	if (tech_pvt->profile->strict_codec_match && !switch_channel_get_variable(channel, "telnyx-strict-codec-match")) {
+		switch_channel_set_variable(channel, "telnyx-strict-codec-match", tech_pvt->profile->strict_codec_match);
+	}
+
 	extra_headers = sofia_glue_get_extra_headers(channel, SOFIA_SIP_HEADER_PREFIX);
 
 	if ((val = switch_channel_get_variable(channel, SOFIA_SESSION_TIMEOUT))) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8216,7 +8216,11 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 						 * codec disagreeing with the answer when a re-INVITE offers only the
 						 * other implementation of the same codec.
 						 */
-						if (switch_core_codec_ready(&a_engine->read_codec) && same_codec_impl(selected_imp, &a_engine->read_impl)) {
+						int codec_ready = switch_core_codec_ready(&a_engine->read_codec);
+						int same_codec_name = codec_ready && selected_imp->iananame && a_engine->read_impl.iananame &&
+							!strcasecmp(selected_imp->iananame, a_engine->read_impl.iananame);
+
+						if (codec_ready && same_codec_impl(selected_imp, &a_engine->read_impl)) {
 							a_engine->reset_codec = 0;
 							switch_clear_flag(&a_engine->read_codec, SWITCH_CODEC_FLAG_RESET_PENDING);
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Not resetting codec. We stick to %s\n", a_engine->read_impl.iananame);
@@ -8237,12 +8241,13 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 												  "Keeping fmtp [%s] for %s on the new payload map\n",
 												  a_engine->cur_payload_map->fmtp_out, a_engine->read_impl.iananame);
 							}
-						} else {
+						} else if (same_codec_name) {
 							/*
-							 * The implementation changed. Reset here rather than leaving it to
-							 * the deferred reset in the read loop: the answer SDP is generated
-							 * before that runs, and it takes a=fmtp from the payload map that
-							 * switch_core_media_set_codec() fills in.
+							 * Another implementation of the codec already in use. Reset here
+							 * rather than leaving it to the deferred reset in the read loop:
+							 * the answer SDP is generated before that runs, and it takes
+							 * a=fmtp from the payload map that switch_core_media_set_codec()
+							 * fills in.
 							 */
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Force reset codec for %s\n", a_engine->read_impl.iananame);
 							if (switch_core_media_set_codec(session, 2, smh->mparams->codec_flags) != SWITCH_STATUS_SUCCESS) {
@@ -8253,6 +8258,14 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 									switch_clear_flag(&a_engine->read_codec, SWITCH_CODEC_FLAG_RESET_PENDING);
 								}
 							}
+						} else {
+							/*
+							 * A different codec entirely, or none up yet. The answer does not
+							 * depend on the reset having already run, so leave it to the read
+							 * loop exactly as the unflagged path does rather than destroying
+							 * and re-initialising the codec on the signalling thread.
+							 */
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Deferring codec reset for %s\n", a_engine->read_impl.iananame);
 						}
 					} else {
 						for(z = 0; z < m_idx && smh->num_negotiated_codecs < SWITCH_MAX_CODECS; z++) { 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8231,9 +8231,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 							 */
 							if (a_engine->cur_payload_map && zstr(a_engine->cur_payload_map->fmtp_out) &&
 								switch_core_codec_ready(&a_engine->write_codec) && !zstr(a_engine->write_codec.fmtp_out) &&
-								a_engine->write_codec.implementation &&
-								a_engine->write_codec.implementation->ianacode == selected_imp->ianacode &&
-								!strcasecmp(a_engine->write_codec.implementation->iananame, selected_imp->iananame)) {
+								same_codec_impl(a_engine->write_codec.implementation, selected_imp)) {
 								a_engine->cur_payload_map->fmtp_out = switch_core_session_strdup(session, a_engine->write_codec.fmtp_out);
 								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
 												  "Keeping fmtp [%s] for %s on the new payload map\n",

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8243,11 +8243,12 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 							}
 						} else if (same_codec_name) {
 							/*
-							 * Another implementation of the codec already in use. Reset here
-							 * rather than leaving it to the deferred reset in the read loop:
-							 * the answer SDP is generated before that runs, and it takes
-							 * a=fmtp from the payload map that switch_core_media_set_codec()
-							 * fills in.
+							 * The codec already in use, at a different implementation, ptime
+							 * or rate. Any of the three rebuilds the payload map, since all
+							 * three are part of its key, so reset here rather than leaving it
+							 * to the deferred reset in the read loop: the answer SDP is
+							 * generated before that runs, and it takes a=fmtp from the payload
+							 * map that switch_core_media_set_codec() fills in.
 							 */
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Force reset codec for %s\n", a_engine->read_impl.iananame);
 							if (switch_core_media_set_codec(session, 2, smh->mparams->codec_flags) != SWITCH_STATUS_SUCCESS) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8233,13 +8233,23 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 							 * codec with no a=fmtp at all. Carry the fmtp of the codec we are
 							 * keeping over to the new payload map.
 							 */
-							if (a_engine->cur_payload_map && zstr(a_engine->cur_payload_map->fmtp_out) &&
-								switch_core_codec_ready(&a_engine->write_codec) && !zstr(a_engine->write_codec.fmtp_out) &&
+							if (a_engine->cur_payload_map && switch_core_codec_ready(&a_engine->write_codec) &&
+								!zstr(a_engine->write_codec.fmtp_out) &&
 								same_codec_impl(a_engine->write_codec.implementation, selected_imp)) {
-								a_engine->cur_payload_map->fmtp_out = switch_core_session_strdup(session, a_engine->write_codec.fmtp_out);
-								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
-												  "Keeping fmtp [%s] for %s on the new payload map\n",
-												  a_engine->cur_payload_map->fmtp_out, a_engine->read_impl.iananame);
+								const char *kept = NULL;
+
+								switch_mutex_lock(smh->sdp_mutex);
+								if (zstr(a_engine->cur_payload_map->fmtp_out)) {
+									a_engine->cur_payload_map->fmtp_out = switch_core_session_strdup(session, a_engine->write_codec.fmtp_out);
+									kept = a_engine->cur_payload_map->fmtp_out;
+								}
+								switch_mutex_unlock(smh->sdp_mutex);
+
+								if (kept) {
+									switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+													  "Keeping fmtp [%s] for %s on the new payload map\n",
+													  kept, a_engine->read_impl.iananame);
+								}
 							}
 						} else if (same_codec_name) {
 							/*

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -6052,6 +6052,20 @@ struct matches {
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
+/*
+ * Whether an implementation is interchangeable with one already negotiated.
+ * Comparing iananame alone is not enough: AMR, AMR-WB, G7221, SILK and iLBC each
+ * register several implementations under a single name, and an offer that omits
+ * a=ptime matches every implementation a codec has registered.
+ */
+static int same_codec_impl(const switch_codec_implementation_t *imp, const switch_codec_implementation_t *ref)
+{
+	return imp && ref && imp->ianacode == ref->ianacode &&
+		imp->iananame && ref->iananame && !strcasecmp(imp->iananame, ref->iananame) &&
+		imp->microseconds_per_packet == ref->microseconds_per_packet &&
+		imp->samples_per_second == ref->samples_per_second;
+}
+
 static void greedy_sort(switch_media_handle_t *smh, struct matches *matches, int m_idx, const switch_codec_implementation_t **codec_array, int total_codecs)
 {
 	int j = 0, f = 0, g;
@@ -7400,6 +7414,14 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 			int ice = 0;
 			int last_pt = 0;
 			int changed_pt = 0;
+			/*
+			 * When set, a previously negotiated codec is only re-selected if the offered
+			 * implementation is the same one. Codecs such as AMR/AMR-WB register several
+			 * implementations under a single iananame, so matching by name alone cannot
+			 * tell them apart. Off by default.
+			 */
+			int strict_codec_match = switch_true(switch_channel_get_variable(session->channel, "telnyx-strict-codec-match"));
+			int found_prev = 0;
 
 			nm_idx = 0;
 			m_idx = 0;
@@ -8066,7 +8088,12 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					/*
 					 * Prioritize previously negotiated codec
 					 */
-					if (a_engine->read_impl.iananame && switch_core_codec_ready(&a_engine->read_codec) && strcasecmp(pmap->iananame, a_engine->read_impl.iananame) == 0) {
+					if (a_engine->read_impl.iananame && switch_core_codec_ready(&a_engine->read_codec) && strcasecmp(pmap->iananame, a_engine->read_impl.iananame) == 0 &&
+						(!strict_codec_match || (!found_prev && same_codec_impl(matches[j].imp, &a_engine->read_impl)))) {
+						if (strict_codec_match) {
+							/* Latch, so a later match on the same name cannot overwrite the exact one. */
+							found_prev = 1;
+						}
 						if (a_engine->cur_payload_map) {
 							a_engine->cur_payload_map->current = 0;
 						}

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8238,12 +8238,10 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 								same_codec_impl(a_engine->write_codec.implementation, selected_imp)) {
 								const char *kept = NULL;
 
-								switch_mutex_lock(smh->sdp_mutex);
 								if (zstr(a_engine->cur_payload_map->fmtp_out)) {
 									a_engine->cur_payload_map->fmtp_out = switch_core_session_strdup(session, a_engine->write_codec.fmtp_out);
 									kept = a_engine->cur_payload_map->fmtp_out;
 								}
-								switch_mutex_unlock(smh->sdp_mutex);
 
 								if (kept) {
 									switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8220,6 +8220,25 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 							a_engine->reset_codec = 0;
 							switch_clear_flag(&a_engine->read_codec, SWITCH_CODEC_FLAG_RESET_PENDING);
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Not resetting codec. We stick to %s\n", a_engine->read_impl.iananame);
+
+							/*
+							 * A re-offer carrying a different fmtp than the one we stored fails
+							 * fmtp_check_match() and allocates a fresh payload map, and only
+							 * switch_core_media_set_codec() ever fills in fmtp_out. Keeping the
+							 * codec means it is not called, so the answer would advertise the
+							 * codec with no a=fmtp at all. Carry the fmtp of the codec we are
+							 * keeping over to the new payload map.
+							 */
+							if (a_engine->cur_payload_map && zstr(a_engine->cur_payload_map->fmtp_out) &&
+								switch_core_codec_ready(&a_engine->write_codec) && !zstr(a_engine->write_codec.fmtp_out) &&
+								a_engine->write_codec.implementation &&
+								a_engine->write_codec.implementation->ianacode == selected_imp->ianacode &&
+								!strcasecmp(a_engine->write_codec.implementation->iananame, selected_imp->iananame)) {
+								a_engine->cur_payload_map->fmtp_out = switch_core_session_strdup(session, a_engine->write_codec.fmtp_out);
+								switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+												  "Keeping fmtp [%s] for %s on the new payload map\n",
+												  a_engine->cur_payload_map->fmtp_out, a_engine->read_impl.iananame);
+							}
 						} else {
 							/*
 							 * The implementation changed. Reset here rather than leaving it to

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -7422,6 +7422,14 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 			 */
 			int strict_codec_match = switch_true(switch_channel_get_variable(session->channel, "telnyx-strict-codec-match"));
 			int found_prev = 0;
+			/* Implementation behind the payload map we end up selecting. */
+			const switch_codec_implementation_t *selected_imp = NULL;
+			/*
+			 * Set while the partner leg drives this renegotiation (rtp_pass_codecs_on_stream_change).
+			 * Its answer decides the codec, so the one previously negotiated on this leg must not
+			 * be re-asserted over it.
+			 */
+			int partner_driven = switch_channel_test_flag(session->channel, CF_AWAITING_STREAM_CHANGE);
 
 			nm_idx = 0;
 			m_idx = 0;
@@ -8077,6 +8085,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					if (j == 0) {
 						a_engine->cur_payload_map = pmap;
 						a_engine->cur_payload_map->current = 1;
+						selected_imp = matches[j].imp;
 						if (a_engine->rtp_session) {
 							switch_rtp_set_default_payload(a_engine->rtp_session, pmap->pt);
 						}
@@ -8089,7 +8098,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					 * Prioritize previously negotiated codec
 					 */
 					if (a_engine->read_impl.iananame && switch_core_codec_ready(&a_engine->read_codec) && strcasecmp(pmap->iananame, a_engine->read_impl.iananame) == 0 &&
-						(!strict_codec_match || (!found_prev && same_codec_impl(matches[j].imp, &a_engine->read_impl)))) {
+						(!strict_codec_match || (!partner_driven && !found_prev && same_codec_impl(matches[j].imp, &a_engine->read_impl)))) {
 						if (strict_codec_match) {
 							/* Latch, so a later match on the same name cannot overwrite the exact one. */
 							found_prev = 1;
@@ -8099,6 +8108,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 						}
 						a_engine->cur_payload_map = pmap;
 						a_engine->cur_payload_map->current = 1;
+						selected_imp = matches[j].imp;
 						if (a_engine->rtp_session) {
 							switch_rtp_set_default_payload(a_engine->rtp_session, pmap->pt);
 						}
@@ -8196,6 +8206,35 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 							a_engine->reset_codec = 0;
 							if (switch_core_codec_ready(&a_engine->read_codec)) {
 								switch_clear_flag(&a_engine->read_codec, SWITCH_CODEC_FLAG_RESET_PENDING);
+							}
+						}
+					} else if (strict_codec_match && selected_imp) {
+						/*
+						 * Compare the implementation we actually selected rather than any
+						 * match. Scanning every match keeps the current codec whenever the
+						 * offer merely contains something name-compatible, which leaves the
+						 * codec disagreeing with the answer when a re-INVITE offers only the
+						 * other implementation of the same codec.
+						 */
+						if (switch_core_codec_ready(&a_engine->read_codec) && same_codec_impl(selected_imp, &a_engine->read_impl)) {
+							a_engine->reset_codec = 0;
+							switch_clear_flag(&a_engine->read_codec, SWITCH_CODEC_FLAG_RESET_PENDING);
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Not resetting codec. We stick to %s\n", a_engine->read_impl.iananame);
+						} else {
+							/*
+							 * The implementation changed. Reset here rather than leaving it to
+							 * the deferred reset in the read loop: the answer SDP is generated
+							 * before that runs, and it takes a=fmtp from the payload map that
+							 * switch_core_media_set_codec() fills in.
+							 */
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "Force reset codec for %s\n", a_engine->read_impl.iananame);
+							if (switch_core_media_set_codec(session, 2, smh->mparams->codec_flags) != SWITCH_STATUS_SUCCESS) {
+								match = 0;
+							} else {
+								a_engine->reset_codec = 0;
+								if (switch_core_codec_ready(&a_engine->read_codec)) {
+									switch_clear_flag(&a_engine->read_codec, SWITCH_CODEC_FLAG_RESET_PENDING);
+								}
 							}
 						}
 					} else {

--- a/tests/unit/conf_sdp/freeswitch.xml
+++ b/tests/unit/conf_sdp/freeswitch.xml
@@ -11,7 +11,17 @@
         <load module="mod_dptools"/>
         <load module="mod_sndfile"/>
         <load module="mod_test"/>
+        <load module="mod_amrwb"/>
      </modules>
+    </configuration>
+
+    <configuration name="amrwb.conf" description="AMR-WB">
+      <settings>
+        <param name="volte" value="1"/>
+        <param name="mode-set" value="0,1,2"/>
+        <param name="invite-prefer-oa" value="0"/>
+        <param name="invite-prefer-be" value="0"/>
+      </settings>
     </configuration>
 
 <configuration name="switch.conf" description="Core Configuration">

--- a/tests/unit/switch_sdp.c
+++ b/tests/unit/switch_sdp.c
@@ -676,6 +676,125 @@ FST_CORE_BEGIN("./conf_sdp")
 		}
 		}
 		FST_SESSION_END()
+
+		/*
+		 * AMR-WB registers a bandwidth efficient and an octet aligned implementation
+		 * under the single iananame AMR-WB, so codec selection that compares names
+		 * alone cannot tell them apart. With telnyx-strict-codec-match
+		 * set, a re-INVITE must not flip between them, and the answer must keep
+		 * advertising the fmtp of whichever one is in use.
+		 */
+		FST_SESSION_BEGIN(sdp_amrwb_strict_codec_match)
+		{
+			switch_status_t status;
+			switch_media_handle_t *media_handle;
+			switch_core_media_params_t *mparams;
+			switch_codec_implementation_t impl = { 0 };
+			switch_payload_t initial_ianacode;
+			const char *local_sdp;
+			uint8_t match = 0, p = 0;
+
+			/* Both variants offered: PT 104 bandwidth efficient, PT 110 octet aligned. */
+			const char *offer_both =
+				"v=0\r\n"
+				"o=- 1 1 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 104 110\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:104 AMR-WB/16000\r\n"
+				"a=fmtp:104 mode-set=2\r\n"
+				"a=rtpmap:110 AMR-WB/16000\r\n"
+				"a=fmtp:110 octet-align=1; mode-set=2\r\n"
+				"a=sendrecv\r\n";
+
+			/*
+			 * Hold re-offer: bandwidth efficient only, with a different number of fmtp
+			 * fields so that fmtp_check_match() fails and a fresh payload map is built.
+			 */
+			const char *offer_be_only =
+				"v=0\r\n"
+				"o=- 1 2 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 104\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:104 AMR-WB/16000\r\n"
+				"a=fmtp:104 mode-set=2; mode-change-capability=2; max-red=0\r\n"
+				"a=sendrecv\r\n";
+
+			/* Re-offer carrying only the octet aligned variant. */
+			const char *offer_oa_only =
+				"v=0\r\n"
+				"o=- 1 3 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 110\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:110 AMR-WB/16000\r\n"
+				"a=fmtp:110 octet-align=1; mode-set=2\r\n"
+				"a=sendrecv\r\n";
+
+			switch_channel_set_variable(fst_channel, "telnyx-strict-codec-match", "true");
+
+			mparams = switch_core_session_alloc(fst_session, sizeof(switch_core_media_params_t));
+			mparams->inbound_codec_string = switch_core_session_strdup(fst_session, "AMR-WB");
+			mparams->outbound_codec_string = switch_core_session_strdup(fst_session, "AMR-WB");
+			mparams->rtpip = switch_core_session_strdup(fst_session, (char *)rx_host);
+
+			status = switch_media_handle_create(&media_handle, fst_session, mparams);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_media_prepare_codecs(fst_session, SWITCH_FALSE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			/* Initial negotiation settles on one of the two implementations. */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_both, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_check(!strcasecmp(impl.iananame, "AMR-WB"));
+			initial_ianacode = impl.ianacode;
+
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:") != NULL, "initial answer carries an fmtp");
+
+			/* Re-offering the same list must not flip to the other implementation. */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_both, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_xcheck(impl.ianacode == initial_ianacode, "re-offer of the same list keeps the implementation");
+
+			/*
+			 * Same implementation, different fmtp. The payload map is rebuilt and the
+			 * codec is not reset, so nothing repopulates fmtp_out; the answer used to
+			 * come out with no a=fmtp line at all.
+			 */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_be_only, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:104") != NULL, "answer keeps the fmtp when only the fmtp changed");
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_xcheck(impl.ianacode == initial_ianacode, "codec unchanged when only the fmtp changed");
+
+			/*
+			 * Only the other implementation is offered. The codec has to actually change,
+			 * and the answer still has to carry an fmtp: deferring the reset to the read
+			 * loop would generate the SDP before the payload map is repopulated.
+			 */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_oa_only, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:110") != NULL, "answer carries an fmtp after switching implementation");
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_xcheck(impl.ianacode != initial_ianacode, "codec follows an offer carrying only the other implementation");
+		}
+		FST_SESSION_END()
 	}
 	FST_SUITE_END()
 }

--- a/tests/unit/switch_sdp.c
+++ b/tests/unit/switch_sdp.c
@@ -867,6 +867,78 @@ FST_CORE_BEGIN("./conf_sdp")
 			fst_xcheck(strstr(local_sdp, "a=fmtp:104") != NULL, "hold answer still carries the AMR-WB fmtp");
 		}
 		FST_SESSION_END()
+
+		/*
+		 * A re-INVITE that swaps the codec outright is not the case this flag exists for.
+		 * Nothing in the answer depends on the codec having already been re-initialised,
+		 * so the reset stays deferred to the read loop rather than running on the
+		 * signalling thread, which is what the unflagged path does.
+		 */
+		FST_SESSION_BEGIN(sdp_strict_codec_match_defers_unrelated_swap)
+		{
+			switch_status_t status;
+			switch_media_handle_t *media_handle;
+			switch_core_media_params_t *mparams;
+			switch_codec_implementation_t impl = { 0 };
+			const char *local_sdp;
+			uint8_t match = 0, p = 0;
+
+			const char *offer_pcmu =
+				"v=0\r\n"
+				"o=- 4 1 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 0\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:0 PCMU/8000\r\n"
+				"a=sendrecv\r\n";
+
+			const char *offer_pcma =
+				"v=0\r\n"
+				"o=- 4 2 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 8\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:8 PCMA/8000\r\n"
+				"a=sendrecv\r\n";
+
+			switch_channel_set_variable(fst_channel, "telnyx-strict-codec-match", "true");
+			/* Keep both codecs offerable across the re-negotiation. */
+			switch_channel_set_variable(fst_channel, "absolute_codec_string", "PCMU,PCMA");
+
+			mparams = switch_core_session_alloc(fst_session, sizeof(switch_core_media_params_t));
+			mparams->inbound_codec_string = switch_core_session_strdup(fst_session, "PCMU,PCMA");
+			mparams->outbound_codec_string = switch_core_session_strdup(fst_session, "PCMU,PCMA");
+			mparams->rtpip = switch_core_session_strdup(fst_session, (char *)rx_host);
+
+			status = switch_media_handle_create(&media_handle, fst_session, mparams);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_media_prepare_codecs(fst_session, SWITCH_FALSE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			match = switch_core_media_negotiate_sdp(fst_session, offer_pcmu, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_requires(!strcasecmp(impl.iananame, "PCMU"));
+
+			match = switch_core_media_negotiate_sdp(fst_session, offer_pcma, &p, SDP_OFFER);
+			fst_xcheck(match == 1, "an unrelated codec swap still negotiates");
+
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "PCMA/8000") != NULL, "the answer follows the swap");
+
+			/*
+			 * Still the old codec here: the read loop has not run, which is what tells
+			 * the deferred reset apart from one forced on this thread.
+			 */
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_xcheck(!strcasecmp(impl.iananame, "PCMU"), "the codec reset is left to the read loop");
+		}
+		FST_SESSION_END()
 	}
 	FST_SUITE_END()
 }

--- a/tests/unit/switch_sdp.c
+++ b/tests/unit/switch_sdp.c
@@ -1015,6 +1015,70 @@ FST_CORE_BEGIN("./conf_sdp")
 			fst_xcheck(!strcasecmp(impl.iananame, "PCMU"), "the codec reset is left to the read loop");
 		}
 		FST_SESSION_END()
+
+		/*
+		 * A ptime change on one codec takes the inline reset as well, not only a flip
+		 * between two implementations of it. ptime is part of the payload map key, so a
+		 * re-offer that changes it allocates a fresh map, which is the same reason the
+		 * implementation flip cannot be left to the read loop.
+		 */
+		FST_SESSION_BEGIN(sdp_strict_codec_match_resets_on_ptime_change)
+		{
+			switch_status_t status;
+			switch_media_handle_t *media_handle;
+			switch_core_media_params_t *mparams;
+			switch_codec_implementation_t impl = { 0 };
+			uint8_t match = 0, p = 0;
+
+			const char *offer_20ms =
+				"v=0\r\n"
+				"o=- 5 1 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 0\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:0 PCMU/8000\r\n"
+				"a=ptime:20\r\n"
+				"a=sendrecv\r\n";
+
+			const char *offer_30ms =
+				"v=0\r\n"
+				"o=- 5 2 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 0\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:0 PCMU/8000\r\n"
+				"a=ptime:30\r\n"
+				"a=sendrecv\r\n";
+
+			switch_channel_set_variable(fst_channel, "telnyx-strict-codec-match", "true");
+			switch_channel_set_variable(fst_channel, "absolute_codec_string", "PCMU");
+
+			mparams = switch_core_session_alloc(fst_session, sizeof(switch_core_media_params_t));
+			mparams->inbound_codec_string = switch_core_session_strdup(fst_session, "PCMU");
+			mparams->outbound_codec_string = switch_core_session_strdup(fst_session, "PCMU");
+			mparams->rtpip = switch_core_session_strdup(fst_session, (char *)rx_host);
+
+			status = switch_media_handle_create(&media_handle, fst_session, mparams);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_media_prepare_codecs(fst_session, SWITCH_FALSE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			match = switch_core_media_negotiate_sdp(fst_session, offer_20ms, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_requires(impl.microseconds_per_packet == 20000);
+
+			match = switch_core_media_negotiate_sdp(fst_session, offer_30ms, &p, SDP_OFFER);
+			fst_requires(match == 1);
+
+			/* Reset already done here, unlike the unrelated swap above. */
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_xcheck(impl.microseconds_per_packet == 30000, "a ptime change on one codec resets inline");
+		}
+		FST_SESSION_END()
 	}
 	FST_SUITE_END()
 }

--- a/tests/unit/switch_sdp.c
+++ b/tests/unit/switch_sdp.c
@@ -869,6 +869,82 @@ FST_CORE_BEGIN("./conf_sdp")
 		FST_SESSION_END()
 
 		/*
+		 * Negative control: the same offers with telnyx-strict-codec-match left unset.
+		 * These assertions pin the behaviour of the unflagged path, defects included, so
+		 * that a change to it has to be deliberate rather than accidental.
+		 */
+		FST_SESSION_BEGIN(sdp_amrwb_legacy_codec_match)
+		{
+			switch_status_t status;
+			switch_media_handle_t *media_handle;
+			switch_core_media_params_t *mparams;
+			switch_codec_implementation_t impl = { 0 };
+			switch_payload_t initial_ianacode;
+			const char *local_sdp;
+			uint8_t match = 0, p = 0;
+
+			const char *offer_both =
+				"v=0\r\n"
+				"o=- 3 1 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 104 110\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:104 AMR-WB/16000\r\n"
+				"a=fmtp:104 mode-set=2\r\n"
+				"a=rtpmap:110 AMR-WB/16000\r\n"
+				"a=fmtp:110 octet-align=1; mode-set=2\r\n"
+				"a=sendrecv\r\n";
+
+			const char *offer_hold =
+				"v=0\r\n"
+				"o=- 3 2 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 104\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:104 AMR-WB/16000\r\n"
+				"a=fmtp:104 mode-set=2; mode-change-capability=2; max-red=0\r\n"
+				"a=sendonly\r\n";
+
+			mparams = switch_core_session_alloc(fst_session, sizeof(switch_core_media_params_t));
+			mparams->inbound_codec_string = switch_core_session_strdup(fst_session, "AMR-WB");
+			mparams->outbound_codec_string = switch_core_session_strdup(fst_session, "AMR-WB");
+			mparams->rtpip = switch_core_session_strdup(fst_session, (char *)rx_host);
+
+			status = switch_media_handle_create(&media_handle, fst_session, mparams);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_media_prepare_codecs(fst_session, SWITCH_FALSE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			match = switch_core_media_negotiate_sdp(fst_session, offer_both, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			initial_ianacode = impl.ianacode;
+
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:") != NULL, "legacy: initial answer carries an fmtp");
+
+			/* Legacy drops the fmtp when a re-offer rebuilds the payload map. */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_hold, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:104") == NULL, "legacy: hold answer loses the AMR-WB fmtp");
+
+			/* Legacy matches on iananame alone, so the last implementation offered wins. */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_both, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			fst_requires(switch_core_session_get_read_impl(fst_session, &impl) == SWITCH_STATUS_SUCCESS);
+			fst_xcheck(impl.ianacode != initial_ianacode, "legacy: re-offer of the same list flips the implementation");
+		}
+		FST_SESSION_END()
+
+		/*
 		 * A re-INVITE that swaps the codec outright is not the case this flag exists for.
 		 * Nothing in the answer depends on the codec having already been re-initialised,
 		 * so the reset stays deferred to the read loop rather than running on the

--- a/tests/unit/switch_sdp.c
+++ b/tests/unit/switch_sdp.c
@@ -795,6 +795,78 @@ FST_CORE_BEGIN("./conf_sdp")
 			fst_xcheck(impl.ianacode != initial_ianacode, "codec follows an offer carrying only the other implementation");
 		}
 		FST_SESSION_END()
+
+		/*
+		 * The hold case on its own: one re-offer of the implementation already in use,
+		 * carrying a different fmtp so that a fresh payload map is allocated. Kept
+		 * separate from the sequence above because a preceding implementation change
+		 * forces a codec reset, which repopulates the fmtp and hides the defect.
+		 */
+		FST_SESSION_BEGIN(sdp_amrwb_fmtp_kept_on_reoffer)
+		{
+			switch_status_t status;
+			switch_media_handle_t *media_handle;
+			switch_core_media_params_t *mparams;
+			const char *local_sdp;
+			uint8_t match = 0, p = 0;
+
+			const char *offer_both =
+				"v=0\r\n"
+				"o=- 2 1 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 104 110\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:104 AMR-WB/16000\r\n"
+				"a=fmtp:104 mode-set=2\r\n"
+				"a=rtpmap:110 AMR-WB/16000\r\n"
+				"a=fmtp:110 octet-align=1; mode-set=2\r\n"
+				"a=sendrecv\r\n";
+
+			/* Same payload type, three fmtp fields instead of one. */
+			const char *offer_hold =
+				"v=0\r\n"
+				"o=- 2 2 IN IP4 198.51.100.1\r\n"
+				"s=-\r\n"
+				"t=0 0\r\n"
+				"m=audio 56210 RTP/AVP 104\r\n"
+				"c=IN IP4 198.51.100.1\r\n"
+				"a=rtpmap:104 AMR-WB/16000\r\n"
+				"a=fmtp:104 mode-set=2; mode-change-capability=2; max-red=0\r\n"
+				"a=sendonly\r\n";
+
+			switch_channel_set_variable(fst_channel, "telnyx-strict-codec-match", "true");
+
+			mparams = switch_core_session_alloc(fst_session, sizeof(switch_core_media_params_t));
+			mparams->inbound_codec_string = switch_core_session_strdup(fst_session, "AMR-WB");
+			mparams->outbound_codec_string = switch_core_session_strdup(fst_session, "AMR-WB");
+			mparams->rtpip = switch_core_session_strdup(fst_session, (char *)rx_host);
+
+			status = switch_media_handle_create(&media_handle, fst_session, mparams);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_media_prepare_codecs(fst_session, SWITCH_FALSE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			match = switch_core_media_negotiate_sdp(fst_session, offer_both, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:104") != NULL, "initial answer carries the AMR-WB fmtp");
+
+			/*
+			 * No implementation change, so nothing resets the codec and nothing else
+			 * repopulates fmtp_out on the payload map this re-offer allocates.
+			 */
+			match = switch_core_media_negotiate_sdp(fst_session, offer_hold, &p, SDP_OFFER);
+			fst_requires(match == 1);
+			switch_core_media_gen_local_sdp(fst_session, SDP_ANSWER, rx_host, 12345, NULL, 1);
+			local_sdp = switch_channel_get_variable(fst_channel, "rtp_local_sdp_str");
+			fst_requires(local_sdp);
+			fst_xcheck(strstr(local_sdp, "a=fmtp:104") != NULL, "hold answer still carries the AMR-WB fmtp");
+		}
+		FST_SESSION_END()
 	}
 	FST_SUITE_END()
 }


### PR DESCRIPTION
## Problem

A PSTN caller on AT&T VoLTE presses hold on an inbound call to a Call Control DID. The inbound leg is AMR-WB, transcoded to OPUS toward the customer SBC. Hold is accepted, then reverted by the originating IMS core 719 ms later (`hold_accum_ms = 719`). Android shows "Can't hold call"; iPhone/VoLTE tears the call down. AT&T eventually BYEs.

Two distinct defects, both verified in the customer pcap:

| CSeq | Caller offers | We answered |
|---|---|---|
| 1 initial | PT 104 (octet-align=0) + PT 110 (octet-align=1) | PT 104, `mode-set=2;octet-align=0;max-red=0;mode-change-capability=2` |
| 3 hold | PT 104 only | PT 104, **no `a=fmtp:104` at all** |
| 4 resume | PT 104 + PT 110 | **PT 110**, `octet-align=1` |
| 5 | PT 104 only | PT 104, **no `a=fmtp:104`**, while the codec stayed octet aligned internally |

The carrier ACKs the hold answer at t=26.158 and re-INVITEs 9 ms later, so the fmtp omission is the trigger; the payload type flip is the failed recovery.

## Root cause

`mod_amrwb` registers **two** implementations under a single iananame (`mod_amrwb.c:926-951`): octet aligned (ianacode 100) and bandwidth efficient (ianacode 110). They differ only in `ianacode` and `fmtp` — rate, ptime and channels are identical. AMR, G7221, SILK and iLBC register the same way.

**1. Payload type flip.** The "prioritize previously negotiated codec" loop compared `iananame` only, with no break, so every implementation sharing the name matched and the last one won. On the initial INVITE `read_impl.iananame` is unset, so the first match survived — which is why CSeq 1 and CSeq 4 answer differently to the same offer.

**2. Codec kept when it should change.** The loop deciding whether to reset asked whether *any* match was name/rate/ptime compatible, not whether the implementation actually selected was. A re-INVITE offering only the other implementation kept the running codec while the answer advertised the offered one.

**3. Dropped fmtp.** The `a=fmtp` line comes from `cur_payload_map->fmtp_out`, and `switch_core_media_set_codec()` is the only thing that populates it. A re-offer whose fmtp differs from the stored one fails `fmtp_check_match()` (field-count comparison, `:928`) and allocates a fresh payload map, so when the codec is kept and `set_codec()` is not called, the answer goes out with no fmtp at all.

An offer that omits `a=ptime` also matches *every* implementation a codec registers, because the ptime filter at `:7903` is guarded on `ptime` being present — so this is not limited to AMR-WB.

## Changes

All behaviour is gated behind the `telnyx-strict-codec-match` channel variable, **off by default**, modelled on the existing `telnyx-strict-ptime` in the same function. With it unset, every condition short-circuits and the original code paths run unchanged.

- **`same_codec_impl()`** — one definition of "same implementation" (ianacode, iananame, ptime, rate), used by both decision sites so they cannot drift.
- **Prioritize loop** — requires a full implementation match and latches the first exact one, so a later same-name match cannot overwrite it. Also skips re-asserting this leg's codec while the partner leg drives the renegotiation (`CF_AWAITING_STREAM_CHANGE`), so the partner's answer decides.
- **Reset decision** — compares the implementation actually selected. When it changed, resets **inline** rather than deferring: the answer SDP is generated before the deferred reset runs on the media thread (`:3891`), so deferring would drop the fmtp from the answer.
- **fmtp carry-over** — when the codec is kept but the payload map was rebuilt, copies the fmtp of the codec in use onto the new map, guarded on the implementation so a map cannot inherit another's fmtp.
- **`strict-codec-match` sofia profile parameter** — profiles cannot carry channel variables, so this stamps the variable on the channel: on inbound in `sofia_handle_sip_i_invite()`, on outbound in `sofia_outgoing_channel()`. Both run before the point at which a channel variable for that leg is set, so the dialplan still overrides the profile. Stored as a string rather than a profile flag so an absent parameter stays distinguishable from an explicit `false` and lets the global variable decide.

Scoping, lowest precedence to highest: global variable → sofia profile parameter → channel variable from the dialplan or Call Control. The whole fix acts only on re-INVITEs, which arrive long after the dialplan has run, so a per-call variable is effective.

## Verification

**Unit** — `tests/unit/switch_sdp.c`, five sessions driving `switch_core_media_negotiate_sdp()` and asserting on the generated answer. Suite is **PASSED 8/8**.

| Session | Flag | Asserts |
|---|---|---|
| `sdp_amrwb_strict_codec_match` | on | implementation is stable across re-INVITEs, and follows an offer carrying only the other one |
| `sdp_amrwb_fmtp_kept_on_reoffer` | on | the hold re-offer keeps `a=fmtp:104` |
| `sdp_amrwb_legacy_codec_match` | **off** | the unflagged path still drops the fmtp and still flips implementation |
| `sdp_strict_codec_match_defers_unrelated_swap` | on | a PCMU→PCMA re-offer leaves the reset to the read loop |
| `sdp_strict_codec_match_resets_on_ptime_change` | on | PCMU 20ms→30ms resets inline |

With the flag off the log reproduces the defect verbatim: `Sticking with previously negotiated codec AMR-WB but different pt 104 --> 110`. Each code change has an assertion that fails without it. `sdp_amrwb_fmtp_kept_on_reoffer` exists separately because the first session changes implementation before reaching the re-offer, and that change forces a reset which repopulates the fmtp and hides the defect. `sdp_amrwb_legacy_codec_match` deliberately asserts the *defects* on the unflagged path, so a future change to it has to update that session rather than pass silently.

**SIPp** — new `uac-amrwb-hold-resume.xml` plus four re-INVITE variants against a local FS built from this branch.

| Re-INVITE offers | Flag on | Baseline |
|---|---|---|
| same full list | PT 104 `octet-align=0` | PT 110 `octet-align=1` |
| AMR-WB BE only, different fmtp | PT 104 **+ fmtp** | PT 104, **no fmtp** |
| AMR-WB OA only | PT 110 + fmtp | PT 110 + fmtp |
| PCMU/PCMA/G722 only | PT 0 | PT 0 |

Behaviour changes in exactly the two broken cases; the other two are byte-identical. The baseline column reproduces the customer pcap.

**Build** — clean rebuild in `freeswitch-docker-base:1.14.3`, exit 0, zero warnings referencing any changed file.

## Reviewer notes

- **This needs a clean build.** `struct sofia_profile` gained a field, and this tree disables dependency tracking, so an incremental rebuild mixing old and new objects corrupts silently rather than failing.
- **Inline reset and locking.** `switch_core_media_set_codec()` takes the session codec read/write locks and `codec_init_mutex`, with a single exit releasing all three. Calling it from the partner's thread during a partner-driven pass is a pre-existing ordering — the `changed_pt` branch already does exactly this — but this change exercises it more often. The deferred alternative is what drops the fmtp, so correctness rules it out.
- **First-match-wins.** Where a remote offers the same implementation at two payload types, the latch now selects the first rather than falling through to the last. Both were arbitrary; this is a deliberate change under the flag.
- **Blast radius.** Codec *selection* changes only for AMR, AMR-WB, G7221, SILK and iLBC — the implementation comparison is a no-op for every codec registering one ianacode per name. The *inline reset* is broader: it fires whenever a re-INVITE keeps the codec name but changes its implementation, ptime or rate, which includes a plain ptime renegotiation on a single-implementation codec such as PCMU. All three are part of the payload map key, so all three rebuild the map and need the reset to have run before the answer is generated. A re-INVITE that swaps the codec outright keeps the deferred reset.

## Rollback

Unset `telnyx-strict-codec-match` (or set it `false`, or drop the profile parameter). Behaviour returns to current, byte for byte, without redeploying anything else.

## Known gaps, filed separately

- **TELCORE-368** — with `rtp_pass_codecs_on_stream_change`, a B-leg renegotiation that never produces an SDP answer (488, timeout, partner teardown) leaves `CF_AWAITING_STREAM_CHANGE` set, and `sofia.c:9397` then suppresses the A-leg 200 OK forever. Pre-existing.
- **TELCORE-371** — the B-leg answer decides the codec but not which implementation, so it cannot steer the AMR-WB octet-align variant. `inherit_codec=true` builds the caller string without fmtp; `passthru` carries fmtp but still names both implementations. Measured, pre-existing, unaffected by this change.

Neither is caused or fixed here, and neither affects the customer defect.

