### PR TITLE
TELCORE-355: report recorder open timeouts on record_session_error

### DIFF
--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -2329,7 +2329,10 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		if (ret < 0) {
 			char ebuf[255] = "";
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
-			switch_goto_status(SWITCH_STATUS_GENERR, end);
+			/* Report rw_timeout expiry distinctly: switch_core_file_open()
+			 * returns this status unchanged, so callers can tell a
+			 * recorder-server timeout from any other open failure. */
+			switch_goto_status(ret == AVERROR(ETIMEDOUT) ? SWITCH_STATUS_TIMEOUT : SWITCH_STATUS_GENERR, end);
 		}
 	} else {
 		avformat_network_init();

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1393,13 +1393,17 @@ static void send_record_stop_event(switch_channel_t *channel, switch_codec_imple
 	rh->start_event_sent = 0;
 }
 
-static void send_record_error_event(switch_channel_t *channel, const char* file, const char* error)
+static void send_record_error_event(switch_channel_t *channel, const char* file, const char* error, switch_status_t open_status)
 {
 	switch_event_t *event;
 	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, "record_session_error") == SWITCH_STATUS_SUCCESS) {
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-File-Path", file);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-Error", error);
+		/* Report whether the open failed on an I/O timeout (a recorder-server
+		 * timeout for rtmp:// targets) so consumers can alert on it. */
+		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Record-Open-Timeout",
+									   open_status == SWITCH_STATUS_TIMEOUT ? "true" : "false");
 		switch_event_fire(&event);
 	}
 }
@@ -3407,6 +3411,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	const char *file_open_path = file;
 	switch_event_t *file_params = NULL;
 	int have_recording_file_param_override = 0;
+	/* File-module status of the failing open, so record_session_error can
+	 * report a recorder-server timeout distinctly. */
+	switch_status_t open_status = SWITCH_STATUS_SUCCESS;
 
 	if ((p = get_recording_var(channel, vars, "RECORD_HANGUP_ON_ERROR"))) {
 		hangup_on_error = switch_true(p);
@@ -3731,13 +3738,13 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 			file_flags |= SWITCH_FILE_FLAG_VIDEO;
 		}
 
