### PR TITLE
TELCORE-373: add a B2BUA event confirming outbound DTMF was sent

### DIFF
--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -631,6 +631,24 @@ SWITCH_DECLARE(void) switch_channel_flush_dtmf(_In_ switch_channel_t *channel);
 SWITCH_DECLARE(switch_size_t) switch_channel_dequeue_dtmf_string(_In_ switch_channel_t *channel, _Out_opt_bytecapcount_(len)
 																 char *dtmf_str, _In_ switch_size_t len);
 
+/*! Subclass of the CUSTOM event fired once an outbound digit has been transmitted. */
+#define SWITCH_EVENT_SUBCLASS_DTMF_SENT "telnyx::dtmf_sent"
+
+/*!
+  \brief Fire the confirmation event for a digit we finished sending
+  \param channel channel the digit was sent on
+  \param dtmf the digit being sent; its duration is the one we set out to send, which
+              may already have been clamped to the min/max dtmf duration
+  \param sent_duration duration actually transmitted, in samples
+  \param samples_per_second rate both durations are expressed in, 0 if unknown
+  \param method transport the digit was sent with ("RFC2833", "INFO")
+  \note Unlike SWITCH_EVENT_DTMF, which is a receive-side event, this is fired
+        only after the digit has left the switch.
+*/
+SWITCH_DECLARE(void) switch_channel_fire_dtmf_sent_event(_In_ switch_channel_t *channel, _In_ const switch_dtmf_t *dtmf,
+														 _In_ uint32_t sent_duration, _In_ uint32_t samples_per_second,
+														 _In_z_ const char *method);
+
 /*!
   \brief Render the name of the provided state enum
   \param state state to get name of

--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -646,6 +646,14 @@ SWITCH_DECLARE(switch_size_t) switch_channel_dequeue_dtmf_string(_In_ switch_cha
   \param method transport the digit was sent with ("RFC2833")
   \note Unlike SWITCH_EVENT_DTMF, which is a receive-side event, this is fired
         only after the digit has left the switch.
+  \note sent_duration is not a truncation check. A transport emits whole packet
+        intervals and only reports once it has covered the requested duration, so
+        compared like for like it lands on or past dtmf->duration and measures
+        overshoot from scheduling gaps. A digit abandoned before it finished -- the
+        genuinely truncated case -- fires nothing, so a consumer needs a timeout
+        rather than a short duration to detect it. The two figures can still
+        disagree downwards across clock domains, which is what the millisecond
+        headers exist to expose.
 */
 SWITCH_DECLARE(void) switch_channel_fire_dtmf_sent_event(_In_ switch_channel_t *channel, _In_ const switch_dtmf_t *dtmf,
 														 _In_ uint32_t sent_duration, _In_ uint32_t samples_per_second,

--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -639,8 +639,10 @@ SWITCH_DECLARE(switch_size_t) switch_channel_dequeue_dtmf_string(_In_ switch_cha
   \param channel channel the digit was sent on
   \param dtmf the digit being sent; its duration is the one we set out to send, which
               may already have been clamped to the min/max dtmf duration
-  \param sent_duration duration actually transmitted, in samples
-  \param samples_per_second rate both durations are expressed in, 0 if unknown
+  \param sent_duration duration actually transmitted, in samples_per_second samples
+                       (not in dtmf->duration's 8kHz domain -- the two only coincide
+                       on an 8kHz session)
+  \param samples_per_second rate sent_duration is expressed in, 0 if unknown
   \param method transport the digit was sent with ("RFC2833")
   \note Unlike SWITCH_EVENT_DTMF, which is a receive-side event, this is fired
         only after the digit has left the switch.

--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -645,7 +645,8 @@ SWITCH_DECLARE(switch_size_t) switch_channel_dequeue_dtmf_string(_In_ switch_cha
   \param samples_per_second rate sent_duration is expressed in, 0 if unknown
   \param method transport the digit was sent with ("RFC2833")
   \note Unlike SWITCH_EVENT_DTMF, which is a receive-side event, this is fired
-        only after the digit has left the switch.
+        only after the digit has left the switch. It also always goes to the event
+        bus, where SWITCH_EVENT_DTMF honours CF_DIVERT_EVENTS.
   \note sent_duration is not a truncation check. A transport emits whole packet
         intervals and only reports once it has covered the requested duration, so
         compared like for like it lands on or past dtmf->duration and measures

--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -641,7 +641,7 @@ SWITCH_DECLARE(switch_size_t) switch_channel_dequeue_dtmf_string(_In_ switch_cha
               may already have been clamped to the min/max dtmf duration
   \param sent_duration duration actually transmitted, in samples
   \param samples_per_second rate both durations are expressed in, 0 if unknown
-  \param method transport the digit was sent with ("RFC2833", "INFO")
+  \param method transport the digit was sent with ("RFC2833")
   \note Unlike SWITCH_EVENT_DTMF, which is a receive-side event, this is fired
         only after the digit has left the switch.
 */

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1620,6 +1620,12 @@ static switch_status_t sofia_send_dtmf(switch_core_session_t *session, const swi
 				switch_mutex_lock(tech_pvt->sofia_mutex);
 				nua_info(tech_pvt->nh, SIPTAG_CONTENT_TYPE_STR("application/dtmf-relay"), SIPTAG_PAYLOAD_STR(message), TAG_END());
 				switch_mutex_unlock(tech_pvt->sofia_mutex);
+
+				/* Confirm the digit we just signalled. Unlike the RFC 2833 path -- where the
+				   event is fired once the end packets are on the wire -- this fires when the
+				   INFO has been handed to the SIP stack, with the duration we advertised in
+				   the body (the INFO body is expressed at 8kHz). */
+				switch_channel_fire_dtmf_sent_event(channel, dtmf, dtmf->duration, 8000, "INFO");
 			}
 		}
 		break;

--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1621,11 +1621,11 @@ static switch_status_t sofia_send_dtmf(switch_core_session_t *session, const swi
 				nua_info(tech_pvt->nh, SIPTAG_CONTENT_TYPE_STR("application/dtmf-relay"), SIPTAG_PAYLOAD_STR(message), TAG_END());
 				switch_mutex_unlock(tech_pvt->sofia_mutex);
 
-				/* Confirm the digit we just signalled. Unlike the RFC 2833 path -- where the
-				   event is fired once the end packets are on the wire -- this fires when the
-				   INFO has been handed to the SIP stack, with the duration we advertised in
-				   the body (the INFO body is expressed at 8kHz). */
-				switch_channel_fire_dtmf_sent_event(channel, dtmf, dtmf->duration, 8000, "INFO");
+				/* No telnyx::dtmf_sent confirmation here: nua_info() only queues the request
+				   into the SIP stack and returns, so firing now would report the same "handed
+				   off" state the +OK from uuid_send_dtmf already gives. The response arrives
+				   asynchronously as nua_r_info, which is not attributable to a single digit
+				   (every INFO on the handle lands there), so INFO stays unconfirmed for now. */
 			}
 		}
 		break;

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -689,6 +689,19 @@ SWITCH_DECLARE(switch_status_t) switch_channel_queue_dtmf_string(switch_channel_
 /* The rate switch_dtmf_t.duration is expressed in, everywhere in the core. */
 #define DTMF_DURATION_CLOCK_RATE 8000
 
+/* Divide once, at the end: samples / (rate / 1000) truncates the rate first, which is
+   exact only when the rate is a whole number of kHz. At 11025Hz it overstates a 440ms
+   digit as 441ms. The 64-bit intermediate keeps a maximum-length digit at 48kHz
+   (SWITCH_MAX_DTMF_DURATION rescaled, ~1.15M samples) clear of a 32-bit overflow. */
+static uint32_t dtmf_samples_to_ms(uint32_t samples, uint32_t samples_per_second)
+{
+	if (samples_per_second < 1000) {
+		return 0;
+	}
+
+	return (uint32_t) (((uint64_t) samples * 1000) / samples_per_second);
+}
+
 static const char *dtmf_source_str(switch_dtmf_source_t source)
 {
 	switch(source) {
@@ -786,12 +799,12 @@ SWITCH_DECLARE(void) switch_channel_fire_dtmf_sent_event(switch_channel_t *chann
 	   is in samples_per_second, the transmitting session's own rate. Publish each with
 	   its own rate and a millisecond form so a consumer has one comparable number. */
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration", "%u", dtmf->duration);
-	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-MS", "%u", dtmf->duration / (DTMF_DURATION_CLOCK_RATE / 1000));
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-MS", "%u", dtmf_samples_to_ms(dtmf->duration, DTMF_DURATION_CLOCK_RATE));
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Clock-Rate", "%u", (uint32_t) DTMF_DURATION_CLOCK_RATE);
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent", "%u", sent_duration);
 
 	if (samples_per_second >= 1000) {
-		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent-MS", "%u", sent_duration / (samples_per_second / 1000));
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent-MS", "%u", dtmf_samples_to_ms(sent_duration, samples_per_second));
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent-Clock-Rate", "%u", samples_per_second);
 	}
 

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -811,6 +811,13 @@ SWITCH_DECLARE(void) switch_channel_fire_dtmf_sent_event(switch_channel_t *chann
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Source", "%s", dtmf_source_str(dtmf->source));
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "DTMF-Method", method);
 
+	/* Deliberately always on the bus, unlike the receive-side event in
+	   switch_channel_dequeue_dtmf(), which honours CF_DIVERT_EVENTS. That flag is set
+	   by an ESL client asking for a session's events to be routed to its own queue
+	   instead (mod_event_socket "divert_events"). The consumer of this event is the
+	   mod_telnyx ZMQ publisher, a plain bus subscriber, so diverting would silently
+	   drop the B2BUA's confirmation for the duration of an unrelated ESL session --
+	   and a confirmation that can vanish is worth no more than no confirmation. */
 	switch_event_fire(&event);
 }
 

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -686,6 +686,9 @@ SWITCH_DECLARE(switch_status_t) switch_channel_queue_dtmf_string(switch_channel_
 	return bad_input ? SWITCH_STATUS_GENERR : SWITCH_STATUS_FALSE;
 }
 
+/* The rate switch_dtmf_t.duration is expressed in, everywhere in the core. */
+#define DTMF_DURATION_CLOCK_RATE 8000
+
 static const char *dtmf_source_str(switch_dtmf_source_t source)
 {
 	switch(source) {
@@ -775,12 +778,21 @@ SWITCH_DECLARE(void) switch_channel_fire_dtmf_sent_event(switch_channel_t *chann
 
 	switch_channel_event_set_data(channel, event);
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Digit", "%c", dtmf->digit);
+
+	/* The two durations are not in the same clock domain and must not be compared as
+	   sample counts. switch_dtmf_t.duration is always in FreeSWITCH's 8kHz convention
+	   (SWITCH_DEFAULT_DTMF_DURATION and the min/max clamps are 8kHz sample counts,
+	   which is why mod_sofia divides it by 8 for the INFO body), while sent_duration
+	   is in samples_per_second, the transmitting session's own rate. Publish each with
+	   its own rate and a millisecond form so a consumer has one comparable number. */
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration", "%u", dtmf->duration);
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-MS", "%u", dtmf->duration / (DTMF_DURATION_CLOCK_RATE / 1000));
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Clock-Rate", "%u", (uint32_t) DTMF_DURATION_CLOCK_RATE);
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent", "%u", sent_duration);
 
 	if (samples_per_second >= 1000) {
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent-MS", "%u", sent_duration / (samples_per_second / 1000));
-		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Clock-Rate", "%u", samples_per_second);
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent-Clock-Rate", "%u", samples_per_second);
 	}
 
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Source", "%s", dtmf_source_str(dtmf->source));

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -686,6 +686,23 @@ SWITCH_DECLARE(switch_status_t) switch_channel_queue_dtmf_string(switch_channel_
 	return bad_input ? SWITCH_STATUS_GENERR : SWITCH_STATUS_FALSE;
 }
 
+static const char *dtmf_source_str(switch_dtmf_source_t source)
+{
+	switch(source) {
+	case SWITCH_DTMF_INBAND_AUDIO:	/* From audio */
+		return "INBAND_AUDIO";
+	case SWITCH_DTMF_RTP:			/* From RTP as a telephone event */
+		return "RTP";
+	case SWITCH_DTMF_ENDPOINT:		/* From endpoint signaling */
+		return "ENDPOINT";
+	case SWITCH_DTMF_APP:			/* Injected by application */
+		return "APP";
+	case SWITCH_DTMF_UNKNOWN:		/* Unknown source */
+	default:
+		return "UNKNOWN";
+	}
+}
+
 SWITCH_DECLARE(switch_status_t) switch_channel_dequeue_dtmf(switch_channel_t *channel, switch_dtmf_t *dtmf)
 {
 	switch_event_t *event;
@@ -725,29 +742,10 @@ SWITCH_DECLARE(switch_status_t) switch_channel_dequeue_dtmf(switch_channel_t *ch
 	switch_mutex_unlock(channel->dtmf_mutex);
 
 	if (!event_sensitive && status == SWITCH_STATUS_SUCCESS && switch_event_create(&event, SWITCH_EVENT_DTMF) == SWITCH_STATUS_SUCCESS) {
-		const char *dtmf_source_str = NULL;
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Digit", "%c", dtmf->digit);
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration", "%u", dtmf->duration);
-		switch(dtmf->source) {
-			case SWITCH_DTMF_INBAND_AUDIO:	/* From audio */
-				dtmf_source_str = "INBAND_AUDIO";
-				break;
-			case SWITCH_DTMF_RTP:			/* From RTP as a telephone event */
-				dtmf_source_str = "RTP";
-				break;
-			case SWITCH_DTMF_ENDPOINT:		/* From endpoint signaling */
-				dtmf_source_str = "ENDPOINT";
-				break;
-			case SWITCH_DTMF_APP:			/* Injected by application */
-				dtmf_source_str = "APP";
-				break;
-			case SWITCH_DTMF_UNKNOWN:		/* Unknown source */
-			default:
-				dtmf_source_str = "UNKNOWN";
-				break;
-		}
-		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Source", "%s", dtmf_source_str);
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Source", "%s", dtmf_source_str(dtmf->source));
 		if (switch_channel_test_flag(channel, CF_DIVERT_EVENTS)) {
 			switch_core_session_queue_event(channel->session, &event);
 		} else {
@@ -756,6 +754,39 @@ SWITCH_DECLARE(switch_status_t) switch_channel_dequeue_dtmf(switch_channel_t *ch
 	}
 
 	return status;
+}
+
+SWITCH_DECLARE(void) switch_channel_fire_dtmf_sent_event(switch_channel_t *channel, const switch_dtmf_t *dtmf,
+														 uint32_t sent_duration, uint32_t samples_per_second, const char *method)
+{
+	switch_event_t *event;
+
+	if (!channel || !dtmf) {
+		return;
+	}
+
+	if (switch_test_flag(dtmf, DTMF_FLAG_SENSITIVE) || switch_test_flag(dtmf, DTMF_FLAG_EVENT_SENSITIVE)) {
+		return;
+	}
+
+	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, SWITCH_EVENT_SUBCLASS_DTMF_SENT) != SWITCH_STATUS_SUCCESS) {
+		return;
+	}
+
+	switch_channel_event_set_data(channel, event);
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Digit", "%c", dtmf->digit);
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration", "%u", dtmf->duration);
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent", "%u", sent_duration);
+
+	if (samples_per_second >= 1000) {
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Duration-Sent-MS", "%u", sent_duration / (samples_per_second / 1000));
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Clock-Rate", "%u", samples_per_second);
+	}
+
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Source", "%s", dtmf_source_str(dtmf->source));
+	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "DTMF-Method", method);
+
+	switch_event_fire(&event);
 }
 
 SWITCH_DECLARE(switch_size_t) switch_channel_dequeue_dtmf_string(switch_channel_t *channel, char *dtmf_str, switch_size_t len)

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -271,6 +271,8 @@ struct switch_rtp_rfc2833_data {
 	unsigned int out_digit_sofar;
 	unsigned int out_digit_sub_sofar;
 	unsigned int out_digit_dur;
+	int32_t out_digit_flags;			/* Kept from the queued digit so the sent event can honour the sensitive flags. */
+	switch_dtmf_source_t out_digit_source;	/* Kept from the queued digit so the sent event can report where it came from. */
 	switch_time_t out_digit_last_progress_us; /* Prevents sub-ptime do_2833() wakeups. */
 	uint16_t in_digit_seq;
 	uint32_t in_digit_ts;
@@ -8531,6 +8533,17 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 				rtp_session->last_write_samplecount = rtp_session->write_timer.samplecount;
 			}
 
+			/* The end packets are on the wire: this digit is done, confirm what we sent. */
+			if (rtp_session->session) {
+				switch_dtmf_t sent_dtmf = { rtp_session->dtmf_data.out_digit,
+											rtp_session->dtmf_data.out_digit_dur,
+											rtp_session->dtmf_data.out_digit_flags,
+											rtp_session->dtmf_data.out_digit_source };
+
+				switch_channel_fire_dtmf_sent_event(switch_core_session_get_channel(rtp_session->session), &sent_dtmf,
+													rtp_session->dtmf_data.out_digit_sofar, rtp_session->samples_per_second, "RFC2833");
+			}
+
 			rtp_session->dtmf_data.out_digit_dur = 0;
 
 			if (rtp_session->interdigit_delay) {
@@ -8604,6 +8617,8 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 			rtp_session->dtmf_data.out_digit_sub_sofar = samples;
 			rtp_session->dtmf_data.out_digit_dur = rdigit->duration;
 			rtp_session->dtmf_data.out_digit = rdigit->digit;
+			rtp_session->dtmf_data.out_digit_flags = rdigit->flags;
+			rtp_session->dtmf_data.out_digit_source = rdigit->source;
 			rtp_session->dtmf_data.out_digit_last_progress_us = switch_micro_time_now(); /* seed gate */
 			rtp_session->dtmf_data.out_digit_packet[0] = (unsigned char) switch_char_to_rfc2833(rdigit->digit);
 			rtp_session->dtmf_data.out_digit_packet[1] = 13;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -8441,7 +8441,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 	//switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG1, "do_2833 %s / %p\n", rtp_session->session ? switch_channel_get_name(switch_core_session_get_channel(rtp_session->session)) : "NoName", (void*) rtp_session);
 
 	if (rtp_session->dtmf_data.out_digit_dur > 0) {
-		int x, loops = 1;
+		int x, loops = 1, end_packets_sent = 0;
 		switch_time_t now_us = switch_micro_time_now();
 
 		/* Ignore sub-ptime wakeups so tight read loops cannot collapse the digit. */
@@ -8488,7 +8488,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 
 		for (x = 0; x < loops; x++) {
 
-			switch_size_t wrote = 0;
+			int wrote = 0;
 
 			if (rtp_session->rtp_bugs & RTP_BUG_SEND_NORMALISED_TIMESTAMPS) {
 				wrote = switch_rtp_write_manual(rtp_session,
@@ -8498,8 +8498,18 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 				wrote = switch_rtp_write_manual(rtp_session, rtp_session->dtmf_data.out_digit_packet, 4, 0, rtp_session->te, rtp_session->dtmf_data.timestamp_dtmf, &flags);
 			}
 
-			rtp_session->stats.outbound.raw_bytes += wrote;
-			rtp_session->stats.outbound.dtmf_packet_count++;
+			/* switch_rtp_write_manual() returns -1 when RTP is not writable or the socket
+			   /SRTP send failed, and 0 when the packet was dropped before it reached the
+			   socket. Only count what left the switch: the previous unsigned assignment
+			   turned -1 into SIZE_MAX and added it to raw_bytes. */
+			if (wrote > 0) {
+				rtp_session->stats.outbound.raw_bytes += wrote;
+				rtp_session->stats.outbound.dtmf_packet_count++;
+
+				if (loops != 1) {
+					end_packets_sent++;
+				}
+			}
 
 			if (loops == 1) {
 				rtp_session->last_write_ts += samples;
@@ -8533,8 +8543,10 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 				rtp_session->last_write_samplecount = rtp_session->write_timer.samplecount;
 			}
 
-			/* The end packets are on the wire: this digit is done, confirm what we sent. */
-			if (rtp_session->session) {
+			/* The end packets are on the wire: this digit is done, confirm what we sent.
+			   Nothing is confirmed when every end write was rejected -- claiming a digit
+			   the socket never accepted is the exact false positive this event removes. */
+			if (rtp_session->session && end_packets_sent) {
 				switch_dtmf_t sent_dtmf = { rtp_session->dtmf_data.out_digit,
 											rtp_session->dtmf_data.out_digit_dur,
 											rtp_session->dtmf_data.out_digit_flags,
@@ -8597,7 +8609,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 
 		if (switch_queue_trypop(rtp_session->dtmf_data.dtmf_queue, &pop) == SWITCH_STATUS_SUCCESS) {
 			switch_dtmf_t *rdigit = pop;
-			switch_size_t wrote;
+			int wrote;
 			uint32_t shift = 0, new_ts = 0;
 
 			if (rdigit->digit == 'w') {
@@ -8688,8 +8700,10 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 						rtp_session->te, rtp_session->dtmf_data.timestamp_dtmf, &flags);
 
 
-				rtp_session->stats.outbound.raw_bytes += wrote;
-				rtp_session->stats.outbound.dtmf_packet_count++;
+				if (wrote > 0) {
+					rtp_session->stats.outbound.raw_bytes += wrote;
+					rtp_session->stats.outbound.dtmf_packet_count++;
+				}
 
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG, "Send start packet for [%c] ts=%u dur=%d/%d/%d seq=%d lw=%u\n",
 						rtp_session->dtmf_data.out_digit,

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -8545,7 +8545,13 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 
 			/* The end packets are on the wire: this digit is done, confirm what we sent.
 			   Nothing is confirmed when every end write was rejected -- claiming a digit
-			   the socket never accepted is the exact false positive this event removes. */
+			   the socket never accepted is the exact false positive this event removes.
+
+			   out_digit_sofar is a whole number of packet intervals and this branch is
+			   only reached once it has passed out_digit_dur, so within one clock domain
+			   the reported figure lands on or past the requested one: it measures
+			   overshoot from scheduling gaps, never a short digit. A digit cut short by
+			   teardown never gets here and is reported by nothing at all. */
 			if (rtp_session->session && end_packets_sent) {
 				switch_dtmf_t sent_dtmf = { rtp_session->dtmf_data.out_digit,
 											rtp_session->dtmf_data.out_digit_dur,

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -43,6 +43,7 @@ switch_xml
 switch_estimators
 switch_jitter_buffer
 test_sofia
+test_dtmf_sent_event
 switch_mod_lumenvox
 conf_lumenvox/[0-9]*/**
 .deps/

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 			   switch_ivr_play_say switch_core_codec switch_rtp switch_xml
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log switch_stun switch_trickle_ice
 
-noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup
+noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup test_dtmf_sent_event
 
 # switch_mod_lumenvox is intentionally NOT built/run in CI yet: LumenVox servers
 # are not reachable from CI, so the ASR tests cannot run there. Re-enable by

--- a/tests/unit/test_dtmf_sent_event.c
+++ b/tests/unit/test_dtmf_sent_event.c
@@ -29,6 +29,7 @@ static switch_port_t tx_port = 12346;
 static const switch_payload_t TEST_PT = 8;
 static const switch_payload_t TEST_TE_PT = 101;
 
+static switch_memory_pool_t *event_pool = NULL;
 static switch_mutex_t *event_mutex = NULL;
 static switch_event_t *dtmf_sent_event = NULL;
 static int dtmf_sent_event_count = 0;
@@ -78,12 +79,21 @@ FST_SUITE_BEGIN(test_dtmf_sent_event)
 FST_SETUP_BEGIN()
 {
 	fst_requires_module("mod_loopback");
-	switch_mutex_init(&event_mutex, SWITCH_MUTEX_NESTED, fst_pool);
+
+	/* Not fst_pool: FST_TEARDOWN_BEGIN() destroys fst_pool inside the macro, before the
+	   teardown body that unbinds the handler ever runs (switch_test.h), so a mutex taken
+	   from fst_pool would be freed while the handler is still bound. This pool is created
+	   once for the whole suite and left to the core to reclaim at shutdown, which also
+	   keeps the mutex valid for a dispatch already in flight when we unbind. */
+	if (!event_pool) {
+		switch_core_new_memory_pool(&event_pool);
+		switch_mutex_init(&event_mutex, SWITCH_MUTEX_NESTED, event_pool);
+	}
+
 	dtmf_sent_event = NULL;
 	dtmf_sent_event_count = 0;
-	/* Bound here rather than in the test body: an aborted assertion skips the rest
-	   of the body, and a handler left bound would go on locking a mutex allocated
-	   from the per-test pool that teardown is about to destroy. */
+	/* Bound here rather than in the test body: an aborted assertion skips the rest of
+	   the body, so a bind done there could never be undone. */
 	switch_event_bind("test_dtmf_sent_event", SWITCH_EVENT_CUSTOM, SWITCH_EVENT_SUBCLASS_ANY, dtmf_sent_event_handler, NULL);
 }
 FST_SETUP_END()

--- a/tests/unit/test_dtmf_sent_event.c
+++ b/tests/unit/test_dtmf_sent_event.c
@@ -175,6 +175,59 @@ FST_TEST_BEGIN(dtmf_sent_event_fires_when_rfc2833_digit_finishes)
 }
 FST_TEST_END()
 
+FST_TEST_BEGIN(no_dtmf_sent_event_when_the_end_packets_are_rejected)
+{
+	switch_core_session_t *session = NULL;
+	switch_channel_t *channel = NULL;
+	switch_memory_pool_t *pool = NULL;
+	switch_rtp_t *rtp_session = NULL;
+	switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+	switch_dtmf_t dtmf = { '5', 800, 0, SWITCH_DTMF_APP };
+	switch_call_cause_t cause;
+	switch_status_t status;
+	const char *err = NULL;
+	int i;
+
+	switch_core_new_memory_pool(&pool);
+
+	status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+	fst_requires(session);
+	fst_check(status == SWITCH_STATUS_SUCCESS);
+
+	channel = switch_core_session_get_channel(session);
+	fst_requires(channel);
+	switch_channel_set_variable(channel, "call_control", "true");
+
+	switch_core_memory_pool_set_data(pool, "__session", session);
+	rtp_session = switch_rtp_new(rx_host, rx_port, tx_host, tx_port, TEST_PT, 160, 20 * 1000, flags, "soft", &err, pool);
+	fst_requires(rtp_session);
+	fst_requires(switch_rtp_ready(rtp_session));
+	switch_rtp_set_default_payload(rtp_session, TEST_PT);
+	switch_rtp_set_telephony_event(rtp_session, TEST_TE_PT);
+
+	status = switch_rtp_queue_rfc2833(rtp_session, &dtmf);
+	fst_xcheck(status == SWITCH_STATUS_SUCCESS, "queue outbound RFC 2833 digit");
+
+	/* Take IO away after queueing: switch_rtp_write_manual() now fails switch_rtp_ready()
+	   and returns -1 for every packet, so nothing reaches the socket even though do_2833()
+	   still walks the digit to completion. */
+	switch_rtp_clear_flag(rtp_session, SWITCH_RTP_FLAG_IO);
+
+	/* 800 samples at 160 per interval completes in 5 pumps; 20 is well past the point
+	   where the working case above has already fired. */
+	for (i = 0; i < 20; i++) {
+		do_2833(rtp_session);
+		switch_yield(20000);
+	}
+
+	fst_xcheck(got_dtmf_sent_event() == 0, "a digit whose end packets were all rejected is never confirmed");
+
+	switch_rtp_destroy(&rtp_session);
+	switch_core_session_rwunlock(session);
+	switch_core_destroy_memory_pool(&pool);
+}
+FST_TEST_END()
+
 FST_TEST_BEGIN(no_dtmf_sent_event_for_an_event_sensitive_digit)
 {
 	switch_core_session_t *session = NULL;

--- a/tests/unit/test_dtmf_sent_event.c
+++ b/tests/unit/test_dtmf_sent_event.c
@@ -1,0 +1,228 @@
+/*
+ * TELCORE-373: confirmation event for outbound DTMF.
+ *
+ * FreeSWITCH fires SWITCH_EVENT_DTMF only on the receive side
+ * (switch_channel_dequeue_dtmf). Nothing is emitted when we transmit a digit,
+ * so the B2BUA cannot tell a customer that a requested DTMF actually went out
+ * on the wire -- the "+OK" from uuid_send_dtmf only means "queued".
+ *
+ * This test drives the real RFC 2833 send path: a digit is queued on an RTP
+ * session and do_2833() is pumped until the end-of-digit packets are written.
+ * At that point -- and only then -- a CUSTOM/telnyx::dtmf_sent event must be
+ * fired for the channel, carrying the digit, the requested duration and the
+ * duration actually transmitted.
+ *
+ * The "call_control" header assertion matters as much as the rest: the ZMQ
+ * publisher in mod_telnyx filters the call_control queue on that header
+ * (conf/telnyx/zmq_publishers.json), so an event built without full channel
+ * data would never reach the B2BUA.
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+
+static const char *rx_host = "127.0.0.1";
+static switch_port_t rx_port = 12344;
+static const char *tx_host = "127.0.0.1";
+static switch_port_t tx_port = 12346;
+
+static const switch_payload_t TEST_PT = 8;
+static const switch_payload_t TEST_TE_PT = 101;
+
+static switch_mutex_t *event_mutex = NULL;
+static switch_event_t *dtmf_sent_event = NULL;
+static int dtmf_sent_event_count = 0;
+
+static void dtmf_sent_event_handler(switch_event_t *event)
+{
+	const char *subclass = switch_event_get_header(event, "Event-Subclass");
+
+	if (zstr(subclass) || strcmp(subclass, "telnyx::dtmf_sent")) {
+		return;
+	}
+
+	switch_mutex_lock(event_mutex);
+	if (!dtmf_sent_event) {
+		switch_event_dup(&dtmf_sent_event, event);
+	}
+	dtmf_sent_event_count++;
+	switch_mutex_unlock(event_mutex);
+}
+
+static int got_dtmf_sent_event(void)
+{
+	int got;
+
+	switch_mutex_lock(event_mutex);
+	got = dtmf_sent_event_count;
+	switch_mutex_unlock(event_mutex);
+
+	return got;
+}
+
+static const char *dtmf_sent_header(const char *name)
+{
+	const char *value;
+
+	switch_mutex_lock(event_mutex);
+	value = dtmf_sent_event ? switch_event_get_header(dtmf_sent_event, name) : NULL;
+	switch_mutex_unlock(event_mutex);
+
+	return value;
+}
+
+FST_CORE_BEGIN("./conf")
+{
+FST_SUITE_BEGIN(test_dtmf_sent_event)
+{
+FST_SETUP_BEGIN()
+{
+	fst_requires_module("mod_loopback");
+	switch_mutex_init(&event_mutex, SWITCH_MUTEX_NESTED, fst_pool);
+	dtmf_sent_event = NULL;
+	dtmf_sent_event_count = 0;
+	/* Bound here rather than in the test body: an aborted assertion skips the rest
+	   of the body, and a handler left bound would go on locking a mutex allocated
+	   from the per-test pool that teardown is about to destroy. */
+	switch_event_bind("test_dtmf_sent_event", SWITCH_EVENT_CUSTOM, SWITCH_EVENT_SUBCLASS_ANY, dtmf_sent_event_handler, NULL);
+}
+FST_SETUP_END()
+
+FST_TEARDOWN_BEGIN()
+{
+	switch_event_unbind_callback(dtmf_sent_event_handler);
+	switch_event_destroy(&dtmf_sent_event);
+}
+FST_TEARDOWN_END()
+
+FST_TEST_BEGIN(dtmf_sent_event_fires_when_rfc2833_digit_finishes)
+{
+	switch_core_session_t *session = NULL;
+	switch_channel_t *channel = NULL;
+	switch_memory_pool_t *pool = NULL;
+	switch_rtp_t *rtp_session = NULL;
+	switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+	/* 800 samples == 100ms at 8kHz */
+	switch_dtmf_t dtmf = { '5', 800, 0, SWITCH_DTMF_APP };
+	switch_call_cause_t cause;
+	switch_status_t status;
+	const char *err = NULL;
+	const char *value;
+	int i;
+
+	switch_core_new_memory_pool(&pool);
+
+	status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+	fst_requires(session);
+	fst_check(status == SWITCH_STATUS_SUCCESS);
+
+	channel = switch_core_session_get_channel(session);
+	fst_requires(channel);
+	switch_channel_set_variable(channel, "call_control", "true");
+
+	switch_core_memory_pool_set_data(pool, "__session", session);
+	/* 160 samples per 20ms interval == 8kHz */
+	rtp_session = switch_rtp_new(rx_host, rx_port, tx_host, tx_port, TEST_PT, 160, 20 * 1000, flags, "soft", &err, pool);
+	fst_requires(rtp_session);
+	fst_requires(switch_rtp_ready(rtp_session));
+	switch_rtp_set_default_payload(rtp_session, TEST_PT);
+	switch_rtp_set_telephony_event(rtp_session, TEST_TE_PT);
+
+	status = switch_rtp_queue_rfc2833(rtp_session, &dtmf);
+	fst_xcheck(status == SWITCH_STATUS_SUCCESS, "queue outbound RFC 2833 digit");
+
+	/* No event may be fired while the digit is still on the wire. */
+	fst_xcheck(got_dtmf_sent_event() == 0, "no confirmation before the digit is transmitted");
+
+	for (i = 0; i < 100 && !got_dtmf_sent_event(); i++) {
+		do_2833(rtp_session);
+		switch_yield(20000);
+	}
+
+	fst_xcheck(got_dtmf_sent_event() == 1, "exactly one confirmation event for one digit");
+	fst_requires(dtmf_sent_event);
+
+	value = dtmf_sent_header("DTMF-Digit");
+	fst_xcheck(!zstr(value) && !strcmp(value, "5"), "DTMF-Digit is the transmitted digit");
+
+	value = dtmf_sent_header("DTMF-Source");
+	fst_xcheck(!zstr(value) && !strcmp(value, "APP"), "DTMF-Source distinguishes injected digits from relayed ones");
+
+	value = dtmf_sent_header("DTMF-Method");
+	fst_xcheck(!zstr(value) && !strcmp(value, "RFC2833"), "DTMF-Method is the transport used");
+
+	value = dtmf_sent_header("DTMF-Duration");
+	fst_xcheck(!zstr(value) && atoi(value) == 800, "DTMF-Duration is the requested duration in samples");
+
+	value = dtmf_sent_header("DTMF-Duration-Sent");
+	fst_xcheck(!zstr(value) && atoi(value) == 800, "DTMF-Duration-Sent is the duration actually transmitted");
+
+	value = dtmf_sent_header("DTMF-Duration-Sent-MS");
+	fst_xcheck(!zstr(value) && atoi(value) == 100, "DTMF-Duration-Sent-MS reports the transmitted length in ms");
+
+	value = dtmf_sent_header("DTMF-Clock-Rate");
+	fst_xcheck(!zstr(value) && atoi(value) == 8000, "DTMF-Clock-Rate states the rate the sample counts are expressed in");
+
+	value = dtmf_sent_header("Unique-ID");
+	fst_xcheck(!zstr(value) && !strcmp(value, switch_core_session_get_uuid(session)), "event is bound to the sending channel");
+
+	value = dtmf_sent_header("call_control");
+	fst_xcheck(!zstr(value) && !strcmp(value, "true"), "event carries the call_control header the ZMQ publisher filters on");
+
+	switch_rtp_destroy(&rtp_session);
+	switch_core_session_rwunlock(session);
+	switch_core_destroy_memory_pool(&pool);
+}
+FST_TEST_END()
+
+FST_TEST_BEGIN(no_dtmf_sent_event_for_an_event_sensitive_digit)
+{
+	switch_core_session_t *session = NULL;
+	switch_channel_t *channel = NULL;
+	switch_memory_pool_t *pool = NULL;
+	switch_rtp_t *rtp_session = NULL;
+	switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+	switch_dtmf_t dtmf = { '7', 800, DTMF_FLAG_EVENT_SENSITIVE, SWITCH_DTMF_APP };
+	switch_call_cause_t cause;
+	switch_status_t status;
+	const char *err = NULL;
+	int i;
+
+	switch_core_new_memory_pool(&pool);
+
+	status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+	fst_requires(session);
+	fst_check(status == SWITCH_STATUS_SUCCESS);
+
+	channel = switch_core_session_get_channel(session);
+	fst_requires(channel);
+	switch_channel_set_variable(channel, "call_control", "true");
+
+	switch_core_memory_pool_set_data(pool, "__session", session);
+	rtp_session = switch_rtp_new(rx_host, rx_port, tx_host, tx_port, TEST_PT, 160, 20 * 1000, flags, "soft", &err, pool);
+	fst_requires(rtp_session);
+	fst_requires(switch_rtp_ready(rtp_session));
+	switch_rtp_set_default_payload(rtp_session, TEST_PT);
+	switch_rtp_set_telephony_event(rtp_session, TEST_TE_PT);
+
+	status = switch_rtp_queue_rfc2833(rtp_session, &dtmf);
+	fst_xcheck(status == SWITCH_STATUS_SUCCESS, "queue outbound RFC 2833 digit");
+
+	/* Pump past the point where a non-sensitive digit would have been confirmed. */
+	for (i = 0; i < 20; i++) {
+		do_2833(rtp_session);
+		switch_yield(20000);
+	}
+
+	fst_xcheck(got_dtmf_sent_event() == 0, "a digit flagged event-sensitive is sent but never reported");
+
+	switch_rtp_destroy(&rtp_session);
+	switch_core_session_rwunlock(session);
+	switch_core_destroy_memory_pool(&pool);
+}
+FST_TEST_END()
+
+}
+FST_SUITE_END()
+}
+FST_CORE_END()

--- a/tests/unit/test_dtmf_sent_event.c
+++ b/tests/unit/test_dtmf_sent_event.c
@@ -152,7 +152,13 @@ FST_TEST_BEGIN(dtmf_sent_event_fires_when_rfc2833_digit_finishes)
 	fst_xcheck(!zstr(value) && !strcmp(value, "RFC2833"), "DTMF-Method is the transport used");
 
 	value = dtmf_sent_header("DTMF-Duration");
-	fst_xcheck(!zstr(value) && atoi(value) == 800, "DTMF-Duration is the requested duration in samples");
+	fst_xcheck(!zstr(value) && atoi(value) == 800, "DTMF-Duration is the requested duration in 8kHz samples");
+
+	value = dtmf_sent_header("DTMF-Duration-MS");
+	fst_xcheck(!zstr(value) && atoi(value) == 100, "DTMF-Duration-MS reports the requested length in ms");
+
+	value = dtmf_sent_header("DTMF-Duration-Clock-Rate");
+	fst_xcheck(!zstr(value) && atoi(value) == 8000, "DTMF-Duration is always in the 8kHz domain");
 
 	value = dtmf_sent_header("DTMF-Duration-Sent");
 	fst_xcheck(!zstr(value) && atoi(value) == 800, "DTMF-Duration-Sent is the duration actually transmitted");
@@ -160,14 +166,89 @@ FST_TEST_BEGIN(dtmf_sent_event_fires_when_rfc2833_digit_finishes)
 	value = dtmf_sent_header("DTMF-Duration-Sent-MS");
 	fst_xcheck(!zstr(value) && atoi(value) == 100, "DTMF-Duration-Sent-MS reports the transmitted length in ms");
 
-	value = dtmf_sent_header("DTMF-Clock-Rate");
-	fst_xcheck(!zstr(value) && atoi(value) == 8000, "DTMF-Clock-Rate states the rate the sample counts are expressed in");
+	value = dtmf_sent_header("DTMF-Duration-Sent-Clock-Rate");
+	fst_xcheck(!zstr(value) && atoi(value) == 8000, "DTMF-Duration-Sent-Clock-Rate states the rate DTMF-Duration-Sent is in");
 
 	value = dtmf_sent_header("Unique-ID");
 	fst_xcheck(!zstr(value) && !strcmp(value, switch_core_session_get_uuid(session)), "event is bound to the sending channel");
 
 	value = dtmf_sent_header("call_control");
 	fst_xcheck(!zstr(value) && !strcmp(value, "true"), "event carries the call_control header the ZMQ publisher filters on");
+
+	switch_rtp_destroy(&rtp_session);
+	switch_core_session_rwunlock(session);
+	switch_core_destroy_memory_pool(&pool);
+}
+FST_TEST_END()
+
+FST_TEST_BEGIN(dtmf_sent_event_keeps_the_two_clock_domains_apart)
+{
+	switch_core_session_t *session = NULL;
+	switch_channel_t *channel = NULL;
+	switch_memory_pool_t *pool = NULL;
+	switch_rtp_t *rtp_session = NULL;
+	switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+	/* 2000 == SWITCH_DEFAULT_DTMF_DURATION, i.e. 250ms in FS's 8kHz convention. */
+	switch_dtmf_t dtmf = { '5', 2000, 0, SWITCH_DTMF_APP };
+	switch_call_cause_t cause;
+	switch_status_t status;
+	const char *err = NULL;
+	const char *value;
+	int i;
+
+	switch_core_new_memory_pool(&pool);
+
+	status = switch_ivr_originate(NULL, &session, &cause, "null/+15553334444", 2, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+	fst_requires(session);
+	fst_check(status == SWITCH_STATUS_SUCCESS);
+
+	channel = switch_core_session_get_channel(session);
+	fst_requires(channel);
+	switch_channel_set_variable(channel, "call_control", "true");
+
+	switch_core_memory_pool_set_data(pool, "__session", session);
+	/* 960 samples per 20ms interval == 48kHz, the rate an Opus leg is created at
+	   (switch_core_media.c). At 8kHz the requested and transmitted domains coincide
+	   and the distinction is invisible, so this is the case that pins it down. */
+	rtp_session = switch_rtp_new(rx_host, rx_port, tx_host, tx_port, TEST_PT, 960, 20 * 1000, flags, "soft", &err, pool);
+	fst_requires(rtp_session);
+	fst_requires(switch_rtp_ready(rtp_session));
+	switch_rtp_set_default_payload(rtp_session, TEST_PT);
+	switch_rtp_set_telephony_event(rtp_session, TEST_TE_PT);
+
+	status = switch_rtp_queue_rfc2833(rtp_session, &dtmf);
+	fst_xcheck(status == SWITCH_STATUS_SUCCESS, "queue outbound RFC 2833 digit");
+
+	for (i = 0; i < 100 && !got_dtmf_sent_event(); i++) {
+		do_2833(rtp_session);
+		switch_yield(20000);
+	}
+
+	fst_xcheck(got_dtmf_sent_event() == 1, "exactly one confirmation event for one digit");
+	fst_requires(dtmf_sent_event);
+
+	value = dtmf_sent_header("DTMF-Duration");
+	fst_xcheck(!zstr(value) && atoi(value) == 2000, "DTMF-Duration stays in the 8kHz domain regardless of the session rate");
+
+	value = dtmf_sent_header("DTMF-Duration-Clock-Rate");
+	fst_xcheck(!zstr(value) && atoi(value) == 8000, "DTMF-Duration-Clock-Rate is 8kHz, not the session rate");
+
+	value = dtmf_sent_header("DTMF-Duration-MS");
+	fst_xcheck(!zstr(value) && atoi(value) == 250, "DTMF-Duration-MS is the requested 250ms");
+
+	value = dtmf_sent_header("DTMF-Duration-Sent-Clock-Rate");
+	fst_xcheck(!zstr(value) && atoi(value) == 48000, "DTMF-Duration-Sent-Clock-Rate is the session rate");
+
+	/* do_2833() compares out_digit_sofar (48kHz samples) against out_digit_dur (8kHz
+	   samples), so the digit ends after ceil(2000/960) == 3 intervals: 2880 samples,
+	   60ms, far short of the 250ms asked for. That truncation is pre-existing core
+	   behaviour; what matters here is that the event describes it without lying -- the
+	   two MS values are directly comparable and disagree. */
+	value = dtmf_sent_header("DTMF-Duration-Sent");
+	fst_xcheck(!zstr(value) && atoi(value) == 2880, "DTMF-Duration-Sent is in session samples");
+
+	value = dtmf_sent_header("DTMF-Duration-Sent-MS");
+	fst_xcheck(!zstr(value) && atoi(value) == 60, "DTMF-Duration-Sent-MS is comparable to DTMF-Duration-MS");
 
 	switch_rtp_destroy(&rtp_session);
 	switch_core_session_rwunlock(session);


### PR DESCRIPTION
[TELCORE-373](https://linear.app/telnyx/issue/TELCORE-373/add-b2bua-event-confirming-outbound-dtmf-was-sent)

## Why

`SWITCH_EVENT_DTMF` is fired only on the receive side (`switch_channel_dequeue_dtmf`, `switch_ivr_async.c`), so nothing tells the B2BUA that a requested outbound digit actually went out — the `+OK` from `uuid_send_dtmf` only means the digit was handed to the endpoint. The customer wants to continue their call flow once the DTMF is on the wire, and asked for the sent signal length as well.

Reusing `SWITCH_EVENT_DTMF` with a direction header was not an option: the call_control ZMQ queue already subscribes to `DTMF` and would turn sent digits into bogus `call.dtmf.received` webhooks.

## What

Fire `CUSTOM` / subclass `telnyx::dtmf_sent` once a digit has left the switch, over **RFC 2833** only (`do_2833`, the production path) — at the end-of-digit branch, and only once at least one end packet has been accepted by the socket. The queued digit's flags and source are now kept in `switch_rtp_rfc2833_data` so the event can honour `DTMF_FLAG_*SENSITIVE` and report where the digit came from.

`do_2833()` previously discarded every `switch_rtp_write_manual()` result. Besides letting the confirmation fire when nothing left the switch, that turned a `-1` return into `SIZE_MAX` on `stats.outbound.raw_bytes` (the local was a `switch_size_t`) and counted unsent packets in `dtmf_packet_count`. Both loops now check the result.

### Headers

The requested and transmitted durations are **not in the same clock domain** — `switch_dtmf_t.duration` is always in FreeSWITCH's 8 kHz convention, while the transmitted count is in the RTP session's own rate — so each carries its own rate and its own millisecond form:

| header | meaning |
|---|---|
| `DTMF-Digit` | the digit |
| `DTMF-Duration` | requested, 8 kHz samples (post min/max clamping) |
| `DTMF-Duration-MS` | requested, ms |
| `DTMF-Duration-Clock-Rate` | always `8000` |
| `DTMF-Duration-Sent` | transmitted, session samples |
| `DTMF-Duration-Sent-MS` | transmitted, ms |
| `DTMF-Duration-Sent-Clock-Rate` | the session rate |
| `DTMF-Source` | `APP` for injected digits vs `RTP` for digits relayed across a bridge |
| `DTMF-Method` | `RFC2833` |

The two `*-MS` headers are the ones to compare. On a 48 kHz (Opus) leg a default digit reports 250 ms requested against 60 ms sent, because `do_2833()` compares `out_digit_sofar` (session samples) against `out_digit_dur` (8 kHz samples) and ends the digit early. That truncation is pre-existing core behaviour; this event is the first thing to make it visible, and it now describes it rather than disguising it under a single clock rate.

**`DTMF-Duration-Sent` is not a truncation check.** A transport emits whole packet intervals and only reports once it has covered the requested duration, so compared like for like it lands on or past `DTMF-Duration` and measures overshoot from scheduling gaps. A digit abandoned before it finished fires nothing at all, so a consumer needs a timeout, not a short duration, to detect that.

The event always fires on the bus and deliberately does not honour `CF_DIVERT_EVENTS` (which the receive-side event does): its consumer is a plain bus subscriber, so diverting would silently drop the confirmation for the lifetime of an unrelated ESL session. Documented at the fire site.

The `DTMF-Source` switch in `switch_channel_dequeue_dtmf()` is extracted into a `dtmf_source_str()` helper shared by both events.

## Follow-ups (not in this PR)

- `zmq_publishers.json` in the b2bua repo needs `telnyx::dtmf_sent` added to the CUSTOM subclass list before the event reaches the B2BUA; the CCA then maps it to a webhook.
- **SIP INFO is not confirmed.** `nua_info()` only queues the request into sofia-sip and returns, so firing there would report the same "handed off" state `uuid_send_dtmf` already gives. The response arrives asynchronously as `nua_r_info` (`sofia.c:1731`), which fires for every INFO on the handle and carries nothing tying it to a specific request, so a digit can only be paired with it by guessing arrival order. This also covers the passthrough sites at `sofia.c:11029` / `sofia.c:11211`, which relay a received `application/dtmf-relay` INFO via `nua_info()` directly.
- No event is emitted for a digit still queued when the call tears down, so a consumer must time out rather than being told the digit was dropped.
- Inband DTMF generation (`start_dtmf_generate`) is unchanged.
- No per-call gate on the event: relayed (`DTMF-Source: RTP`) digits are confirmed too. The cost is one event per digit, not per packet; gating is a one-line change if it ever shows up in a profile.

## Test plan

`tests/unit/test_dtmf_sent_event.c` drives the real RFC 2833 send path over a live RTP session (added to `tests/unit/Makefile.am`):

- `dtmf_sent_event_fires_when_rfc2833_digit_finishes` — pumps `do_2833()` until the digit completes and asserts no event fires before that, then the digit, source, method, both duration domains and the `call_control` header the mod_telnyx ZMQ publisher filters on, without which the event would never reach the B2BUA;
- `dtmf_sent_event_keeps_the_two_clock_domains_apart` — same path at 960 samples/20 ms (48 kHz), pinning down the requested-vs-transmitted split. The original test ran at 160/20 ms, the one rate where the two domains coincide;
- `no_dtmf_sent_event_when_the_end_packets_are_rejected` — clears `SWITCH_RTP_FLAG_IO` after queueing so every `write_manual()` fails, and asserts nothing is confirmed. Verified the assertion catches a regression by dropping the `end_packets_sent` guard (2/3 without it);
- `no_dtmf_sent_event_for_an_event_sensitive_digit` — a digit flagged event-sensitive is transmitted but never reported. Verified the assertion catches a regression by removing the guard.

```
test_dtmf_sent_event     PASSED (4/4)
switch_rtp               PASSED (3/3)
switch_ivr_async         PASSED (3/3)
switch_core_session      PASSED (6/6)
switch_event             PASSED (2/2)
```