-		if (switch_core_file_open(fh, file_open_path, channels, read_impl.actual_samples_per_second, file_flags, NULL) != SWITCH_STATUS_SUCCESS) {
+		if ((open_status = switch_core_file_open(fh, file_open_path, channels, read_impl.actual_samples_per_second, file_flags, NULL)) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error opening %s\n", file_open_path);
 			if (hangup_on_error) {
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			send_record_error_event(channel, file_open_path, "Error opening file");
+			send_record_error_event(channel, file_open_path, "Error opening file", open_status);
 			set_completion_cause(rh, "uri-failure");
 			switch_goto_status(SWITCH_STATUS_GENERR, err);
 		}
@@ -3785,25 +3792,25 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		switch_set_flag(&rh->in_fh, SWITCH_FILE_NATIVE);
 		switch_set_flag(&rh->out_fh, SWITCH_FILE_NATIVE);
 
-		if (switch_core_file_open(&rh->in_fh, in_file, channels, read_impl.actual_samples_per_second, file_flags, NULL) != SWITCH_STATUS_SUCCESS) {
+		if ((open_status = switch_core_file_open(&rh->in_fh, in_file, channels, read_impl.actual_samples_per_second, file_flags, NULL)) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error opening %s\n", in_file);
 			if (hangup_on_error) {
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			send_record_error_event(channel, in_file, "Error opening file");
+			send_record_error_event(channel, in_file, "Error opening file", open_status);
 			set_completion_cause(rh, "uri-failure");
 			switch_goto_status(SWITCH_STATUS_GENERR, err);
 		}
 
-		if (switch_core_file_open(&rh->out_fh, out_file, channels, read_impl.actual_samples_per_second, file_flags, NULL) != SWITCH_STATUS_SUCCESS) {
+		if ((open_status = switch_core_file_open(&rh->out_fh, out_file, channels, read_impl.actual_samples_per_second, file_flags, NULL)) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error opening %s\n", out_file);
 			switch_core_file_close(&rh->in_fh);
 			if (hangup_on_error) {
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			send_record_error_event(channel, out_file, "Error opening file");
+			send_record_error_event(channel, out_file, "Error opening file", open_status);
 			set_completion_cause(rh, "uri-failure");
 			switch_goto_status(SWITCH_STATUS_GENERR, err);
 		}


### PR DESCRIPTION
## Problem

`switch_core_file_open()` collapsed every open failure into `SWITCH_STATUS_GENERR`. When the recorder server timed out during INC-217 the only place the concrete cause appeared was the log line:

```
avformat.c:2331 Could not open 'rtmp://recorder.query.prod.telnyx.io:1935/mp3/...': Connection timed out
switch_ivr_async.c:3735 Error opening {...rw_timeout=15000000...}rtmp://recorder...
```

The `record_session_error` event that follows carries only `Record-File-Path` and a fixed `Record-Error: Error opening file`, so a recorder-server timeout is indistinguishable from a bad URL, a refused connection or a full disk. All B2BUA alerting in `tel-core-alerts` is Prometheus-expression based and cannot read logs, so the distinction has to reach the event to be alertable.

## Change

Two files, +18/-8.

- `mod_av`: `av_file_open()` returns `SWITCH_STATUS_TIMEOUT` instead of `SWITCH_STATUS_GENERR` when `avio_open2()` fails with `AVERROR(ETIMEDOUT)` — i.e. `rw_timeout` expiry.
- `switch_ivr_async`: capture the open status at the three record-open failure sites (single file, split in, split out) and add `Record-Open-Timeout: true|false` to `record_session_error`.

## Why the status and not a handle field or `handle->event`

The status is the only channel that already survives a failed open. `switch_core_perform_file_open()`'s `fail:` path destroys `fh->params` **and** the handle memory pool (`switch_core_file.c`), so nothing allocated there lives past the return; and it propagates the file module's `status` unchanged, so a distinct status arrives at the caller for free.

`fh->event` does survive, but it is caller-owned playback metadata merged into `PLAYBACK_START`/`PLAYBACK_STOP` (`switch_ivr_play_say.c:1685`, `:2087`) and read by `mod_http_cache`, so a format module writing into it means either polluting caller data or handing ownership out of a failed open. A new field on `switch_file_handle_t` would work but changes the layout of a struct that callers all over the tree stack-allocate — an avoidable rebuild hazard for a boolean that the return value can already carry.

## Blast radius

- `send_record_error_event()` is `static` with exactly three call sites, all updated.
- All 92 `switch_core_file_open()` call sites in the tree were checked: every one branches on `SWITCH_STATUS_SUCCESS` (`==` or `!=`) or propagates the status to a caller that does, so a second failure status is inert for them. The one test that asserts a specific failure status, `avformat_test_read_err` (`test_avformat.c:208`, expects `GENERR`), is on the **read** path — this change is in the output-file branch of `av_file_open()` and cannot reach it.
- Every success path is unchanged; the event gains one header.

## Verification

- Built with the paired mod_telnyx change: `USE_REGISTRY_IMAGE=1 make build-deb-package-on-docker` in `telnyx_b2bua_builder` (`telnyx_b2bua-1.10.12-telv111.1.deb`).
- Runtime check (canary): point a recording at an unroutable recorder and confirm the header, then the counter it feeds:

```
fs_cli -x "uuid_record <uuid> start {rw_timeout=5000000,modname=mod_av}rtmp://10.255.255.1:1935/mp3/x"
# record_session_error now carries Record-Open-Timeout: true
curl -s localhost:7080/metrics | grep freeswitch_record_failure_total
```

An unreachable-but-routable target (connection refused) should report `Record-Open-Timeout: false`, which is the other half of the check.

## Paired PR

Consumer: https://github.com/team-telnyx/mod_telnyx/pull/72 — counts the classified failures into `freeswitch_record_failure_total`. That PR is independently deployable; without this one every open failure lands under `reason="open-unknown"`.

Linear: https://linear.app/telnyx/issue/TELCORE-355/add-b2bua-alerting-for-recorder-server-timeouts
