### PR TITLE
TELCORE-353: keep recorder stalls off the media path

### DIFF
--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -164,9 +164,9 @@ enum AVColorRange {
   <settings>
       <param name="colorspace" value="1"/>
 
-      <!-- Timeouts for network outputs, in milliseconds.  0 (the default) disables
-           them: an unreachable or overloaded server can then block the opening or
-           writing thread indefinitely.
+      <!-- Timeouts for RTMP outputs (rtmp/rtmps), in milliseconds.  0 (the default)
+           disables them: an unreachable or overloaded recorder can then block the
+           opening or writing thread indefinitely.
 
            network-rw-timeout      read/write timeout applied when the record command
                                    does not carry its own rw_timeout file parameter.
@@ -177,9 +177,9 @@ enum AVColorRange {
            NOTE: the rw_timeout file parameter is in microseconds (ffmpeg's own unit);
            these settings are in milliseconds.
 
-           network-connect-timeout applies to protocols whose muxer opens the connection
-           up front (rtmp/rtmps).  It does NOT apply to RTSP: that muxer is AVFMT_NOFILE
-           and sets its session up inside the header write, which nothing bounds yet. -->
+           Coverage: audio RTMP recordings, which is where recorder stalls have hurt.
+           Other protocols (rtsp) and video recordings are unaffected and keep their
+           previous behaviour; for video, ffmpeg's own rw_timeout still applies. -->
       <!-- <param name="network-rw-timeout" value="2000"/> -->
       <!-- <param name="network-max-rw-timeout" value="5000"/> -->
       <!-- <param name="network-connect-timeout" value="2000"/> -->

--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -196,5 +196,34 @@ enum AVColorRange {
            write fails rather than when recording starts, so the failure shows up as a
            RECORD_STOP with uri-failure instead of an immediate error. -->
       <!-- <param name="network-async-open" value="true"/> -->
+
+      <!-- Everything above is the default for the box.  A single recording may override
+           any of it, which is what makes this tunable without a restart:
+
+             {} on the record command  >  channel variable  >  this file
+
+           channel variable                     record command param      unit
+           RECORD_NETWORK_CONNECT_TIMEOUT_MS    network_connect_timeout   ms
+           RECORD_NETWORK_RW_TIMEOUT_MS         network_rw_timeout        ms
+           RECORD_NETWORK_MAX_RW_TIMEOUT_MS     network_max_rw_timeout    ms
+           RECORD_NETWORK_ASYNC_OPEN            network_async_open        bool
+           RECORD_NETWORK_RESILIENCY            network_resiliency        bool
+
+           RECORD_NETWORK_RESILIENCY=false is the kill switch: it disables the timeouts
+           and the async open together for that recording, restoring the behaviour this
+           file's defaults would give if every setting were 0/false.  It is disable-only:
+           setting it true where the config has the feature off does nothing at all.
+
+           The individual settings are not disable-only, and each takes effect in either
+           direction.  A recording may therefore switch the feature on where this file
+           has it off -- network_async_open=true together with a network_connect_timeout
+           is enough to get the full behaviour for one recording, which is the way to try
+           this on a single call before turning it on for the box.  Equally, a recording
+           may loosen a budget this file has set; network_max_rw_timeout below is the one
+           setting that cannot be loosened, and it backstops the others.
+
+           network_max_rw_timeout is the one setting a recording may only *tighten*.  It
+           exists to stop an over-generous caller-supplied rw_timeout from defeating the
+           bound, so a looser per-recording value is refused and logged. -->
   </settings>
 </configuration>

--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -177,9 +177,10 @@ enum AVColorRange {
            NOTE: the rw_timeout file parameter is in microseconds (ffmpeg's own unit);
            these settings are in milliseconds.
 
-           Coverage: audio RTMP recordings, which is where recorder stalls have hurt.
-           Other protocols (rtsp) and video recordings are unaffected and keep their
-           previous behaviour; for video, ffmpeg's own rw_timeout still applies. -->
+           Coverage: RTMP recordings, which is where recorder stalls have hurt.  Other
+           protocols are unaffected and keep their previous behaviour -- notably rtsp,
+           whose muxer opens no file of its own and connects from elsewhere.  Local file
+           recording is deliberately untouched: a slow disk is not a stuck peer. -->
       <!-- <param name="network-rw-timeout" value="2000"/> -->
       <!-- <param name="network-max-rw-timeout" value="5000"/> -->
       <!-- <param name="network-connect-timeout" value="2000"/> -->

--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -163,5 +163,21 @@ enum AVColorRange {
 <configuration name="avformat.conf" description="AVFormat Config">
   <settings>
       <param name="colorspace" value="1"/>
+
+      <!-- Timeouts for network outputs (rtmp/rtmps/rtsp), in milliseconds.
+           0 (the default) disables them: an unreachable or overloaded server can
+           then block the opening/writing thread indefinitely.
+
+           network-rw-timeout      read/write timeout applied when the record command
+                                   does not carry its own rw_timeout file parameter.
+           network-max-rw-timeout  upper bound applied to a caller-supplied rw_timeout,
+                                   so an over-generous caller value cannot defeat this.
+           network-connect-timeout timeout for establishing the connection.
+
+           NOTE: the rw_timeout file parameter is in microseconds (ffmpeg's own unit);
+           these settings are in milliseconds. -->
+      <!-- <param name="network-rw-timeout" value="2000"/> -->
+      <!-- <param name="network-max-rw-timeout" value="5000"/> -->
+      <!-- <param name="network-connect-timeout" value="2000"/> -->
   </settings>
 </configuration>

--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -164,9 +164,9 @@ enum AVColorRange {
   <settings>
       <param name="colorspace" value="1"/>
 
-      <!-- Timeouts for network outputs (rtmp/rtmps/rtsp), in milliseconds.
-           0 (the default) disables them: an unreachable or overloaded server can
-           then block the opening/writing thread indefinitely.
+      <!-- Timeouts for network outputs, in milliseconds.  0 (the default) disables
+           them: an unreachable or overloaded server can then block the opening or
+           writing thread indefinitely.
 
            network-rw-timeout      read/write timeout applied when the record command
                                    does not carry its own rw_timeout file parameter.
@@ -175,7 +175,11 @@ enum AVColorRange {
            network-connect-timeout timeout for establishing the connection.
 
            NOTE: the rw_timeout file parameter is in microseconds (ffmpeg's own unit);
-           these settings are in milliseconds. -->
+           these settings are in milliseconds.
+
+           network-connect-timeout applies to protocols whose muxer opens the connection
+           up front (rtmp/rtmps).  It does NOT apply to RTSP: that muxer is AVFMT_NOFILE
+           and sets its session up inside the header write, which nothing bounds yet. -->
       <!-- <param name="network-rw-timeout" value="2000"/> -->
       <!-- <param name="network-max-rw-timeout" value="5000"/> -->
       <!-- <param name="network-connect-timeout" value="2000"/> -->

--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -183,5 +183,17 @@ enum AVColorRange {
       <!-- <param name="network-rw-timeout" value="2000"/> -->
       <!-- <param name="network-max-rw-timeout" value="5000"/> -->
       <!-- <param name="network-connect-timeout" value="2000"/> -->
+
+      <!-- Connect on the writer's thread instead of the caller's, when the caller has
+           a dedicated writer thread (recordings do).  Connecting to an RTMP server
+           takes a TCP handshake plus the RTMP handshake, and doing that on the calling
+           thread stops that call's media until it finishes.  With this on, the caller
+           returns immediately and audio queues (bounded by RECORD_BUFFER_MAX_MS) while
+           the connection is established.
+
+           The trade-off: a recorder that cannot be reached is reported when the first
+           write fails rather than when recording starts, so the failure shows up as a
+           RECORD_STOP with uri-failure instead of an immediate error. -->
+      <!-- <param name="network-async-open" value="true"/> -->
   </settings>
 </configuration>

--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -2888,7 +2888,11 @@ typedef enum {
 	SCFC_FLUSH_AUDIO,
 	SCFC_PAUSE_READ,
 	SCFC_PAUSE_WRITE,
-	SCFC_RESUME_WRITE
+	SCFC_RESUME_WRITE,
+	/* Abort any I/O in flight on this handle and fail subsequent I/O rather than
+	 * blocking, so a caller waiting on the writer can stop waiting.  Formats that do
+	 * not implement it simply ignore it. */
+	SCFC_ABORT_IO
 } switch_file_command_t;
 
 

--- a/src/include/switch_utils.h
+++ b/src/include/switch_utils.h
@@ -1222,6 +1222,18 @@ SWITCH_DECLARE(char *) switch_url_encode_opt(const char *url, char *buf, size_t 
 SWITCH_DECLARE(char *) switch_url_encode(const char *url, char *buf, size_t len);
 SWITCH_DECLARE(char *) switch_url_decode(char *s);
 
+/*!
+  \brief Render a file target in a form that is safe to log
+  \param target the target as the caller gave it, parameter groups and all
+  \param buf buffer to write the redacted form into
+  \param buflen size of buf
+  \return buf, or a literal when there was nothing usable to render
+
+  Strips the leading {} and [] parameter groups, then reduces a URL to scheme://host,
+  dropping userinfo, path, query and anything past a space.  Local paths are left alone.
+*/
+SWITCH_DECLARE(const char *) switch_redact_file_target(const char *target, char *buf, switch_size_t buflen);
+
 SWITCH_DECLARE(char *) switch_core_url_encode_opt(switch_memory_pool_t *pool, const char *url, switch_bool_t double_encode);
 SWITCH_DECLARE(char *) switch_core_url_encode(switch_memory_pool_t *pool, const char *url);
 SWITCH_DECLARE(char *) switch_core_session_url_encode_opt(switch_core_session_t *session, const char *url, switch_bool_t double_encode);

--- a/src/mod/applications/mod_av/.gitignore
+++ b/src/mod/applications/mod_av/.gitignore
@@ -1,3 +1,4 @@
 test/test_BT7.mp4
 test/test_RGB.mp4
+test/test_local_timeouts.mp4
 test/test_packetizer

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -93,6 +93,8 @@ struct avformat_globals {
 	int64_t default_rw_timeout_us;
 	int64_t max_rw_timeout_us;
 	int64_t connect_timeout_us;
+	/* Move the connect off the caller's thread when a writer thread will drive it. */
+	switch_bool_t network_async_open;
 };
 
 struct avformat_globals avformat_globals = { 0 };
@@ -196,6 +198,10 @@ struct av_file_context {
 	int io_timeout_logged;
 	/* Set from another thread via SCFC_ABORT_IO to break out of a blocked read/write. */
 	int abort_io;
+	/* Connect postponed to the writer thread; deferred_file is what to connect to. */
+	int deferred_open;
+	int open_failed;
+	char *deferred_file;
 	/* Resolved once at open, so the write path does not have to re-derive them. */
 	switch_bool_t io_is_network;
 	int64_t io_write_timeout_us;
@@ -567,12 +573,111 @@ static void io_deadline_report(av_file_context_t *context, const char *what)
 					  context->handle && context->handle->file_path ? context->handle->file_path : "(unknown)");
 }
 
+/* Establish the output connection, arming the connect deadline around it.  Called from
+ * av_file_open, or -- when the open is deferred -- from the writer thread on first use. */
+static switch_status_t open_output_avio(av_file_context_t *context, const char *file)
+{
+	AVDictionary *dict = NULL;
+	AVIOInterruptCB cb = {
+		.callback = interrupt_cb,
+		.opaque = context,
+	};
+	int ret;
+
+	if (context->rw_timeout_opt) {
+		av_dict_set(&dict, "rw_timeout", context->rw_timeout_opt, 0);
+	}
+
+	/* Monotonic: a realtime step (NTP, operator) must not extend the deadline out of
+	 * reach, which would restore the very hang this exists to prevent. */
+	context->connect_start_time = switch_mono_micro_time_now();
+
+	/* rw_timeout governs reads and writes, not the TCP connect: against an unreachable
+	 * peer it makes no difference and the connect runs to ffmpeg's own 5s tcp default.
+	 * Its coverage of the RTMP handshake also varies by protocol and version.  So
+	 * enforce the budget ourselves through the interrupt callback, which ffmpeg polls
+	 * throughout both phases.  Disarmed once open returns: the writes that follow carry
+	 * their own deadline. */
+	io_deadline_arm(context, context->io_connect_timeout_us);
+
+	/* Always via avio_open2, even with no timeout configured: it installs the interrupt
+	 * callback, without which a close cannot abort an open in flight. */
+	ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE, &cb, &dict);
+
+	io_deadline_disarm(context);
+
+	/* Options left in the dict after a *successful* open were not recognised by this
+	 * ffmpeg build for this protocol -- i.e. the timeout we asked for is not actually in
+	 * force.  Say so rather than silently believing we are protected.  On failure the
+	 * dict may never have been consulted, so checking it would cry wolf. */
+	if (ret >= 0 && av_dict_count(dict) > 0) {
+		AVDictionaryEntry *unused = NULL;
+
+		while ((unused = av_dict_get(dict, "", unused, AV_DICT_IGNORE_SUFFIX))) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "Option '%s' not honoured by this ffmpeg build for '%s'; that timeout is NOT in force\n",
+							  unused->key, file);
+		}
+	}
+
+	av_dict_free(&dict);
+
+	if (ret < 0) {
+		char ebuf[255] = "";
+
+		if (context->io_timed_out) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+							  "Could not open '%s': timed out after %lldms (connect timeout %lldms)\n",
+							  file, (long long) ((switch_mono_micro_time_now() - context->connect_start_time) / 1000),
+							  (long long) (context->io_connect_timeout_us / 1000));
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
+		}
+
+		return SWITCH_STATUS_GENERR;
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+/* Run the deferred connect on first write.  Everything that writes to the muxer must
+ * call this first; it is a no-op unless the open was actually deferred. */
+static switch_status_t ensure_output_open(av_file_context_t *context)
+{
+	if (!context->deferred_open) {
+		return context->open_failed ? SWITCH_STATUS_FALSE : SWITCH_STATUS_SUCCESS;
+	}
+
+	/* Never connect on the way out: av_file_close sets closed before flushing, and
+	 * dialling a recorder we are about to abandon would block the closing thread. */
+	if (context->closed || context->abort_io) {
+		context->deferred_open = 0;
+		context->open_failed = 1;
+		return SWITCH_STATUS_FALSE;
+	}
+
+	/* Cleared first so a failure is not retried on every subsequent frame. */
+	context->deferred_open = 0;
+
+	if (open_output_avio(context, context->deferred_file) != SWITCH_STATUS_SUCCESS) {
+		context->open_failed = 1;
+		return SWITCH_STATUS_FALSE;
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
 /* The header goes out over the connection avio_open2 already established, so it carries
  * the ordinary write budget, falling back to the connect budget when only that is set. */
 static int write_header_with_deadline(av_file_context_t *context)
 {
 	int64_t timeout_us = context->io_write_timeout_us ? context->io_write_timeout_us : context->io_connect_timeout_us;
 	int ret;
+
+	/* This is the first muxer write, so it is where a deferred connect lands. */
+	if (ensure_output_open(context) != SWITCH_STATUS_SUCCESS) {
+		return AVERROR(EIO);
+	}
 
 	io_deadline_arm(context, timeout_us);
 	ret = avformat_write_header(context->fc, NULL);
@@ -2274,9 +2379,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 	enum AVCodecID video_codec = AV_CODEC_ID_NONE;
 	enum AVCodecID audio_codec = AV_CODEC_ID_NONE;
 #endif
-	AVDictionary *dict = NULL; // Might be useful to set some options from what we got from the cmd
 	const char *format = NULL;
-	int ret;
 	char file[1024];
 	int disable_write_buffer = 0;
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -2513,62 +2616,19 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 
 	/* open the output file, if needed */
 	if (!(fmt->flags & AVFMT_NOFILE)) {
-		int64_t connect_timeout_us = context->io_connect_timeout_us;
-		const char *rw_timeout_opt = context->rw_timeout_opt;
-		AVIOInterruptCB cb = {
-			.callback = interrupt_cb,
-			.opaque = context,
-		};
+		/* Defer the connect to the writer thread when the caller has one.  The connect
+		 * and RTMP handshake are the slow part, and doing them here blocks whichever
+		 * thread called switch_core_file_open -- for a recording that is the session
+		 * thread, so an unresponsive recorder stops that call's media.  Deferring costs
+		 * nothing when the recorder is healthy and keeps audio flowing when it is not. */
+		if (context->io_is_network && avformat_globals.network_async_open &&
+			handle->params && switch_true(switch_event_get_header(handle->params, "writer_thread"))) {
+			context->deferred_open = 1;
+			context->deferred_file = switch_core_strdup(handle->memory_pool, file);
 
-		if (rw_timeout_opt) {
-			av_dict_set(&dict, "rw_timeout", rw_timeout_opt, 0);
-		}
-
-		/* Monotonic: a realtime step (NTP, operator) must not extend the deadline out of
-		 * reach, which would restore the very hang this exists to prevent. */
-		context->connect_start_time = switch_mono_micro_time_now();
-
-		/* ffmpeg's own rw_timeout does not reliably bound the connect and handshake
-		 * across protocols and versions, so enforce the connect budget ourselves via the
-		 * interrupt callback.  Disarmed once open returns: the writes that follow carry
-		 * their own deadline. */
-		io_deadline_arm(context, connect_timeout_us);
-
-		/* Always via avio_open2, even with no timeout configured: it installs the
-		 * interrupt callback, without which a close cannot abort an open in flight. */
-		ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE, &cb, &dict);
-
-		io_deadline_disarm(context);
-
-		/* Options left in the dict after a *successful* open were not recognised by this
-		 * ffmpeg build for this protocol -- i.e. the timeout we asked for is not actually
-		 * in force.  Say so rather than silently believing we are protected.  On failure
-		 * the dict may never have been consulted, so checking it would cry wolf. */
-		if (ret >= 0 && av_dict_count(dict) > 0) {
-			AVDictionaryEntry *unused = NULL;
-
-			while ((unused = av_dict_get(dict, "", unused, AV_DICT_IGNORE_SUFFIX))) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-								  "Option '%s' not honoured by this ffmpeg build for '%s'; that timeout is NOT in force\n",
-								  unused->key, file);
-			}
-		}
-
-		/* Freed here because the success path below returns before the end: label. */
-		av_dict_free(&dict);
-
-		if (ret < 0) {
-			char ebuf[255] = "";
-
-			if (context->io_timed_out) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
-								  "Could not open '%s': timed out after %lldms (connect timeout %lldms)\n",
-								  file, (long long) ((switch_mono_micro_time_now() - context->connect_start_time) / 1000),
-								  (long long) (connect_timeout_us / 1000));
-			} else {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
-			}
-
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+							  "Deferring connect for '%s' to the writer thread\n", file);
+		} else if (open_output_avio(context, file) != SWITCH_STATUS_SUCCESS) {
 			switch_goto_status(SWITCH_STATUS_GENERR, end);
 		}
 	} else {
@@ -2747,10 +2807,6 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		switch_buffer_destroy(&context->audio_buffer);
 	}
 
-	if (dict) {
-		av_dict_free(&dict);
-	}
-
 	return status;
 }
 
@@ -2777,8 +2833,10 @@ static switch_status_t av_file_write(switch_file_handle_t *handle, void *data, s
 		return SWITCH_STATUS_FALSE;
 	}
 
-	/* Once aborted, fail fast rather than blocking again on the same dead peer. */
-	if (context->abort_io) {
+	/* Once aborted or failed to connect, fail fast rather than blocking again on the
+	 * same dead peer.  The caller turns this into a write error and stops the
+	 * recording, which is how a deferred connect failure surfaces. */
+	if (context->abort_io || context->open_failed) {
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -3608,6 +3666,12 @@ static switch_status_t av_file_write_video(switch_file_handle_t *handle, switch_
 	switch_image_t *img = NULL;
 	AVCodecContext *c = NULL;
 
+	/* Same fast-fail as the audio path: once aborted or unable to connect, stop rather
+	 * than entering ffmpeg per frame only to be interrupted back out again. */
+	if (context->abort_io || context->open_failed) {
+		return SWITCH_STATUS_FALSE;
+	}
+
 	if (!switch_test_flag(handle, SWITCH_FILE_FLAG_VIDEO)) {
 		return SWITCH_STATUS_FALSE;
 	}
@@ -3775,6 +3839,8 @@ static switch_status_t load_config(void)
 				avformat_globals.max_rw_timeout_us = parse_timeout_ms_to_us(var, val);
 			} else if (!strcasecmp(var, "network-connect-timeout")) {
 				avformat_globals.connect_timeout_us = parse_timeout_ms_to_us(var, val);
+			} else if (!strcasecmp(var, "network-async-open")) {
+				avformat_globals.network_async_open = switch_true(val) ? SWITCH_TRUE : SWITCH_FALSE;
 			}
 		}
 	}

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -600,9 +600,15 @@ static switch_status_t open_output_avio(av_file_context_t *context, const char *
 	 * their own deadline. */
 	io_deadline_arm(context, context->io_connect_timeout_us);
 
-	/* Always via avio_open2, even with no timeout configured: it installs the interrupt
-	 * callback, without which a close cannot abort an open in flight. */
-	ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE, &cb, &dict);
+	/* Install the interrupt callback only where it can help -- a network peer that may
+	 * never answer, or a caller who asked for a timeout.  It must NOT go on a plain
+	 * local file: interrupt_cb reports context->closed, av_file_close() sets that before
+	 * it flushes and writes the trailer, and ffmpeg checks the callback on every
+	 * transfer including the file protocol.  The flush would then abort and the file be
+	 * left without its trailer -- for mp4, no moov atom and nothing can play it.
+	 * Upstream passed no callback here, and for local files that is still right. */
+	ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE,
+					 (context->io_is_network || !zstr(context->rw_timeout)) ? &cb : NULL, &dict);
 
 	io_deadline_disarm(context);
 
@@ -699,12 +705,10 @@ static int write_frame(av_file_context_t *context, AVFormatContext *fmt_ctx, con
 	/* Write the compressed frame to the media file. */
 	log_packet(fmt_ctx, pkt);
 
-	/* Only bound the write when this is the sole writer.  With video present the video
-	 * thread writes to this same muxer under a *different* mutex (eh.mutex vs mutex), so
-	 * a context-wide deadline would be armed and disarmed by both threads; rather than
-	 * ship a bound that silently races, leave video outputs to ffmpeg's own rw_timeout,
-	 * which is still set on the handle. */
-	io_deadline_arm(context, context->has_video ? 0 : context->io_write_timeout_us);
+	/* Safe to arm even with video present: the recording path points eh.mutex at the
+	 * same mutex the audio path uses (av_file_write_video), so the two writers are
+	 * serialised here and the deadline cannot be armed by one while the other holds it. */
+	io_deadline_arm(context, context->io_write_timeout_us);
 	ret = av_interleaved_write_frame(fmt_ctx, pkt);
 	io_deadline_disarm(context);
 
@@ -3030,6 +3034,15 @@ GCC_DIAG_ON(deprecated-declarations)
 
 				if (ret < 0) {
 					context->errs++;
+
+					/* A write that we aborted ourselves -- deadline or explicit abort --
+					 * is not going to recover, and the error code is AVERROR_EXIT rather
+					 * than one of the connection errors checked below.  Fail now instead
+					 * of reporting success for another thousand frames. */
+					if (context->io_timed_out || context->abort_io) {
+						context->errs = 1001;
+					}
+
 					if ((context->errs % 10) == 0) {
 						char ebuf[255] = "";
 
@@ -3077,6 +3090,15 @@ GCC_DIAG_ON(deprecated-declarations)
 
 				if (ret < 0) {
 					context->errs++;
+
+					/* A write that we aborted ourselves -- deadline or explicit abort --
+					 * is not going to recover, and the error code is AVERROR_EXIT rather
+					 * than one of the connection errors checked below.  Fail now instead
+					 * of reporting success for another thousand frames. */
+					if (context->io_timed_out || context->abort_io) {
+						context->errs = 1001;
+					}
+
 					if ((context->errs % 10) == 0) {
 						char ebuf[255] = "";
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "[%s] Error while writing audio frame: %s\n", 
@@ -3136,7 +3158,15 @@ static switch_status_t av_file_command(switch_file_handle_t *handle, switch_file
 	case SCFC_ABORT_IO:
 		/* Deliberately not context->closed: that flag also drives read and video-ready
 		 * logic elsewhere in this file.  interrupt_cb picks this up from whichever
-		 * thread is currently blocked inside ffmpeg. */
+		 * thread is currently blocked inside ffmpeg.
+		 *
+		 * Applies to local handles as well as network ones, which looks at odds with
+		 * leaving local writes unbounded elsewhere -- but those are deadlines we impose
+		 * on a healthy write, whereas this is an explicit last-resort abort the caller
+		 * only reaches once the write has stopped making progress.  Refusing it for
+		 * local files would leave a genuinely hung write (a wedged disk or NFS mount)
+		 * with nothing to interrupt it, and the caller waiting on it forever: losing the
+		 * file is the better trade against wedging the channel. */
 		context->abort_io = 1;
 		/* DEBUG, not WARNING: whoever asked for the abort is expected to say why, and
 		 * during a recorder stall this would otherwise double every such report. */
@@ -3209,7 +3239,11 @@ static switch_status_t av_file_close(switch_file_handle_t *handle)
 	}
 
 	if (context->fc) {
-		if ((context->aud_ready || context->has_video) && switch_test_flag(handle, SWITCH_FILE_FLAG_WRITE)) {
+		/* pb is NULL when the output was never opened -- a deferred connect that failed
+		 * leaves has_video already set from the stream setup that preceded it, so the
+		 * flags alone are not enough to conclude there is anything to finalise. */
+		if ((context->aud_ready || context->has_video) && switch_test_flag(handle, SWITCH_FILE_FLAG_WRITE) &&
+			(context->fc->pb || (context->fc->oformat && (context->fc->oformat->flags & AVFMT_NOFILE)))) {
 			av_write_trailer(context->fc);
 		}
 

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -87,9 +87,9 @@ GCC_DIAG_ON(deprecated-declarations)
 
 struct avformat_globals {
 	enum AVColorSpace colorspace;
-	/* Timeouts for network outputs (rtmp/rtmps/rtsp/youtube), in microseconds to match
-	 * ffmpeg's own units; configured in milliseconds.  0 disables, preserving the
-	 * historical behaviour of an unbounded blocking open/write. */
+	/* Timeouts for RTMP outputs (rtmp/rtmps/youtube), in microseconds to match ffmpeg's
+	 * own units; configured in milliseconds.  0 disables, preserving the historical
+	 * behaviour of an unbounded blocking open/write. */
 	int64_t default_rw_timeout_us;
 	int64_t max_rw_timeout_us;
 	int64_t connect_timeout_us;
@@ -188,10 +188,20 @@ struct av_file_context {
 	/* Microseconds, not milliseconds: switch_time_now()/1000 overflows 32 bits. */
 	switch_time_t connect_start_time;
 	const char *rw_timeout;
-	/* Absolute deadline (switch_time_now units) for the I/O currently in flight;
-	 * 0 means no deadline.  Read by interrupt_cb from inside ffmpeg. */
+	/* Absolute deadline (monotonic microseconds) for the I/O currently in flight;
+	 * 0 means no deadline.  Read by interrupt_cb from inside ffmpeg.  Only ever armed
+	 * by the thread performing that I/O, so it needs no lock of its own. */
 	switch_time_t io_deadline;
 	int io_timed_out;
+	int io_timeout_logged;
+	/* Resolved once at open, so the write path does not have to re-derive them. */
+	switch_bool_t io_is_network;
+	int64_t io_write_timeout_us;
+	int64_t io_connect_timeout_us;
+	int64_t io_armed_timeout_us;
+	/* Option string handed to ffmpeg, and the storage it may point at. */
+	const char *rw_timeout_opt;
+	char rw_timeout_buf[32];
 
 	switch_bool_t no_video_decode;
 	switch_queue_t *video_pkt_queue;
@@ -519,15 +529,81 @@ error:
 	return ret;
 }
 
-static int write_frame(AVFormatContext *fmt_ctx, const AVRational *time_base, AVStream *st, AVPacket *pkt)
+/* Arm the deadline that interrupt_cb enforces for the call about to be made.  Only
+ * network outputs get one: aborting a local file write would corrupt an otherwise
+ * healthy recording to no purpose, since a slow disk is not a stuck peer. */
+static void io_deadline_arm(av_file_context_t *context, int64_t timeout_us)
 {
+	context->io_timed_out = 0;
+	context->io_armed_timeout_us = timeout_us;
+
+	if (context->io_is_network && timeout_us > 0) {
+		context->io_deadline = switch_mono_micro_time_now() + timeout_us;
+	} else {
+		context->io_deadline = 0;
+	}
+}
+
+static void io_deadline_disarm(av_file_context_t *context)
+{
+	context->io_deadline = 0;
+}
+
+/* Report the first timeout on a handle and stay quiet afterwards: once a recorder
+ * stalls every subsequent frame would repeat the same line. */
+static void io_deadline_report(av_file_context_t *context, const char *what)
+{
+	if (!context->io_timed_out || context->io_timeout_logged) {
+		return;
+	}
+
+	context->io_timeout_logged = 1;
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+					  "Timed out after %lldms during %s on '%s'; the recording will be stopped\n",
+					  (long long) (context->io_armed_timeout_us / 1000), what,
+					  context->handle && context->handle->file_path ? context->handle->file_path : "(unknown)");
+}
+
+/* The header goes out over the connection avio_open2 already established, so it carries
+ * the ordinary write budget, falling back to the connect budget when only that is set. */
+static int write_header_with_deadline(av_file_context_t *context)
+{
+	int64_t timeout_us = context->io_write_timeout_us ? context->io_write_timeout_us : context->io_connect_timeout_us;
+	int ret;
+
+	io_deadline_arm(context, timeout_us);
+	ret = avformat_write_header(context->fc, NULL);
+	io_deadline_disarm(context);
+
+	io_deadline_report(context, "the header write");
+
+	return ret;
+}
+
+static int write_frame(av_file_context_t *context, AVFormatContext *fmt_ctx, const AVRational *time_base, AVStream *st, AVPacket *pkt)
+{
+	int ret;
+
 	/* rescale output packet timestamp values from codec to stream timebase */
 	av_packet_rescale_ts(pkt, *time_base, st->time_base);
 	pkt->stream_index = st->index;
 
 	/* Write the compressed frame to the media file. */
 	log_packet(fmt_ctx, pkt);
-	return av_interleaved_write_frame(fmt_ctx, pkt);
+
+	/* Only bound the write when this is the sole writer.  With video present the video
+	 * thread writes to this same muxer under a *different* mutex (eh.mutex vs mutex), so
+	 * a context-wide deadline would be armed and disarmed by both threads; rather than
+	 * ship a bound that silently races, leave video outputs to ffmpeg's own rw_timeout,
+	 * which is still set on the handle. */
+	io_deadline_arm(context, context->has_video ? 0 : context->io_write_timeout_us);
+	ret = av_interleaved_write_frame(fmt_ctx, pkt);
+	io_deadline_disarm(context);
+
+	io_deadline_report(context, "a frame write");
+
+	return ret;
 }
 
 /* Add an output stream. */
@@ -1160,7 +1236,7 @@ GCC_DIAG_ON(deprecated-declarations)
 #endif
 
 			switch_mutex_lock(context->eh.mutex);
-			write_frame(context->eh.fc, &c->time_base, context->eh.video_st->st, pkt);
+			write_frame(context, context->eh.fc, &c->time_base, context->eh.video_st->st, pkt);
 			switch_mutex_unlock(context->eh.mutex);
 		}
 
@@ -1221,9 +1297,9 @@ GCC_DIAG_ON(deprecated-declarations)
 #endif
 			switch_mutex_lock(context->eh.mutex);
 #if (LIBAVCODEC_VERSION_MAJOR < LIBAVCODEC_V)
-			ret = write_frame(context->eh.fc, &c->time_base, context->eh.video_st->st, pkt);
+			ret = write_frame(context, context->eh.fc, &c->time_base, context->eh.video_st->st, pkt);
 #else
-			wret = write_frame(context->eh.fc, &c->time_base, context->eh.video_st->st, pkt);
+			wret = write_frame(context, context->eh.fc, &c->time_base, context->eh.video_st->st, pkt);
 #endif
 			switch_mutex_unlock(context->eh.mutex);
 #if (LIBAVCODEC_VERSION_MAJOR < LIBAVCODEC_V)
@@ -2169,7 +2245,11 @@ static switch_bool_t parse_int64_strict(const char *str, int64_t *out)
 	return SWITCH_TRUE;
 }
 
-/* Network outputs are the ones that can block on an unreachable or overloaded peer. */
+/* RTMP outputs are the ones that can block on an unreachable or overloaded recorder.
+ * "youtube" is included because it is RTMP too: it builds an rtmp:// URL and uses the
+ * flv muxer.  RTSP is deliberately excluded -- its muxer is AVFMT_NOFILE and connects
+ * from a different place, and we have no recording traffic on it to justify changing
+ * that path.  Covering it is a follow-up, not a prerequisite. */
 static switch_bool_t is_network_stream_name(const char *stream_name)
 {
 	if (zstr(stream_name)) {
@@ -2177,7 +2257,7 @@ static switch_bool_t is_network_stream_name(const char *stream_name)
 	}
 
 	return (!strcasecmp(stream_name, "rtmp") || !strcasecmp(stream_name, "rtmps") ||
-			!strcasecmp(stream_name, "rtsp") || !strcasecmp(stream_name, "youtube")) ? SWITCH_TRUE : SWITCH_FALSE;
+			!strcasecmp(stream_name, "youtube")) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
 static switch_status_t av_file_open(switch_file_handle_t *handle, const char *path)
@@ -2371,16 +2451,15 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		switch_clear_flag(handle, SWITCH_FILE_FLAG_VIDEO);
 	}
 
-	/* open the output file, if needed */
-	if (!(fmt->flags & AVFMT_NOFILE)) {
-		switch_bool_t is_network = is_network_stream_name(handle->stream_name);
-		int64_t connect_timeout_us = is_network ? avformat_globals.connect_timeout_us : 0;
-		const char *rw_timeout_opt = NULL;
-		char rw_timeout_buf[32] = "";
-		AVIOInterruptCB cb = {
-			.callback = interrupt_cb,
-			.opaque = context,
-		};
+	/* Resolve the timeouts before the AVFMT_NOFILE split: muxers that open no file of
+	 * their own (rtsp) still establish their session inside the header write, and the
+	 * write path needs these regardless of which branch opens the connection. */
+	{
+		const char *rw_timeout_opt_resolved = NULL;
+		int64_t effective_rw_us = 0;
+
+		context->io_is_network = is_network_stream_name(handle->stream_name);
+		context->io_connect_timeout_us = context->io_is_network ? avformat_globals.connect_timeout_us : 0;
 
 		/* A caller-supplied rw_timeout still wins, and is passed through verbatim so
 		 * ffmpeg's own suffixed forms ("5M") keep working; it is only rewritten when we
@@ -2389,10 +2468,15 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		if (!zstr(context->rw_timeout)) {
 			int64_t caller_us = 0;
 
-			rw_timeout_opt = context->rw_timeout;
+			rw_timeout_opt_resolved = context->rw_timeout;
 
 			if (!parse_int64_strict(context->rw_timeout, &caller_us)) {
-				if (is_network && avformat_globals.max_rw_timeout_us) {
+				/* Unparseable here only means we cannot reason about it ourselves;
+				 * ffmpeg may still understand it, so hand it over untouched and fall
+				 * back to the configured default for our own deadlines. */
+				effective_rw_us = avformat_globals.default_rw_timeout_us;
+
+				if (context->io_is_network && avformat_globals.max_rw_timeout_us) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
 									  "rw_timeout '%s' is not a plain integer; passing it through unclamped for '%s'\n",
 									  context->rw_timeout, file);
@@ -2400,20 +2484,39 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 			} else if (caller_us <= 0) {
 				/* Explicit 0/negative means "no timeout"; treat it as unset so a
 				 * configured default can still protect a network output. */
-				rw_timeout_opt = NULL;
-			} else if (is_network && avformat_globals.max_rw_timeout_us && caller_us > avformat_globals.max_rw_timeout_us) {
+				rw_timeout_opt_resolved = NULL;
+			} else if (context->io_is_network && avformat_globals.max_rw_timeout_us && caller_us > avformat_globals.max_rw_timeout_us) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
 								  "Clamping rw_timeout %lldus to configured maximum %lldus for '%s'\n",
 								  (long long) caller_us, (long long) avformat_globals.max_rw_timeout_us, file);
-				switch_snprintf(rw_timeout_buf, sizeof(rw_timeout_buf), "%lld", (long long) avformat_globals.max_rw_timeout_us);
-				rw_timeout_opt = rw_timeout_buf;
+				switch_snprintf(context->rw_timeout_buf, sizeof(context->rw_timeout_buf), "%lld",
+								(long long) avformat_globals.max_rw_timeout_us);
+				rw_timeout_opt_resolved = context->rw_timeout_buf;
+				effective_rw_us = avformat_globals.max_rw_timeout_us;
+			} else {
+				effective_rw_us = caller_us;
 			}
 		}
 
-		if (!rw_timeout_opt && is_network && avformat_globals.default_rw_timeout_us > 0) {
-			switch_snprintf(rw_timeout_buf, sizeof(rw_timeout_buf), "%lld", (long long) avformat_globals.default_rw_timeout_us);
-			rw_timeout_opt = rw_timeout_buf;
+		if (!rw_timeout_opt_resolved && context->io_is_network && avformat_globals.default_rw_timeout_us > 0) {
+			switch_snprintf(context->rw_timeout_buf, sizeof(context->rw_timeout_buf), "%lld",
+							(long long) avformat_globals.default_rw_timeout_us);
+			rw_timeout_opt_resolved = context->rw_timeout_buf;
+			effective_rw_us = avformat_globals.default_rw_timeout_us;
 		}
+
+		context->io_write_timeout_us = effective_rw_us;
+		context->rw_timeout_opt = rw_timeout_opt_resolved;
+	}
+
+	/* open the output file, if needed */
+	if (!(fmt->flags & AVFMT_NOFILE)) {
+		int64_t connect_timeout_us = context->io_connect_timeout_us;
+		const char *rw_timeout_opt = context->rw_timeout_opt;
+		AVIOInterruptCB cb = {
+			.callback = interrupt_cb,
+			.opaque = context,
+		};
 
 		if (rw_timeout_opt) {
 			av_dict_set(&dict, "rw_timeout", rw_timeout_opt, 0);
@@ -2423,23 +2526,17 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		 * reach, which would restore the very hang this exists to prevent. */
 		context->connect_start_time = switch_mono_micro_time_now();
 
-		/* Cleared before arming, not after the call: the error path below reads it to
-		 * tell a timeout apart from an ordinary failure. */
-		context->io_timed_out = 0;
-
 		/* ffmpeg's own rw_timeout does not reliably bound the connect and handshake
 		 * across protocols and versions, so enforce the connect budget ourselves via the
-		 * interrupt callback.  Cleared once open returns; bounding the writes that follow
-		 * is handled separately. */
-		if (connect_timeout_us > 0) {
-			context->io_deadline = context->connect_start_time + connect_timeout_us;
-		}
+		 * interrupt callback.  Disarmed once open returns: the writes that follow carry
+		 * their own deadline. */
+		io_deadline_arm(context, connect_timeout_us);
 
 		/* Always via avio_open2, even with no timeout configured: it installs the
 		 * interrupt callback, without which a close cannot abort an open in flight. */
 		ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE, &cb, &dict);
 
-		context->io_deadline = 0;
+		io_deadline_disarm(context);
 
 		/* Options left in the dict after a *successful* open were not recognised by this
 		 * ffmpeg build for this protocol -- i.e. the timeout we asked for is not actually
@@ -2687,7 +2784,7 @@ static switch_status_t av_file_write(switch_file_handle_t *handle, void *data, s
 			switch_buffer_zero(context->audio_buffer);
 			return status;
 		} else if (!context->aud_ready) { // audio only recording
-			int ret = avformat_write_header(context->fc, NULL);
+			int ret = write_header_with_deadline(context);
 			if (ret < 0) {
 				char ebuf[255] = "";
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error occurred when opening output file: %s\n", get_error_text(ret, ebuf, sizeof(ebuf)));
@@ -2862,7 +2959,7 @@ GCC_DIAG_ON(deprecated-declarations)
 
 				if (context->mutex) switch_mutex_lock(context->mutex);
 
-				ret = write_frame(context->fc, &c->time_base, context->audio_st[j].st, pkt[j]);
+				ret = write_frame(context, context->fc, &c->time_base, context->audio_st[j].st, pkt[j]);
 
 				if (context->mutex) switch_mutex_unlock(context->mutex);
 
@@ -2909,7 +3006,7 @@ GCC_DIAG_ON(deprecated-declarations)
 					continue;
 				}
 
-				ret = write_frame(context->fc, &c->time_base, context->audio_st[j].st, pkt[j]);
+				ret = write_frame(context, context->fc, &c->time_base, context->audio_st[j].st, pkt[j]);
 
 				if (context->mutex) switch_mutex_unlock(context->mutex);
 
@@ -3521,7 +3618,7 @@ static switch_status_t av_file_write_video(switch_file_handle_t *handle, switch_
 
 			// av_dump_format(context->fc, 0, "/tmp/av.mp4", 1);
 
-			ret = avformat_write_header(context->fc, NULL);
+			ret = write_header_with_deadline(context);
 			if (ret < 0) {
 				char ebuf[255] = "";
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error occurred when opening output file: %s\n", get_error_text(ret, ebuf, sizeof(ebuf)));

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -200,6 +200,8 @@ struct av_file_context {
 	 * and read by interrupt_cb on whichever thread is blocked inside ffmpeg -- so it
 	 * is atomic rather than a plain int, which the reader may cache. */
 	switch_atomic_t abort_io;
+	/* Redacted form of the target, safe to log; see switch_redact_file_target(). */
+	const char *log_target;
 	/* Connect postponed to the writer thread; deferred_file is what to connect to. */
 	int deferred_open;
 	int open_failed;
@@ -572,7 +574,7 @@ static void io_deadline_report(av_file_context_t *context, const char *what)
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
 					  "Timed out after %lldms during %s on '%s'; the recording will be stopped\n",
 					  (long long) (context->io_armed_timeout_us / 1000), what,
-					  context->handle && context->handle->file_path ? context->handle->file_path : "(unknown)");
+					  context->log_target ? context->log_target : "(unknown)");
 }
 
 /* Establish the output connection, arming the connect deadline around it.  Called from
@@ -624,7 +626,7 @@ static switch_status_t open_output_avio(av_file_context_t *context, const char *
 		while ((unused = av_dict_get(dict, "", unused, AV_DICT_IGNORE_SUFFIX))) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
 							  "Option '%s' not honoured by this ffmpeg build for '%s'; that timeout is NOT in force\n",
-							  unused->key, file);
+							  unused->key, context->log_target);
 		}
 	}
 
@@ -636,10 +638,10 @@ static switch_status_t open_output_avio(av_file_context_t *context, const char *
 		if (context->io_timed_out) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
 							  "Could not open '%s': timed out after %lldms (connect timeout %lldms)\n",
-							  file, (long long) ((switch_mono_micro_time_now() - context->connect_start_time) / 1000),
+							  context->log_target, (long long) ((switch_mono_micro_time_now() - context->connect_start_time) / 1000),
 							  (long long) (context->io_connect_timeout_us / 1000));
 		} else {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", context->log_target, get_error_text(ret, ebuf, sizeof(ebuf)));
 		}
 
 		return SWITCH_STATUS_GENERR;
@@ -2500,6 +2502,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 #endif
 	const char *format = NULL;
 	char file[1024];
+	char safe_file[512];
 	int disable_write_buffer = 0;
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 
@@ -2553,6 +2556,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 	context->handle = handle;
 	context->audio_timer = 1;
 	context->colorspace = avformat_globals.colorspace;
+	context->log_target = switch_core_strdup(handle->memory_pool, switch_redact_file_target(file, safe_file, sizeof(safe_file)));
 	
 	if (handle->params) {
 		if ((tmp = switch_event_get_header(handle->params, "av_video_offset"))) {
@@ -2705,7 +2709,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 				if (context->io_is_network && net.max_rw_timeout_us) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
 									  "rw_timeout '%s' is not a plain integer; passing it through unclamped for '%s'\n",
-									  context->rw_timeout, file);
+									  context->rw_timeout, context->log_target);
 				}
 			} else if (caller_us <= 0) {
 				/* Explicit 0/negative means "no timeout"; treat it as unset so a
@@ -2714,7 +2718,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 			} else if (context->io_is_network && net.max_rw_timeout_us && caller_us > net.max_rw_timeout_us) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
 								  "Clamping rw_timeout %lldus to configured maximum %lldus for '%s'\n",
-								  (long long) caller_us, (long long) net.max_rw_timeout_us, file);
+								  (long long) caller_us, (long long) net.max_rw_timeout_us, context->log_target);
 				switch_snprintf(context->rw_timeout_buf, sizeof(context->rw_timeout_buf), "%lld",
 								(long long) net.max_rw_timeout_us);
 				rw_timeout_opt_resolved = context->rw_timeout_buf;
@@ -2748,7 +2752,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 			context->deferred_file = switch_core_strdup(handle->memory_pool, file);
 
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
-							  "Deferring connect for '%s' to the writer thread\n", file);
+							  "Deferring connect for '%s' to the writer thread\n", context->log_target);
 		} else if (open_output_avio(context, file) != SWITCH_STATUS_SUCCESS) {
 			switch_goto_status(SWITCH_STATUS_GENERR, end);
 		}
@@ -3288,7 +3292,7 @@ static switch_status_t av_file_command(switch_file_handle_t *handle, switch_file
 		/* DEBUG, not WARNING: whoever asked for the abort is expected to say why, and
 		 * during a recorder stall this would otherwise double every such report. */
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Aborting I/O on %s\n",
-						  handle->file_path ? handle->file_path : "(unknown)");
+						  context->log_target ? context->log_target : "(unknown)");
 		break;
 	case SCFC_RESUME_WRITE:
 		if (context->eh.record_timer_paused) {

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -194,6 +194,8 @@ struct av_file_context {
 	switch_time_t io_deadline;
 	int io_timed_out;
 	int io_timeout_logged;
+	/* Set from another thread via SCFC_ABORT_IO to break out of a blocked read/write. */
+	int abort_io;
 	/* Resolved once at open, so the write path does not have to re-derive them. */
 	switch_bool_t io_is_network;
 	int64_t io_write_timeout_us;
@@ -442,7 +444,7 @@ static int interrupt_cb(void *cp)
 		return 0;
 	}
 
-	if (context->closed) {
+	if (context->closed || context->abort_io) {
 		return 1;
 	}
 
@@ -2775,6 +2777,11 @@ static switch_status_t av_file_write(switch_file_handle_t *handle, void *data, s
 		return SWITCH_STATUS_FALSE;
 	}
 
+	/* Once aborted, fail fast rather than blocking again on the same dead peer. */
+	if (context->abort_io) {
+		return SWITCH_STATUS_FALSE;
+	}
+
 	if (!context->has_audio) {
 		return SWITCH_STATUS_SUCCESS;
 	}
@@ -3067,6 +3074,16 @@ static switch_status_t av_file_command(switch_file_handle_t *handle, switch_file
 		context->vid_ready = 0;
 		context->eh.record_timer_paused = switch_micro_time_now();
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s pause write\n", handle->file_path);
+		break;
+	case SCFC_ABORT_IO:
+		/* Deliberately not context->closed: that flag also drives read and video-ready
+		 * logic elsewhere in this file.  interrupt_cb picks this up from whichever
+		 * thread is currently blocked inside ffmpeg. */
+		context->abort_io = 1;
+		/* DEBUG, not WARNING: whoever asked for the abort is expected to say why, and
+		 * during a recorder stall this would otherwise double every such report. */
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Aborting I/O on %s\n",
+						  handle->file_path ? handle->file_path : "(unknown)");
 		break;
 	case SCFC_RESUME_WRITE:
 		if (context->eh.record_timer_paused) {

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -82,6 +82,9 @@ GCC_DIAG_ON(deprecated-declarations)
 #define AV_CODEC_CAP_VARIABLE_FRAME_SIZE CODEC_CAP_VARIABLE_FRAME_SIZE
 #endif
 
+/* 24h: far beyond any sane recording timeout, and keeps ms*1000 clear of int64 overflow. */
+#define AVFORMAT_MAX_TIMEOUT_MS 86400000
+
 struct avformat_globals {
 	enum AVColorSpace colorspace;
 	/* Timeouts for network outputs (rtmp/rtmps/rtsp/youtube), in microseconds to match
@@ -182,9 +185,14 @@ struct av_file_context {
 	switch_time_t last_vid_write;
 	int audio_timer;
 
-	unsigned int connect_start_time;
+	/* Microseconds, not milliseconds: switch_time_now()/1000 overflows 32 bits. */
+	switch_time_t connect_start_time;
 	const char *rw_timeout;
-	
+	/* Absolute deadline (switch_time_now units) for the I/O currently in flight;
+	 * 0 means no deadline.  Read by interrupt_cb from inside ffmpeg. */
+	switch_time_t io_deadline;
+	int io_timed_out;
+
 	switch_bool_t no_video_decode;
 	switch_queue_t *video_pkt_queue;
 	switch_packetizer_t *packetizer;
@@ -413,11 +421,23 @@ static void log_packet(const AVFormatContext *fmt_ctx, const AVPacket *pkt)
 	}
 }
 
+/* Called by ffmpeg from inside its blocking I/O loops.  Returns non-zero to abort the
+ * operation in flight, either because the handle is closing or because the operation has
+ * outlived its deadline.  Keep it allocation- and log-free: ffmpeg polls it frequently. */
 static int interrupt_cb(void *cp)
 {
 	av_file_context_t *context = (av_file_context_t *) cp;
 
+	if (!context) {
+		return 0;
+	}
+
 	if (context->closed) {
+		return 1;
+	}
+
+	if (context->io_deadline && switch_mono_micro_time_now() >= context->io_deadline) {
+		context->io_timed_out = 1;
 		return 1;
 	}
 
@@ -2115,16 +2135,50 @@ GCC_DIAG_ON(deprecated-declarations)
 	return NULL;
 }
 
-static int avio_interrupt_cb(void *ctx) 
-{ 
-	av_file_context_t* context = (av_file_context_t*)ctx;
-	
-	if (context == NULL) {
-		return 0;
-	} else {
-		return context->closed;
+/* Strict integer parse: only an optional sign followed by digits is accepted, so a typo
+ * such as "2s" is rejected outright rather than silently becoming 2.  Deliberately does
+ * NOT understand ffmpeg's suffixed forms ("5M"); callers pass those through untouched. */
+static switch_bool_t parse_int64_strict(const char *str, int64_t *out)
+{
+	const char *p = str;
+	size_t digits = 0;
+
+	if (zstr(str)) {
+		return SWITCH_FALSE;
 	}
-} 
+
+	if (*p == '-' || *p == '+') {
+		p++;
+	}
+
+	for (; *p; p++) {
+		if (*p < '0' || *p > '9') {
+			return SWITCH_FALSE;
+		}
+
+		digits++;
+	}
+
+	/* Well inside int64 range; also rejects absurd input without needing errno. */
+	if (!digits || digits > 18) {
+		return SWITCH_FALSE;
+	}
+
+	*out = (int64_t) strtoll(str, NULL, 10);
+
+	return SWITCH_TRUE;
+}
+
+/* Network outputs are the ones that can block on an unreachable or overloaded peer. */
+static switch_bool_t is_network_stream_name(const char *stream_name)
+{
+	if (zstr(stream_name)) {
+		return SWITCH_FALSE;
+	}
+
+	return (!strcasecmp(stream_name, "rtmp") || !strcasecmp(stream_name, "rtmps") ||
+			!strcasecmp(stream_name, "rtsp") || !strcasecmp(stream_name, "youtube")) ? SWITCH_TRUE : SWITCH_FALSE;
+}
 
 static switch_status_t av_file_open(switch_file_handle_t *handle, const char *path)
 {
@@ -2319,22 +2373,103 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 
 	/* open the output file, if needed */
 	if (!(fmt->flags & AVFMT_NOFILE)) {
+		switch_bool_t is_network = is_network_stream_name(handle->stream_name);
+		int64_t connect_timeout_us = is_network ? avformat_globals.connect_timeout_us : 0;
+		const char *rw_timeout_opt = NULL;
+		char rw_timeout_buf[32] = "";
+		AVIOInterruptCB cb = {
+			.callback = interrupt_cb,
+			.opaque = context,
+		};
+
+		/* A caller-supplied rw_timeout still wins, and is passed through verbatim so
+		 * ffmpeg's own suffixed forms ("5M") keep working; it is only rewritten when we
+		 * clamp it.  Clamp and default both apply to network outputs only -- a local file
+		 * must keep blocking semantics, since a slow disk write is not a stuck peer. */
 		if (!zstr(context->rw_timeout)) {
-			AVIOInterruptCB cb = {
-				.callback = avio_interrupt_cb,
-				.opaque = context,
-			};
-			
-			av_dict_set(&dict, "rw_timeout", context->rw_timeout, 0);
-			context->connect_start_time = switch_time_now() / 1000;
-			ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE, &cb, &dict);
-		} else {
-			ret = avio_open(&context->fc->pb, file, AVIO_FLAG_WRITE);
+			int64_t caller_us = 0;
+
+			rw_timeout_opt = context->rw_timeout;
+
+			if (!parse_int64_strict(context->rw_timeout, &caller_us)) {
+				if (is_network && avformat_globals.max_rw_timeout_us) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+									  "rw_timeout '%s' is not a plain integer; passing it through unclamped for '%s'\n",
+									  context->rw_timeout, file);
+				}
+			} else if (caller_us <= 0) {
+				/* Explicit 0/negative means "no timeout"; treat it as unset so a
+				 * configured default can still protect a network output. */
+				rw_timeout_opt = NULL;
+			} else if (is_network && avformat_globals.max_rw_timeout_us && caller_us > avformat_globals.max_rw_timeout_us) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+								  "Clamping rw_timeout %lldus to configured maximum %lldus for '%s'\n",
+								  (long long) caller_us, (long long) avformat_globals.max_rw_timeout_us, file);
+				switch_snprintf(rw_timeout_buf, sizeof(rw_timeout_buf), "%lld", (long long) avformat_globals.max_rw_timeout_us);
+				rw_timeout_opt = rw_timeout_buf;
+			}
 		}
+
+		if (!rw_timeout_opt && is_network && avformat_globals.default_rw_timeout_us > 0) {
+			switch_snprintf(rw_timeout_buf, sizeof(rw_timeout_buf), "%lld", (long long) avformat_globals.default_rw_timeout_us);
+			rw_timeout_opt = rw_timeout_buf;
+		}
+
+		if (rw_timeout_opt) {
+			av_dict_set(&dict, "rw_timeout", rw_timeout_opt, 0);
+		}
+
+		/* Monotonic: a realtime step (NTP, operator) must not extend the deadline out of
+		 * reach, which would restore the very hang this exists to prevent. */
+		context->connect_start_time = switch_mono_micro_time_now();
+
+		/* Cleared before arming, not after the call: the error path below reads it to
+		 * tell a timeout apart from an ordinary failure. */
+		context->io_timed_out = 0;
+
+		/* ffmpeg's own rw_timeout does not reliably bound the connect and handshake
+		 * across protocols and versions, so enforce the connect budget ourselves via the
+		 * interrupt callback.  Cleared once open returns; bounding the writes that follow
+		 * is handled separately. */
+		if (connect_timeout_us > 0) {
+			context->io_deadline = context->connect_start_time + connect_timeout_us;
+		}
+
+		/* Always via avio_open2, even with no timeout configured: it installs the
+		 * interrupt callback, without which a close cannot abort an open in flight. */
+		ret = avio_open2(&context->fc->pb, file, AVIO_FLAG_WRITE, &cb, &dict);
+
+		context->io_deadline = 0;
+
+		/* Options left in the dict after a *successful* open were not recognised by this
+		 * ffmpeg build for this protocol -- i.e. the timeout we asked for is not actually
+		 * in force.  Say so rather than silently believing we are protected.  On failure
+		 * the dict may never have been consulted, so checking it would cry wolf. */
+		if (ret >= 0 && av_dict_count(dict) > 0) {
+			AVDictionaryEntry *unused = NULL;
+
+			while ((unused = av_dict_get(dict, "", unused, AV_DICT_IGNORE_SUFFIX))) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+								  "Option '%s' not honoured by this ffmpeg build for '%s'; that timeout is NOT in force\n",
+								  unused->key, file);
+			}
+		}
+
+		/* Freed here because the success path below returns before the end: label. */
+		av_dict_free(&dict);
 
 		if (ret < 0) {
 			char ebuf[255] = "";
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
+
+			if (context->io_timed_out) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+								  "Could not open '%s': timed out after %lldms (connect timeout %lldms)\n",
+								  file, (long long) ((switch_mono_micro_time_now() - context->connect_start_time) / 1000),
+								  (long long) (connect_timeout_us / 1000));
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Could not open '%s': %s\n", file, get_error_text(ret, ebuf, sizeof(ebuf)));
+			}
+
 			switch_goto_status(SWITCH_STATUS_GENERR, end);
 		}
 	} else {
@@ -3478,21 +3613,23 @@ static const char modname[] = "mod_av";
  * than the historical unbounded behaviour. */
 static int64_t parse_timeout_ms_to_us(const char *name, const char *val)
 {
-	int ms;
+	int64_t ms = 0;
 
 	if (zstr(val)) {
 		return 0;
 	}
 
-	ms = atoi(val);
-
-	if (ms < 0) {
+	/* Strict, so that "2s" is refused rather than read as 2ms -- a typo must not turn
+	 * into an aggressive timeout that fails every recording instantly.  The upper bound
+	 * keeps the conversion to microseconds clear of int64 overflow. */
+	if (!parse_int64_strict(val, &ms) || ms < 0 || ms > AVFORMAT_MAX_TIMEOUT_MS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-						  "Ignoring negative %s '%s', leaving it disabled\n", name, val);
+						  "Ignoring invalid %s '%s' (expected 0-%d milliseconds as a plain integer), leaving it disabled\n",
+						  name, val, AVFORMAT_MAX_TIMEOUT_MS);
 		return 0;
 	}
 
-	return (int64_t) ms * 1000;
+	return ms * 1000;
 }
 
 static switch_status_t load_config(void)

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -196,8 +196,10 @@ struct av_file_context {
 	switch_time_t io_deadline;
 	int io_timed_out;
 	int io_timeout_logged;
-	/* Set from another thread via SCFC_ABORT_IO to break out of a blocked read/write. */
-	int abort_io;
+	/* Set from another thread via SCFC_ABORT_IO to break out of a blocked read/write,
+	 * and read by interrupt_cb on whichever thread is blocked inside ffmpeg -- so it
+	 * is atomic rather than a plain int, which the reader may cache. */
+	switch_atomic_t abort_io;
 	/* Connect postponed to the writer thread; deferred_file is what to connect to. */
 	int deferred_open;
 	int open_failed;
@@ -450,7 +452,7 @@ static int interrupt_cb(void *cp)
 		return 0;
 	}
 
-	if (context->closed || context->abort_io) {
+	if (context->closed || switch_atomic_read(&context->abort_io)) {
 		return 1;
 	}
 
@@ -656,7 +658,7 @@ static switch_status_t ensure_output_open(av_file_context_t *context)
 
 	/* Never connect on the way out: av_file_close sets closed before flushing, and
 	 * dialling a recorder we are about to abandon would block the closing thread. */
-	if (context->closed || context->abort_io) {
+	if (context->closed || switch_atomic_read(&context->abort_io)) {
 		context->deferred_open = 0;
 		context->open_failed = 1;
 		return SWITCH_STATUS_FALSE;
@@ -2955,7 +2957,7 @@ static switch_status_t av_file_write(switch_file_handle_t *handle, void *data, s
 	/* Once aborted or failed to connect, fail fast rather than blocking again on the
 	 * same dead peer.  The caller turns this into a write error and stops the
 	 * recording, which is how a deferred connect failure surfaces. */
-	if (context->abort_io || context->open_failed) {
+	if (switch_atomic_read(&context->abort_io) || context->open_failed) {
 		return SWITCH_STATUS_FALSE;
 	}
 
@@ -3154,7 +3156,7 @@ GCC_DIAG_ON(deprecated-declarations)
 					 * is not going to recover, and the error code is AVERROR_EXIT rather
 					 * than one of the connection errors checked below.  Fail now instead
 					 * of reporting success for another thousand frames. */
-					if (context->io_timed_out || context->abort_io) {
+					if (context->io_timed_out || switch_atomic_read(&context->abort_io)) {
 						context->errs = 1001;
 					}
 
@@ -3210,7 +3212,7 @@ GCC_DIAG_ON(deprecated-declarations)
 					 * is not going to recover, and the error code is AVERROR_EXIT rather
 					 * than one of the connection errors checked below.  Fail now instead
 					 * of reporting success for another thousand frames. */
-					if (context->io_timed_out || context->abort_io) {
+					if (context->io_timed_out || switch_atomic_read(&context->abort_io)) {
 						context->errs = 1001;
 					}
 
@@ -3282,7 +3284,7 @@ static switch_status_t av_file_command(switch_file_handle_t *handle, switch_file
 		 * local files would leave a genuinely hung write (a wedged disk or NFS mount)
 		 * with nothing to interrupt it, and the caller waiting on it forever: losing the
 		 * file is the better trade against wedging the channel. */
-		context->abort_io = 1;
+		switch_atomic_set(&context->abort_io, 1);
 		/* DEBUG, not WARNING: whoever asked for the abort is expected to say why, and
 		 * during a recorder stall this would otherwise double every such report. */
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Aborting I/O on %s\n",
@@ -3817,7 +3819,7 @@ static switch_status_t av_file_write_video(switch_file_handle_t *handle, switch_
 
 	/* Same fast-fail as the audio path: once aborted or unable to connect, stop rather
 	 * than entering ffmpeg per frame only to be interrupted back out again. */
-	if (context->abort_io || context->open_failed) {
+	if (switch_atomic_read(&context->abort_io) || context->open_failed) {
 		return SWITCH_STATUS_FALSE;
 	}
 

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -2371,8 +2371,121 @@ static switch_bool_t is_network_stream_name(const char *stream_name)
 			!strcasecmp(stream_name, "youtube")) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
+/* Parse a millisecond timeout setting into microseconds.  Returns 0 (disabled) for
+ * anything unparseable or negative, so a bad config can never be more aggressive
+ * than the historical unbounded behaviour. */
+static int64_t parse_timeout_ms_to_us(const char *name, const char *val)
+{
+	int64_t ms = 0;
+
+	if (zstr(val)) {
+		return 0;
+	}
+
+	/* Strict, so that "2s" is refused rather than read as 2ms -- a typo must not turn
+	 * into an aggressive timeout that fails every recording instantly.  The upper bound
+	 * keeps the conversion to microseconds clear of int64 overflow. */
+	if (!parse_int64_strict(val, &ms) || ms < 0 || ms > AVFORMAT_MAX_TIMEOUT_MS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						  "Ignoring invalid %s '%s' (expected 0-%d milliseconds as a plain integer), leaving it disabled\n",
+						  name, val, AVFORMAT_MAX_TIMEOUT_MS);
+		return 0;
+	}
+
+	return ms * 1000;
+}
+
+/* The network settings actually in force for one file handle: the module config as a
+ * baseline, with per-recording overrides applied on top.  Resolved once at open. */
+struct avformat_net_settings {
+	int64_t default_rw_timeout_us;
+	int64_t max_rw_timeout_us;
+	int64_t connect_timeout_us;
+	switch_bool_t async_open;
+};
+
+/* Read one millisecond override out of the file params, if present.  The core injects
+ * these ahead of the caller's own brace block, and switch_event_create_brackets sets
+ * EF_UNIQ_HEADERS, so a value the caller wrote on the record command replaces the one
+ * derived from the channel variable.  Precedence therefore reads:
+ *
+ *     {} on the record command  >  channel variable  >  avformat.conf
+ *
+ * Note the unit split, which is not ours to fix: these are milliseconds, matching the
+ * config file, while the rw_timeout file param is microseconds, matching ffmpeg. */
+static switch_bool_t net_param_ms(switch_event_t *params, const char *name, int64_t *out)
+{
+	const char *val;
+
+	if (!params || zstr(val = switch_event_get_header(params, name))) {
+		return SWITCH_FALSE;
+	}
+
+	*out = parse_timeout_ms_to_us(name, val);
+
+	return SWITCH_TRUE;
+}
+
+static void resolve_net_settings(switch_file_handle_t *handle, struct avformat_net_settings *s)
+{
+	switch_event_t *params = handle ? handle->params : NULL;
+	const char *val;
+	int64_t ms_us = 0;
+
+	s->default_rw_timeout_us = avformat_globals.default_rw_timeout_us;
+	s->max_rw_timeout_us = avformat_globals.max_rw_timeout_us;
+	s->connect_timeout_us = avformat_globals.connect_timeout_us;
+	s->async_open = avformat_globals.network_async_open;
+
+	if (!params) {
+		return;
+	}
+
+	/* Master switch, checked first so one variable disables the whole feature for this
+	 * recording without having to unset each setting individually.  Unset leaves the
+	 * configured behaviour alone; it is not a way to force the feature on. */
+	if (!zstr(val = switch_event_get_header(params, "network_resiliency")) && switch_false(val)) {
+		s->default_rw_timeout_us = 0;
+		s->max_rw_timeout_us = 0;
+		s->connect_timeout_us = 0;
+		s->async_open = SWITCH_FALSE;
+
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+						  "Recorder resiliency disabled for this recording by network_resiliency=%s\n", val);
+		return;
+	}
+
+	if (net_param_ms(params, "network_connect_timeout", &ms_us)) {
+		s->connect_timeout_us = ms_us;
+	}
+
+	if (net_param_ms(params, "network_rw_timeout", &ms_us)) {
+		s->default_rw_timeout_us = ms_us;
+	}
+
+	/* The ceiling is the one setting a recording may only tighten.  It exists to stop an
+	 * over-generous caller-supplied rw_timeout from defeating the bound, so honouring a
+	 * looser per-recording value would hand back exactly the stall it prevents.  A
+	 * configured ceiling of 0 is no ceiling at all, so anything is a tightening. */
+	if (net_param_ms(params, "network_max_rw_timeout", &ms_us)) {
+		if (!s->max_rw_timeout_us || (ms_us && ms_us < s->max_rw_timeout_us)) {
+			s->max_rw_timeout_us = ms_us;
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "Ignoring network_max_rw_timeout %lldus for this recording: it would loosen the "
+							  "configured ceiling of %lldus, which may only be tightened\n",
+							  (long long) ms_us, (long long) s->max_rw_timeout_us);
+		}
+	}
+
+	if (!zstr(val = switch_event_get_header(params, "network_async_open"))) {
+		s->async_open = switch_true(val) ? SWITCH_TRUE : SWITCH_FALSE;
+	}
+}
+
 static switch_status_t av_file_open(switch_file_handle_t *handle, const char *path)
 {
+	struct avformat_net_settings net = { 0 };
 	av_file_context_t *context = NULL;
 	char *ext;
 	const char *tmp = NULL;
@@ -2567,8 +2680,10 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		const char *rw_timeout_opt_resolved = NULL;
 		int64_t effective_rw_us = 0;
 
+		resolve_net_settings(handle, &net);
+
 		context->io_is_network = is_network_stream_name(handle->stream_name);
-		context->io_connect_timeout_us = context->io_is_network ? avformat_globals.connect_timeout_us : 0;
+		context->io_connect_timeout_us = context->io_is_network ? net.connect_timeout_us : 0;
 
 		/* A caller-supplied rw_timeout still wins, and is passed through verbatim so
 		 * ffmpeg's own suffixed forms ("5M") keep working; it is only rewritten when we
@@ -2583,9 +2698,9 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 				/* Unparseable here only means we cannot reason about it ourselves;
 				 * ffmpeg may still understand it, so hand it over untouched and fall
 				 * back to the configured default for our own deadlines. */
-				effective_rw_us = avformat_globals.default_rw_timeout_us;
+				effective_rw_us = net.default_rw_timeout_us;
 
-				if (context->io_is_network && avformat_globals.max_rw_timeout_us) {
+				if (context->io_is_network && net.max_rw_timeout_us) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
 									  "rw_timeout '%s' is not a plain integer; passing it through unclamped for '%s'\n",
 									  context->rw_timeout, file);
@@ -2594,24 +2709,24 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 				/* Explicit 0/negative means "no timeout"; treat it as unset so a
 				 * configured default can still protect a network output. */
 				rw_timeout_opt_resolved = NULL;
-			} else if (context->io_is_network && avformat_globals.max_rw_timeout_us && caller_us > avformat_globals.max_rw_timeout_us) {
+			} else if (context->io_is_network && net.max_rw_timeout_us && caller_us > net.max_rw_timeout_us) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
 								  "Clamping rw_timeout %lldus to configured maximum %lldus for '%s'\n",
-								  (long long) caller_us, (long long) avformat_globals.max_rw_timeout_us, file);
+								  (long long) caller_us, (long long) net.max_rw_timeout_us, file);
 				switch_snprintf(context->rw_timeout_buf, sizeof(context->rw_timeout_buf), "%lld",
-								(long long) avformat_globals.max_rw_timeout_us);
+								(long long) net.max_rw_timeout_us);
 				rw_timeout_opt_resolved = context->rw_timeout_buf;
-				effective_rw_us = avformat_globals.max_rw_timeout_us;
+				effective_rw_us = net.max_rw_timeout_us;
 			} else {
 				effective_rw_us = caller_us;
 			}
 		}
 
-		if (!rw_timeout_opt_resolved && context->io_is_network && avformat_globals.default_rw_timeout_us > 0) {
+		if (!rw_timeout_opt_resolved && context->io_is_network && net.default_rw_timeout_us > 0) {
 			switch_snprintf(context->rw_timeout_buf, sizeof(context->rw_timeout_buf), "%lld",
-							(long long) avformat_globals.default_rw_timeout_us);
+							(long long) net.default_rw_timeout_us);
 			rw_timeout_opt_resolved = context->rw_timeout_buf;
-			effective_rw_us = avformat_globals.default_rw_timeout_us;
+			effective_rw_us = net.default_rw_timeout_us;
 		}
 
 		context->io_write_timeout_us = effective_rw_us;
@@ -2625,7 +2740,7 @@ static switch_status_t av_file_open(switch_file_handle_t *handle, const char *pa
 		 * thread called switch_core_file_open -- for a recording that is the session
 		 * thread, so an unresponsive recorder stops that call's media.  Deferring costs
 		 * nothing when the recorder is healthy and keeps audio flowing when it is not. */
-		if (context->io_is_network && avformat_globals.network_async_open &&
+		if (context->io_is_network && net.async_open &&
 			handle->params && switch_true(switch_event_get_header(handle->params, "writer_thread"))) {
 			context->deferred_open = 1;
 			context->deferred_file = switch_core_strdup(handle->memory_pool, file);
@@ -3819,30 +3934,6 @@ static switch_status_t av_file_get_string(switch_file_handle_t *handle, switch_a
 static char *supported_formats[SWITCH_MAX_CODECS] = { 0 };
 
 static const char modname[] = "mod_av";
-
-/* Parse a millisecond timeout setting into microseconds.  Returns 0 (disabled) for
- * anything unparseable or negative, so a bad config can never be more aggressive
- * than the historical unbounded behaviour. */
-static int64_t parse_timeout_ms_to_us(const char *name, const char *val)
-{
-	int64_t ms = 0;
-
-	if (zstr(val)) {
-		return 0;
-	}
-
-	/* Strict, so that "2s" is refused rather than read as 2ms -- a typo must not turn
-	 * into an aggressive timeout that fails every recording instantly.  The upper bound
-	 * keeps the conversion to microseconds clear of int64 overflow. */
-	if (!parse_int64_strict(val, &ms) || ms < 0 || ms > AVFORMAT_MAX_TIMEOUT_MS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-						  "Ignoring invalid %s '%s' (expected 0-%d milliseconds as a plain integer), leaving it disabled\n",
-						  name, val, AVFORMAT_MAX_TIMEOUT_MS);
-		return 0;
-	}
-
-	return ms * 1000;
-}
 
 static switch_status_t load_config(void)
 {

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -84,6 +84,12 @@ GCC_DIAG_ON(deprecated-declarations)
 
 struct avformat_globals {
 	enum AVColorSpace colorspace;
+	/* Timeouts for network outputs (rtmp/rtmps/rtsp/youtube), in microseconds to match
+	 * ffmpeg's own units; configured in milliseconds.  0 disables, preserving the
+	 * historical behaviour of an unbounded blocking open/write. */
+	int64_t default_rw_timeout_us;
+	int64_t max_rw_timeout_us;
+	int64_t connect_timeout_us;
 };
 
 struct avformat_globals avformat_globals = { 0 };
@@ -3467,6 +3473,28 @@ static char *supported_formats[SWITCH_MAX_CODECS] = { 0 };
 
 static const char modname[] = "mod_av";
 
+/* Parse a millisecond timeout setting into microseconds.  Returns 0 (disabled) for
+ * anything unparseable or negative, so a bad config can never be more aggressive
+ * than the historical unbounded behaviour. */
+static int64_t parse_timeout_ms_to_us(const char *name, const char *val)
+{
+	int ms;
+
+	if (zstr(val)) {
+		return 0;
+	}
+
+	ms = atoi(val);
+
+	if (ms < 0) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						  "Ignoring negative %s '%s', leaving it disabled\n", name, val);
+		return 0;
+	}
+
+	return (int64_t) ms * 1000;
+}
+
 static switch_status_t load_config(void)
 {
 	char *cf = "avformat.conf";
@@ -3490,8 +3518,22 @@ static switch_status_t load_config(void)
 				if (avformat_globals.colorspace > AVCOL_SPC_NB) {
 					avformat_globals.colorspace = AVCOL_SPC_RGB;
 				}
+			} else if (!strcasecmp(var, "network-rw-timeout")) {
+				avformat_globals.default_rw_timeout_us = parse_timeout_ms_to_us(var, val);
+			} else if (!strcasecmp(var, "network-max-rw-timeout")) {
+				avformat_globals.max_rw_timeout_us = parse_timeout_ms_to_us(var, val);
+			} else if (!strcasecmp(var, "network-connect-timeout")) {
+				avformat_globals.connect_timeout_us = parse_timeout_ms_to_us(var, val);
 			}
 		}
+	}
+
+	if (avformat_globals.default_rw_timeout_us || avformat_globals.max_rw_timeout_us || avformat_globals.connect_timeout_us) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
+						  "Network output timeouts: rw default %lldms, rw max %lldms, connect %lldms (0 = disabled)\n",
+						  (long long) (avformat_globals.default_rw_timeout_us / 1000),
+						  (long long) (avformat_globals.max_rw_timeout_us / 1000),
+						  (long long) (avformat_globals.connect_timeout_us / 1000));
 	}
 
 	switch_xml_free(xml);

--- a/src/mod/applications/mod_av/test/README.stall-testing.md
+++ b/src/mod/applications/mod_av/test/README.stall-testing.md
@@ -22,6 +22,31 @@ i.e. the historical behaviour:
 | `network-connect-timeout` | budget for establishing the connection |
 | `network-async-open` | connect on the writer's thread instead of the caller's |
 
+Any of the four can also be set for a single recording, which is how you tune or
+disable this without restarting. Precedence is `{}` on the record command, then the
+channel variable, then `av.conf.xml`:
+
+| channel variable | record command param | unit |
+| --- | --- | --- |
+| `RECORD_NETWORK_CONNECT_TIMEOUT_MS` | `network_connect_timeout` | ms |
+| `RECORD_NETWORK_RW_TIMEOUT_MS` | `network_rw_timeout` | ms |
+| `RECORD_NETWORK_MAX_RW_TIMEOUT_MS` | `network_max_rw_timeout` | ms |
+| `RECORD_NETWORK_ASYNC_OPEN` | `network_async_open` | bool |
+| `RECORD_NETWORK_RESILIENCY` | `network_resiliency` | bool |
+
+`RECORD_NETWORK_RESILIENCY=false` is the kill switch -- it turns off the timeouts and
+the async open together for that recording. It is disable-only; setting it true where the
+config has the feature off does nothing.
+
+The individual settings are not disable-only. Each takes effect in either direction, so
+`RECORD_NETWORK_ASYNC_OPEN=true` with a `RECORD_NETWORK_CONNECT_TIMEOUT_MS` gets the full
+behaviour for one recording on a box that has the feature off -- which is how to try it on
+a single call. A recording may also loosen a budget the config has set.
+
+`network_max_rw_timeout` may only be *tightened* per recording. It is the ceiling that
+stops a caller-supplied `rw_timeout` defeating the bound, so a looser value is refused
+and logged rather than honoured.
+
 Core-side, in `vars.xml` or per recording:
 
 | variable | effect |

--- a/src/mod/applications/mod_av/test/README.stall-testing.md
+++ b/src/mod/applications/mod_av/test/README.stall-testing.md
@@ -1,0 +1,58 @@
+# Testing recording against a stalled RTMP recorder
+
+An overloaded RTMP recorder does not refuse connections — it accepts them and
+then stops answering. Before the network timeout settings existed, the connect
+and RTMP handshake ran on whichever thread called `switch_core_file_open()`,
+which for a recording is the session thread, so the call lost its media for as
+long as the recorder took to answer: dead air, and a channel that would not hang
+up.
+
+`test_avformat.c` covers the deterministic half of this (an unreachable address,
+no server needed). This describes the half that needs a live call.
+
+## Settings
+
+`autoload_configs/av.conf.xml`, `avformat.conf` section — all default to 0/false,
+i.e. the historical behaviour:
+
+| setting | effect |
+| --- | --- |
+| `network-rw-timeout` | read/write timeout when the record command carries no `rw_timeout` of its own |
+| `network-max-rw-timeout` | ceiling applied to a caller-supplied `rw_timeout` |
+| `network-connect-timeout` | budget for establishing the connection |
+| `network-async-open` | connect on the writer's thread instead of the caller's |
+
+Core-side, in `vars.xml` or per recording:
+
+| variable | effect |
+| --- | --- |
+| `record_buffer_max_ms` / `RECORD_BUFFER_MAX_MS` | ceiling on audio queued for the recording thread |
+| `record_close_timeout_ms` / `RECORD_CLOSE_TIMEOUT_MS` | how long close waits for the recording thread before aborting its I/O |
+
+## Running it
+
+Start the stand-in recorder:
+
+    python3 test/blackhole_rtmp.py 11935 accept
+
+Then place a call and start a recording against it, executing `record_session`
+on the session thread the way production does (dialplan or `execute_on_*`,
+`uuid_broadcast` being the easiest equivalent from the CLI):
+
+    originate {origination_uuid=t1}loopback/park &playback(tone_stream://%(600000,0,440))
+    uuid_record t1 start /tmp/probe.wav
+    uuid_broadcast t1 record_session::rtmp://127.0.0.1:11935/live/stalled aleg
+
+`/tmp/probe.wav` is the measurement: it is written by the same session thread,
+so compare its duration against wall clock. Any shortfall is the media that the
+call did not process — the dead air.
+
+## What to expect
+
+With everything off, the recording never connects and the call loses its media
+entirely until the socket gives up; hangup blocks too.
+
+With `network-connect-timeout` and `network-async-open` set, the probe should
+track wall clock with no measurable gap, the recording should be abandoned
+shortly after the connect budget expires, and hangup should be prompt. The
+failed recording should log its error once rather than once per frame.

--- a/src/mod/applications/mod_av/test/README.stall-testing.md
+++ b/src/mod/applications/mod_av/test/README.stall-testing.md
@@ -27,7 +27,7 @@ Core-side, in `vars.xml` or per recording:
 | variable | effect |
 | --- | --- |
 | `record_buffer_max_ms` / `RECORD_BUFFER_MAX_MS` | ceiling on audio queued for the recording thread |
-| `record_close_timeout_ms` / `RECORD_CLOSE_TIMEOUT_MS` | how long close waits for the recording thread before aborting its I/O |
+| `record_close_timeout_ms` / `RECORD_CLOSE_TIMEOUT_MS` | how long the recording thread may make *no progress* at close before its I/O is aborted. A thread still draining its queue keeps the budget alive, so a slow-but-working recorder is not cut off; an overall cap of ten times this value stops trickling progress holding the channel up |
 
 ## Running it
 

--- a/src/mod/applications/mod_av/test/README.stall-testing.md
+++ b/src/mod/applications/mod_av/test/README.stall-testing.md
@@ -28,6 +28,7 @@ Core-side, in `vars.xml` or per recording:
 | --- | --- |
 | `record_buffer_max_ms` / `RECORD_BUFFER_MAX_MS` | ceiling on audio queued for the recording thread |
 | `record_close_timeout_ms` / `RECORD_CLOSE_TIMEOUT_MS` | how long the recording thread may make *no progress* at close before its I/O is aborted. A thread still draining its queue keeps the budget alive, so a slow-but-working recorder is not cut off; an overall cap of ten times this value stops trickling progress holding the channel up |
+| `record_write_error_grace_ms` / `RECORD_WRITE_ERROR_GRACE_MS` | how long consecutive write failures are tolerated before the recording is abandoned. Defaults to 1000ms rather than off, because the alternative is retrying a dead destination on every frame. 0 gives up on the first failure; a value larger than any call effectively never gives up |
 
 ## Running it
 

--- a/src/mod/applications/mod_av/test/blackhole_rtmp.py
+++ b/src/mod/applications/mod_av/test/blackhole_rtmp.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Stand-in for an overloaded RTMP recorder, for manual/scenario testing.
+
+The unit tests in test_avformat.c cover an *unreachable* recorder, which is
+deterministic and needs no server.  This covers the other shape, and the one
+that actually caused the incident: a recorder that completes the TCP connect
+and then never answers.  The kernel accepts into the backlog, so the client
+sees a healthy socket and waits on a handshake that never comes.
+
+  accept  - accept the connection, never answer the RTMP handshake
+  silent  - answer the handshake, then stop reading, so writes block once the
+            socket buffers fill
+
+Usage: blackhole_rtmp.py <port> [accept|silent]
+
+See test/README.stall-testing.md for how to drive a call against it.
+"""
+import socket
+import sys
+import threading
+
+
+def handle(conn, addr, mode):
+    print(f"  [server] connection from {addr[0]}:{addr[1]} ({mode})", flush=True)
+    if mode == "silent":
+        try:
+            conn.settimeout(5)
+            if conn.recv(1537):
+                conn.sendall(b"\x03" + b"\x00" * 1536)  # S0 + S1
+        except Exception:
+            pass
+    try:
+        while True:
+            if not conn.recv(65536):
+                break
+    except Exception:
+        pass
+    finally:
+        conn.close()
+        print(f"  [server] {addr[0]}:{addr[1]} closed", flush=True)
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 1935
+    mode = sys.argv[2] if len(sys.argv) > 2 else "accept"
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen(16)
+    print(f"[server] black-hole RTMP on 127.0.0.1:{port} mode={mode}", flush=True)
+
+    while True:
+        conn, addr = srv.accept()
+        threading.Thread(target=handle, args=(conn, addr, mode), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mod/applications/mod_av/test/conf/av.conf.xml
+++ b/src/mod/applications/mod_av/test/conf/av.conf.xml
@@ -163,5 +163,11 @@ enum AVColorRange {
 <configuration name="avformat.conf" description="AVFormat Config">
   <settings>
       <param name="colorspace" value="1"/>
+
+      <!-- Deliberately short, so the network tests below finish quickly and so a
+           regression that stops applying the budget shows up as a long test rather
+           than a passing one. -->
+      <param name="network-rw-timeout" value="1000"/>
+      <param name="network-connect-timeout" value="1000"/>
   </settings>
 </configuration>

--- a/src/mod/applications/mod_av/test/test_avformat.c
+++ b/src/mod/applications/mod_av/test/test_avformat.c
@@ -250,6 +250,69 @@ FST_CORE_BEGIN("conf")
 		}
 		FST_TEST_END()
 
+		/* 192.0.2.0/24 is TEST-NET-1 (RFC 5737): guaranteed not routable, so the
+		 * connect either stalls or is refused, never succeeds.  Without a connect
+		 * budget a stalled connect runs to ffmpeg's own 5s tcp default; with one it
+		 * must give up inside the configured window. */
+		FST_TEST_BEGIN(avformat_network_connect_timeout_bounds_open)
+		{
+			switch_file_handle_t fh = { 0 };
+			uint32_t flags = SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT;
+			switch_status_t status;
+			switch_time_t start, elapsed_ms;
+
+			start = switch_mono_micro_time_now();
+			status = switch_core_file_open(&fh, "rtmp://192.0.2.1:1935/live/unreachable", 1, 8000, flags, fst_pool);
+			elapsed_ms = (switch_mono_micro_time_now() - start) / 1000;
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+							  "unreachable open returned %d after %" SWITCH_INT64_T_FMT "ms\n", status, (int64_t) elapsed_ms);
+
+			/* It must fail, and must not have waited out ffmpeg's default. */
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			fst_check(elapsed_ms < 4000);
+
+			if (status == SWITCH_STATUS_SUCCESS) {
+				switch_core_file_close(&fh);
+			}
+		}
+		FST_TEST_END()
+
+		/* The network settings must not reach local files: a slow disk is not a stuck
+		 * peer, and aborting a local write would damage a healthy recording. */
+		FST_TEST_BEGIN(avformat_local_file_unaffected_by_network_timeouts)
+		{
+			char path[1024];
+			switch_file_handle_t fh = { 0 };
+			uint32_t flags = SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT;
+			uint8_t data[SAMPLES * 2] = { 0 };
+			switch_size_t len = SAMPLES;
+			switch_status_t status;
+			int i;
+
+			/* mod_av's own container rather than wav, which it does not register. */
+			switch_snprintf(path, sizeof(path), "%s%s%s%s", "{av_record_audio_only=true}",
+							SWITCH_GLOBAL_dirs.conf_dir, SWITCH_PATH_SEPARATOR, "../test_local_timeouts.mp4");
+
+			status = switch_core_file_open(&fh, path, 1, 8000, flags, fst_pool);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			/* Comfortably longer than the 1000ms network budget configured above, so a
+			 * budget wrongly applied here would abort partway through. */
+			for (i = 0; i < 100; i++) {
+				len = SAMPLES;
+				status = switch_core_file_write(&fh, data, &len);
+				fst_check(status == SWITCH_STATUS_SUCCESS);
+
+				if (status != SWITCH_STATUS_SUCCESS) {
+					break;
+				}
+			}
+
+			switch_core_file_close(&fh);
+		}
+		FST_TEST_END()
+
 		FST_TEARDOWN_BEGIN()
 		{
 		  //const char *err = NULL;

--- a/src/mod/applications/mod_av/test/test_avformat.c
+++ b/src/mod/applications/mod_av/test/test_avformat.c
@@ -322,6 +322,65 @@ FST_CORE_BEGIN("conf")
 		}
 		FST_TEST_END()
 
+		/* A recording may tighten the configured budget.  The conf sets 1000ms; this
+		 * asks for 300ms and must be believed, so the open has to return well inside
+		 * the configured window rather than at it. */
+		FST_TEST_BEGIN(avformat_session_connect_timeout_overrides_config)
+		{
+			switch_file_handle_t fh = { 0 };
+			uint32_t flags = SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT;
+			switch_status_t status;
+			switch_time_t start, elapsed_ms;
+
+			start = switch_mono_micro_time_now();
+			status = switch_core_file_open(&fh, "{network_connect_timeout=300}rtmp://192.0.2.1:1935/live/unreachable",
+										   1, 8000, flags, fst_pool);
+			elapsed_ms = (switch_mono_micro_time_now() - start) / 1000;
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+							  "per-session 300ms budget returned %d after %" SWITCH_INT64_T_FMT "ms\n",
+							  status, (int64_t) elapsed_ms);
+
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			/* Comfortably below the configured 1000ms, so this can only pass if the
+			 * per-recording value was the one applied. */
+			fst_check(elapsed_ms < 800);
+
+			if (status == SWITCH_STATUS_SUCCESS) {
+				switch_core_file_close(&fh);
+			}
+		}
+		FST_TEST_END()
+
+		/* The master switch has to reach the whole feature, not just one setting: with
+		 * it off the configured 1000ms budget must stop applying, leaving the open to
+		 * run to ffmpeg's own default.  Asserting it takes *longer* is the only way to
+		 * show the budget was really disabled rather than merely changed. */
+		FST_TEST_BEGIN(avformat_session_resiliency_off_disables_budget)
+		{
+			switch_file_handle_t fh = { 0 };
+			uint32_t flags = SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT;
+			switch_status_t status;
+			switch_time_t start, elapsed_ms;
+
+			start = switch_mono_micro_time_now();
+			status = switch_core_file_open(&fh, "{network_resiliency=false}rtmp://192.0.2.1:1935/live/unreachable",
+										   1, 8000, flags, fst_pool);
+			elapsed_ms = (switch_mono_micro_time_now() - start) / 1000;
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+							  "resiliency off returned %d after %" SWITCH_INT64_T_FMT "ms\n",
+							  status, (int64_t) elapsed_ms);
+
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			fst_check(elapsed_ms > 2000);
+
+			if (status == SWITCH_STATUS_SUCCESS) {
+				switch_core_file_close(&fh);
+			}
+		}
+		FST_TEST_END()
+
 		FST_TEARDOWN_BEGIN()
 		{
 		  //const char *err = NULL;

--- a/src/mod/applications/mod_av/test/test_avformat.c
+++ b/src/mod/applications/mod_av/test/test_avformat.c
@@ -297,9 +297,10 @@ FST_CORE_BEGIN("conf")
 			status = switch_core_file_open(&fh, path, 1, 8000, flags, fst_pool);
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
 
-			/* Comfortably longer than the 1000ms network budget configured above, so a
-			 * budget wrongly applied here would abort partway through. */
-			for (i = 0; i < 100; i++) {
+			/* Paced so the run really does outlast the 1000ms network budget configured
+			 * above; without the pacing these writes complete in microseconds and a
+			 * budget wrongly applied here would never get the chance to expire. */
+			for (i = 0; i < 60; i++) {
 				len = SAMPLES;
 				status = switch_core_file_write(&fh, data, &len);
 				fst_check(status == SWITCH_STATUS_SUCCESS);
@@ -307,9 +308,17 @@ FST_CORE_BEGIN("conf")
 				if (status != SWITCH_STATUS_SUCCESS) {
 					break;
 				}
+
+				switch_yield(20000);
 			}
 
 			switch_core_file_close(&fh);
+
+			/* Deliberately no assertion on the resulting file being playable.  That
+			 * would be the stronger check, but whether mod_av can produce a valid file
+			 * here depends on which encoders the build has, and the sibling read tests
+			 * already fail for that reason -- so such an assertion would report the
+			 * build's codec set rather than anything about the timeouts. */
 		}
 		FST_TEST_END()
 

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1165,6 +1165,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_displace_session(switch_core_session_
  * disabled one. */
 #define RECORD_TIMEOUT_MAX_MS 86400000
 
+/* How long a run of consecutive write failures is tolerated before the recording is
+ * abandoned.  Long enough to ride out a hiccup, short enough that a dead destination
+ * does not spin at frame rate for the rest of the call. */
+#define RECORD_WRITE_ERROR_GRACE_MS 1000
+
 struct record_helper {
 	switch_media_bug_t *bug;
 	switch_memory_pool_t *helper_pool;
@@ -1201,6 +1206,10 @@ struct record_helper {
 	 * flushing" from "wedged" without an untimed join. */
 	int thread_done;
 	int close_timeout_ms;
+	/* Consecutive write failures, and when the run of them began. */
+	uint32_t write_errors;
+	switch_time_t first_write_error;
+	switch_time_t last_write_error_log;
 	switch_thread_t *thread;
 	switch_mutex_t *buffer_mutex;
 	int thread_ready;
@@ -1497,20 +1506,45 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 		switch_mutex_unlock(rh->buffer_mutex);
 
 		if (switch_core_file_write(rh->fh, data, &samples) != SWITCH_STATUS_SUCCESS) {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error writing %s\n", rh->file);
+			switch_time_t now = switch_micro_time_now();
+
+			rh->write_errors++;
+
+			if (!rh->first_write_error) {
+				rh->first_write_error = now;
+			}
+
+			/* Rate limited.  A write that fails immediately -- an unreachable recorder,
+			 * rather than one that blocks -- would otherwise log once per frame, about
+			 * fifty lines a second for every affected recording. */
+			if (rh->write_errors == 1 || (now - rh->last_write_error_log) > 5000000) {
+				rh->last_write_error_log = now;
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+								  "Error writing %s (%u consecutive)\n", rh->file, rh->write_errors);
+			}
+
 			/* File write failed */
 			set_completion_cause(rh, "uri-failure");
 			if (rh->hangup_on_error) {
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 				switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 			}
-			
-			/* We might need to consider a threshold counter that we need to exceed first before
-			 * we prune it.  In the meantime, the chanvar will serve to just enable or disable it 
-			 */
-			if(rh->stop_write_on_error) {
+
+			/* Give up once the failure is plainly not transient.  While writes could
+			 * only fail slowly this loop just blocked; now that a dead destination
+			 * fails instantly, carrying on would spin at frame rate for the rest of
+			 * the call.  The grace period still rides out a brief hiccup. */
+			if (rh->stop_write_on_error || (now - rh->first_write_error) >= RECORD_WRITE_ERROR_GRACE_MS * 1000) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+								  "Giving up on %s after %u write errors; stopping this recording\n",
+								  rh->file, rh->write_errors);
 				switch_set_flag(bug, SMBF_PRUNE);
+				break;
 			}
+		} else {
+			/* Consecutive, so a recovered write clears the tally. */
+			rh->write_errors = 0;
+			rh->first_write_error = 0;
 		}
 	}
 

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1228,6 +1228,20 @@ struct record_helper {
 
 static switch_status_t record_helper_destroy(struct record_helper **rh, switch_core_session_t *session);
 
+/* Bytes still queued for the recording thread; 0 when there is no queue at all. */
+static switch_size_t record_buffer_inuse(struct record_helper *rh)
+{
+	switch_size_t inuse = 0;
+
+	if (rh->thread_buffer && rh->buffer_mutex) {
+		switch_mutex_lock(rh->buffer_mutex);
+		inuse = switch_buffer_inuse(rh->thread_buffer);
+		switch_mutex_unlock(rh->buffer_mutex);
+	}
+
+	return inuse;
+}
+
 /**
  * Set the recording completion cause. The cause can only be set once, to minimize the logic in the record_callback.
  * [The completion_cause strings are essentially those of an MRCP Recorder resource.]
@@ -1837,17 +1851,37 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 					 * join holds up the hangup for as long as the write blocks.  Give it a
 					 * budget, then abort its I/O so the join can complete. */
 					if (rh->close_timeout_ms > 0) {
-						int waited_ms = 0;
+						int stalled_ms = 0, total_ms = 0;
+						int max_total_ms = rh->close_timeout_ms * 10;
+						switch_size_t last_inuse = record_buffer_inuse(rh);
 
-						while (!rh->thread_done && waited_ms < rh->close_timeout_ms) {
+						/* The budget measures lack of *progress*, not elapsed time.  A
+						 * thread draining a backlog to a slow-but-working recorder is
+						 * doing exactly what this join exists to allow, and cutting it
+						 * off would discard audio already captured.  Only a queue that
+						 * has stopped shrinking means the writer is wedged.  The total
+						 * cap is the backstop, so trickling progress cannot hold the
+						 * channel up indefinitely either. */
+						while (!rh->thread_done && stalled_ms < rh->close_timeout_ms && total_ms < max_total_ms) {
+							switch_size_t inuse;
+
 							switch_yield(10000);
-							waited_ms += 10;
+							stalled_ms += 10;
+							total_ms += 10;
+
+							inuse = record_buffer_inuse(rh);
+
+							if (inuse < last_inuse) {
+								stalled_ms = 0;
+							}
+
+							last_inuse = inuse;
 						}
 
 						if (!rh->thread_done) {
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
-											  "Recording thread for %s still busy after %dms; aborting its I/O so the channel can go down\n",
-											  rh->file, rh->close_timeout_ms);
+											  "Recording thread for %s made no progress for %dms (%dms total); aborting its I/O "
+											  "so the channel can go down\n", rh->file, stalled_ms, total_ms);
 							set_completion_cause(rh, "uri-failure");
 							switch_core_file_command(rh->fh, SCFC_ABORT_IO);
 						}

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -3513,6 +3513,21 @@ static switch_status_t record_helper_destroy(struct record_helper **rh, switch_c
 	return SWITCH_STATUS_SUCCESS;
 }
 
+/* Recorder network settings that a session may override, and the mod_av file param each
+ * one maps to.  The channel-variable spelling matches the RECORD_* settings beside it;
+ * the param spelling matches avformat.conf.  All four timeouts are milliseconds -- the
+ * rw_timeout file param is microseconds, being ffmpeg's own, and is not one of these. */
+static const struct {
+	const char *var;
+	const char *param;
+} record_net_vars[] = {
+	{ "RECORD_NETWORK_RESILIENCY", "network_resiliency" },
+	{ "RECORD_NETWORK_CONNECT_TIMEOUT_MS", "network_connect_timeout" },
+	{ "RECORD_NETWORK_RW_TIMEOUT_MS", "network_rw_timeout" },
+	{ "RECORD_NETWORK_MAX_RW_TIMEOUT_MS", "network_max_rw_timeout" },
+	{ "RECORD_NETWORK_ASYNC_OPEN", "network_async_open" }
+};
+
 static const char *get_recording_var(switch_channel_t *channel, switch_event_t *vars, const char *name)
 {
 	const char *val = NULL;
@@ -3904,15 +3919,45 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		 * talks to the network may postpone connecting rather than doing it here, on
 		 * the session thread.  Mirrors the condition record_callback uses when it
 		 * decides whether to create that thread; kept out of file_open_path so log and
-		 * event text still name the recording as the caller wrote it. */
+		 * event text still name the recording as the caller wrote it.
+		 *
+		 * The recorder network settings ride along in the same block.  It is prepended
+		 * rather than appended so that a value the caller wrote in its own brace block
+		 * wins: switch_event_create_brackets sets EF_UNIQ_HEADERS, so the later of two
+		 * occurrences replaces the earlier.  Precedence is therefore
+		 *
+		 *     {} on the record command  >  channel variable  >  avformat.conf  */
 		{
 			const char *use_thread = get_recording_var(channel, vars, "RECORD_USE_THREAD");
-
-			file_open_arg = file_open_path;
+			const char *params = "";
+			size_t i;
 
 			if (zstr(use_thread) || switch_true(use_thread)) {
-				file_open_arg = switch_core_sprintf(rh->helper_pool, "{writer_thread=true}%s", file_open_path);
+				params = "writer_thread=true";
 			}
+
+			for (i = 0; i < switch_arraylen(record_net_vars); i++) {
+				const char *val = get_recording_var(channel, vars, record_net_vars[i].var);
+
+				if (zstr(val)) {
+					continue;
+				}
+
+				/* A value carrying a delimiter would not just be ignored downstream, it
+				 * would truncate the brace block and corrupt the recording path. */
+				if (strpbrk(val, "{},")) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+									  "Ignoring %s '%s': it contains a brace or comma\n",
+									  record_net_vars[i].var, val);
+					continue;
+				}
+
+				params = switch_core_sprintf(rh->helper_pool, "%s%s%s=%s", params,
+											 zstr(params) ? "" : ",", record_net_vars[i].param, val);
+			}
+
+			file_open_arg = zstr(params) ? file_open_path :
+				switch_core_sprintf(rh->helper_pool, "{%s}%s", params, file_open_path);
 		}
 
 		if (switch_core_file_open(fh, file_open_arg, channels, read_impl.actual_samples_per_second, file_flags, NULL) != SWITCH_STATUS_SUCCESS) {

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1205,8 +1205,9 @@ struct record_helper {
 	switch_size_t buffer_dropped_bytes;
 	switch_time_t last_drop_log;
 	/* Set by the recording thread as it exits, so the close path can tell "still
-	 * flushing" from "wedged" without an untimed join. */
-	int thread_done;
+	 * flushing" from "wedged" without an untimed join.  Written by that thread and
+	 * polled by the closing one, so it is atomic rather than a plain int. */
+	switch_atomic_t thread_done;
 	int close_timeout_ms;
 	/* Consecutive write failures, and when the run of them began. */
 	uint32_t write_errors;
@@ -1572,7 +1573,7 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 
 	/* Last thing before exiting: the close path polls this to decide whether the thread
 	 * is still flushing normally or is stuck and needs its I/O aborted. */
-	rh->thread_done = 1;
+	switch_atomic_set(&rh->thread_done, 1);
 
 	return NULL;
 }
@@ -1866,7 +1867,7 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 						 * has stopped shrinking means the writer is wedged.  The total
 						 * cap is the backstop, so trickling progress cannot hold the
 						 * channel up indefinitely either. */
-						while (!rh->thread_done && stalled_ms < rh->close_timeout_ms && total_ms < max_total_ms) {
+						while (!switch_atomic_read(&rh->thread_done) && stalled_ms < rh->close_timeout_ms && total_ms < max_total_ms) {
 							switch_size_t inuse;
 
 							switch_yield(10000);
@@ -1882,7 +1883,7 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 							last_inuse = inuse;
 						}
 
-						if (!rh->thread_done) {
+						if (!switch_atomic_read(&rh->thread_done)) {
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
 											  "Recording thread for %s made no progress for %dms (%dms total); aborting its I/O "
 											  "so the channel can go down\n", rh->file, stalled_ms, total_ms);

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1155,6 +1155,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_displace_session(switch_core_session_
 }
 
 
+/* Below this a ceiling would discard audio continuously rather than absorb a stall,
+ * so such a value is refused outright as a misconfiguration. */
+#define RECORD_BUFFER_MIN_MS 100
+
 struct record_helper {
 	switch_media_bug_t *bug;
 	switch_memory_pool_t *helper_pool;
@@ -1182,6 +1186,11 @@ struct record_helper {
 	switch_codec_implementation_t read_impl;
 	switch_bool_t speech_detected;
 	switch_buffer_t *thread_buffer;
+	/* Ceiling on thread_buffer, in bytes; 0 means unbounded (the historical behaviour).
+	 * Guards against a stalled writer letting the queue grow for the whole call. */
+	switch_size_t buffer_max_bytes;
+	switch_size_t buffer_dropped_bytes;
+	switch_time_t last_drop_log;
 	switch_thread_t *thread;
 	switch_mutex_t *buffer_mutex;
 	int thread_ready;
@@ -1873,9 +1882,50 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 					len = (switch_size_t) frame.datalen / 2 / frame.channels;
 
 					if (rh->thread_buffer) {
+						switch_size_t dropped = 0;
+
 						switch_mutex_lock(rh->buffer_mutex);
+
+						/* If the recording thread is stalled -- typically blocked writing to
+						 * an unresponsive recorder -- this queue would otherwise grow for the
+						 * rest of the call.  Discard the oldest audio to stay under the
+						 * ceiling: the recording is already damaged, and unbounded growth
+						 * would put the whole box at risk rather than just this call. */
+						if (rh->buffer_max_bytes) {
+							switch_size_t inuse = switch_buffer_inuse(rh->thread_buffer);
+
+							if (inuse + frame.datalen > rh->buffer_max_bytes) {
+								switch_size_t align = 2 * (frame.channels ? frame.channels : 1);
+								switch_size_t excess = (inuse + frame.datalen) - rh->buffer_max_bytes;
+
+								/* Round the discard up to a whole sample frame.  Dropping a
+								 * partial one would byte-shift every sample after it, and
+								 * swap the channels in stereo -- corruption rather than a
+								 * gap.  The arithmetic keeps this aligned today; making it
+								 * explicit stops a later change to the ceiling from
+								 * quietly breaking it. */
+								excess = ((excess + align - 1) / align) * align;
+
+								/* switch_buffer_toss() returns what is left, not what it
+								 * discarded, so work out the loss ourselves: it drops
+								 * min(excess, inuse). */
+								dropped = excess > inuse ? inuse : excess;
+								switch_buffer_toss(rh->thread_buffer, excess);
+								rh->buffer_dropped_bytes += dropped;
+							}
+						}
+
 						switch_buffer_write(rh->thread_buffer, mask ? null_data : data, frame.datalen);
 						switch_mutex_unlock(rh->buffer_mutex);
+
+						/* Rate limited: once a recorder stalls this would fire every frame. */
+						if (dropped && (!rh->last_drop_log || (switch_micro_time_now() - rh->last_drop_log) > 5000000)) {
+							rh->last_drop_log = switch_micro_time_now();
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+											  "Recording buffer for %s is full; discarding oldest audio (%" SWITCH_SIZE_T_FMT " bytes dropped so far)\n",
+											  rh->file, rh->buffer_dropped_bytes);
+						}
+
 						if (switch_mutex_trylock(rh->cond_mutex) == SWITCH_STATUS_SUCCESS) {
 							switch_thread_cond_signal(rh->cond);
 							switch_mutex_unlock(rh->cond_mutex);
@@ -3877,6 +3927,34 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		rh->stop_write_on_error = SWITCH_FALSE;
 	}
 	
+	/* Ceiling on how much audio may queue for the recording thread.  Per-recording
+	 * variable first, then a global default so it can be set fleet-wide without the
+	 * caller having to know about it; unset means unbounded, as before. */
+	if (!(p = get_recording_var(channel, vars, "RECORD_BUFFER_MAX_MS"))) {
+		/* _pdup, not the plain getter: that one returns the pointer after dropping the
+		 * lock, so a concurrent global_setvar could free it under us. */
+		p = switch_core_get_variable_pdup("record_buffer_max_ms", rh->helper_pool);
+	}
+
+	if (!zstr(p)) {
+		char *endptr = NULL;
+		long tmp = strtol(p, &endptr, 10);
+
+		/* Strict: atoi("2s") would yield 2, i.e. a 2ms ceiling that discards audio on
+		 * every frame for the whole call while looking like a working recording.  A
+		 * typo here has to be refused, not silently honoured. */
+		if (!endptr || *endptr != '\0' || tmp < RECORD_BUFFER_MIN_MS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+							  "Ignoring RECORD_BUFFER_MAX_MS '%s' (expected at least %d ms as a plain integer); "
+							  "recording buffer stays unbounded\n", p, RECORD_BUFFER_MIN_MS);
+		} else {
+			/* ms of 16-bit samples at the rate and channel count we actually write.
+			 * Multiply before dividing so rates that are not a multiple of 1000 are
+			 * not truncated away. */
+			rh->buffer_max_bytes = (switch_size_t) tmp * read_impl.actual_samples_per_second / 1000 * 2 * channels;
+		}
+	}
+
 	if ((p = get_recording_var(channel, vars, "RECORD_MIN_SEC"))) {
 		int tmp = atoi(p);
 		if (tmp >= 0) {

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1165,9 +1165,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_displace_session(switch_core_session_
  * disabled one. */
 #define RECORD_TIMEOUT_MAX_MS 86400000
 
-/* How long a run of consecutive write failures is tolerated before the recording is
- * abandoned.  Long enough to ride out a hiccup, short enough that a dead destination
- * does not spin at frame rate for the rest of the call. */
+/* Default for how long a run of consecutive write failures is tolerated before the
+ * recording is abandoned.  Long enough to ride out a hiccup, short enough that a dead
+ * destination does not spin at frame rate for the rest of the call.  Overridable per
+ * recording or globally; 0 gives up on the first failure, and a large value effectively
+ * never gives up (which is the pre-existing behaviour, spin included). */
 #define RECORD_WRITE_ERROR_GRACE_MS 1000
 
 struct record_helper {
@@ -1210,6 +1212,7 @@ struct record_helper {
 	uint32_t write_errors;
 	switch_time_t first_write_error;
 	switch_time_t last_write_error_log;
+	int write_error_grace_ms;
 	switch_thread_t *thread;
 	switch_mutex_t *buffer_mutex;
 	int thread_ready;
@@ -1548,10 +1551,11 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 			 * only fail slowly this loop just blocked; now that a dead destination
 			 * fails instantly, carrying on would spin at frame rate for the rest of
 			 * the call.  The grace period still rides out a brief hiccup. */
-			if (rh->stop_write_on_error || (now - rh->first_write_error) >= RECORD_WRITE_ERROR_GRACE_MS * 1000) {
+			if (rh->stop_write_on_error || (now - rh->first_write_error) >= (switch_time_t) rh->write_error_grace_ms * 1000) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
-								  "Giving up on %s after %u write errors; stopping this recording\n",
-								  rh->file, rh->write_errors);
+								  "Giving up on %s after %u write errors over %dms (grace %dms); stopping this recording\n",
+								  rh->file, rh->write_errors, (int) ((now - rh->first_write_error) / 1000),
+								  rh->write_error_grace_ms);
 				switch_set_flag(bug, SMBF_PRUNE);
 				break;
 			}
@@ -4082,6 +4086,29 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 			 * Multiply before dividing so rates that are not a multiple of 1000 are
 			 * not truncated away. */
 			rh->buffer_max_bytes = (switch_size_t) tmp * read_impl.actual_samples_per_second / 1000 * 2 * channels;
+		}
+	}
+
+	/* How long a run of consecutive write failures is tolerated before this recording is
+	 * abandoned.  Unlike the other settings this one has a working default rather than
+	 * being off, because the alternative is retrying a dead destination on every frame;
+	 * it is configurable so a deployment that would rather wait longer can. */
+	rh->write_error_grace_ms = RECORD_WRITE_ERROR_GRACE_MS;
+
+	if (!(p = get_recording_var(channel, vars, "RECORD_WRITE_ERROR_GRACE_MS"))) {
+		p = switch_core_get_variable_pdup("record_write_error_grace_ms", rh->helper_pool);
+	}
+
+	if (!zstr(p)) {
+		char *endptr = NULL;
+		long tmp = strtol(p, &endptr, 10);
+
+		if (!endptr || *endptr != '\0' || tmp < 0 || tmp > RECORD_TIMEOUT_MAX_MS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+							  "Ignoring RECORD_WRITE_ERROR_GRACE_MS '%s' (expected 0-%d milliseconds as a plain integer); "
+							  "keeping the %dms default\n", p, RECORD_TIMEOUT_MAX_MS, rh->write_error_grace_ms);
+		} else {
+			rh->write_error_grace_ms = (int) tmp;
 		}
 	}
 

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1159,6 +1159,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_displace_session(switch_core_session_
  * so such a value is refused outright as a misconfiguration. */
 #define RECORD_BUFFER_MIN_MS 100
 
+/* 24h.  An upper bound matters as much as the lower one: without it a value beyond
+ * INT_MAX truncates on the way into an int and can land on a small positive number,
+ * turning a fat-fingered setting into an aggressively short timeout rather than a
+ * disabled one. */
+#define RECORD_TIMEOUT_MAX_MS 86400000
+
 struct record_helper {
 	switch_media_bug_t *bug;
 	switch_memory_pool_t *helper_pool;
@@ -1191,6 +1197,10 @@ struct record_helper {
 	switch_size_t buffer_max_bytes;
 	switch_size_t buffer_dropped_bytes;
 	switch_time_t last_drop_log;
+	/* Set by the recording thread as it exits, so the close path can tell "still
+	 * flushing" from "wedged" without an untimed join. */
+	int thread_done;
+	int close_timeout_ms;
 	switch_thread_t *thread;
 	switch_mutex_t *buffer_mutex;
 	int thread_ready;
@@ -1508,6 +1518,10 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 
 	switch_core_session_rwunlock(session);
 
+	/* Last thing before exiting: the close path polls this to decide whether the thread
+	 * is still flushing normally or is stuck and needs its I/O aborted. */
+	rh->thread_done = 1;
+
 	return NULL;
 }
 
@@ -1774,6 +1788,28 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 					switch_mutex_lock(rh->cond_mutex);
 					switch_thread_cond_signal(rh->cond);
 					switch_mutex_unlock(rh->cond_mutex);
+
+					/* The join is what lets the recording thread flush whatever is still
+					 * queued, so it must not be cut short in the normal case.  But if that
+					 * thread is blocked writing to an unresponsive recorder, an untimed
+					 * join holds up the hangup for as long as the write blocks.  Give it a
+					 * budget, then abort its I/O so the join can complete. */
+					if (rh->close_timeout_ms > 0) {
+						int waited_ms = 0;
+
+						while (!rh->thread_done && waited_ms < rh->close_timeout_ms) {
+							switch_yield(10000);
+							waited_ms += 10;
+						}
+
+						if (!rh->thread_done) {
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+											  "Recording thread for %s still busy after %dms; aborting its I/O so the channel can go down\n",
+											  rh->file, rh->close_timeout_ms);
+							set_completion_cause(rh, "uri-failure");
+							switch_core_file_command(rh->fh, SCFC_ABORT_IO);
+						}
+					}
 
 					switch_thread_join(&st, rh->thread);
 				}
@@ -3943,15 +3979,35 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 		/* Strict: atoi("2s") would yield 2, i.e. a 2ms ceiling that discards audio on
 		 * every frame for the whole call while looking like a working recording.  A
 		 * typo here has to be refused, not silently honoured. */
-		if (!endptr || *endptr != '\0' || tmp < RECORD_BUFFER_MIN_MS) {
+		if (!endptr || *endptr != '\0' || tmp < RECORD_BUFFER_MIN_MS || tmp > RECORD_TIMEOUT_MAX_MS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
-							  "Ignoring RECORD_BUFFER_MAX_MS '%s' (expected at least %d ms as a plain integer); "
-							  "recording buffer stays unbounded\n", p, RECORD_BUFFER_MIN_MS);
+							  "Ignoring RECORD_BUFFER_MAX_MS '%s' (expected %d-%d ms as a plain integer); "
+							  "recording buffer stays unbounded\n", p, RECORD_BUFFER_MIN_MS, RECORD_TIMEOUT_MAX_MS);
 		} else {
 			/* ms of 16-bit samples at the rate and channel count we actually write.
 			 * Multiply before dividing so rates that are not a multiple of 1000 are
 			 * not truncated away. */
 			rh->buffer_max_bytes = (switch_size_t) tmp * read_impl.actual_samples_per_second / 1000 * 2 * channels;
+		}
+	}
+
+	/* How long the close path waits for the recording thread to finish flushing before
+	 * aborting its I/O.  Unset means wait indefinitely, as before. */
+	if (!(p = get_recording_var(channel, vars, "RECORD_CLOSE_TIMEOUT_MS"))) {
+		p = switch_core_get_variable_pdup("record_close_timeout_ms", rh->helper_pool);
+	}
+
+	if (!zstr(p)) {
+		char *endptr = NULL;
+		long tmp = strtol(p, &endptr, 10);
+
+		if (!endptr || *endptr != '\0' || tmp < 0 || tmp > RECORD_TIMEOUT_MAX_MS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+							  "Ignoring RECORD_CLOSE_TIMEOUT_MS '%s' (expected 0-%d milliseconds as a plain integer); "
+							  "close will wait indefinitely\n", p, RECORD_TIMEOUT_MAX_MS);
+		} else {
+			/* Rounded up to the 10ms polling granularity below. */
+			rh->close_timeout_ms = (int) tmp;
 		}
 	}
 

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1785,9 +1785,17 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 
 					rh->thread_ready = 0;
 
-					switch_mutex_lock(rh->cond_mutex);
-					switch_thread_cond_signal(rh->cond);
-					switch_mutex_unlock(rh->cond_mutex);
+					/* trylock, not lock: the recording thread holds cond_mutex for its
+					 * whole loop and only drops it inside cond_timedwait, so a blocking
+					 * acquire here would wait out the very write we are trying to bound
+					 * -- before reaching the budget below.  Failing to acquire means the
+					 * thread is working rather than waiting, so there is no one to wake;
+					 * it rechecks thread_ready within RECORDING_THREAD_COND_TIMEOUT_US
+					 * anyway.  Same reasoning as the trylock on the READ_PING path. */
+					if (switch_mutex_trylock(rh->cond_mutex) == SWITCH_STATUS_SUCCESS) {
+						switch_thread_cond_signal(rh->cond);
+						switch_mutex_unlock(rh->cond_mutex);
+					}
 
 					/* The join is what lets the recording thread flush whatever is still
 					 * queued, so it must not be cut short in the normal case.  But if that
@@ -3491,6 +3499,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	/* Keep file as the caller-visible recording identity; file_open_path may
 	 * include effective writer params used only for switch_core_file_open(). */
 	const char *file_open_path = file;
+	/* What is actually handed to switch_core_file_open(): file_open_path plus any
+	 * params meant only for the writer, which must not leak into logs or events. */
+	const char *file_open_arg = NULL;
 	switch_event_t *file_params = NULL;
 	int have_recording_file_param_override = 0;
 
@@ -3817,7 +3828,22 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 			file_flags |= SWITCH_FILE_FLAG_VIDEO;
 		}
 
-		if (switch_core_file_open(fh, file_open_path, channels, read_impl.actual_samples_per_second, file_flags, NULL) != SWITCH_STATUS_SUCCESS) {
+		/* Tell the format that writes will be driven by a dedicated thread, so one that
+		 * talks to the network may postpone connecting rather than doing it here, on
+		 * the session thread.  Mirrors the condition record_callback uses when it
+		 * decides whether to create that thread; kept out of file_open_path so log and
+		 * event text still name the recording as the caller wrote it. */
+		{
+			const char *use_thread = get_recording_var(channel, vars, "RECORD_USE_THREAD");
+
+			file_open_arg = file_open_path;
+
+			if (zstr(use_thread) || switch_true(use_thread)) {
+				file_open_arg = switch_core_sprintf(rh->helper_pool, "{writer_thread=true}%s", file_open_path);
+			}
+		}
+
+		if (switch_core_file_open(fh, file_open_arg, channels, read_impl.actual_samples_per_second, file_flags, NULL) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error opening %s\n", file_open_path);
 			if (hangup_on_error) {
 				switch_channel_hangup(channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -1214,6 +1214,9 @@ struct record_helper {
 	switch_time_t first_write_error;
 	switch_time_t last_write_error_log;
 	int write_error_grace_ms;
+	/* rh->file as the caller gave it, reduced to a form that is safe to log: it can
+	 * carry {auth_username=...,auth_password=...} and, for RTMP, a stream key. */
+	const char *log_file;
 	switch_thread_t *thread;
 	switch_mutex_t *buffer_mutex;
 	int thread_ready;
@@ -1538,7 +1541,7 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 			if (rh->write_errors == 1 || (now - rh->last_write_error_log) > 5000000) {
 				rh->last_write_error_log = now;
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
-								  "Error writing %s (%u consecutive)\n", rh->file, rh->write_errors);
+								  "Error writing %s (%u consecutive)\n", rh->log_file, rh->write_errors);
 			}
 
 			/* File write failed */
@@ -1555,7 +1558,7 @@ static void *SWITCH_THREAD_FUNC recording_thread(switch_thread_t *thread, void *
 			if (rh->stop_write_on_error || (now - rh->first_write_error) >= (switch_time_t) rh->write_error_grace_ms * 1000) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
 								  "Giving up on %s after %u write errors over %dms (grace %dms); stopping this recording\n",
-								  rh->file, rh->write_errors, (int) ((now - rh->first_write_error) / 1000),
+								  rh->log_file, rh->write_errors, (int) ((now - rh->first_write_error) / 1000),
 								  rh->write_error_grace_ms);
 				switch_set_flag(bug, SMBF_PRUNE);
 				break;
@@ -1886,7 +1889,7 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 						if (!switch_atomic_read(&rh->thread_done)) {
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
 											  "Recording thread for %s made no progress for %dms (%dms total); aborting its I/O "
-											  "so the channel can go down\n", rh->file, stalled_ms, total_ms);
+											  "so the channel can go down\n", rh->log_file, stalled_ms, total_ms);
 							set_completion_cause(rh, "uri-failure");
 							switch_core_file_command(rh->fh, SCFC_ABORT_IO);
 						}
@@ -2040,7 +2043,7 @@ static switch_bool_t record_callback(switch_media_bug_t *bug, void *user_data, s
 							rh->last_drop_log = switch_micro_time_now();
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
 											  "Recording buffer for %s is full; discarding oldest audio (%" SWITCH_SIZE_T_FMT " bytes dropped so far)\n",
-											  rh->file, rh->buffer_dropped_bytes);
+											  rh->log_file, rh->buffer_dropped_bytes);
 						}
 
 						if (switch_mutex_trylock(rh->cond_mutex) == SWITCH_STATUS_SUCCESS) {
@@ -3582,6 +3585,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	int file_flags = SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT;
 	switch_bool_t hangup_on_error = SWITCH_FALSE;
 	char *file_path = NULL;
+	char redacted[512];
 	char *ext;
 	char *in_file = NULL, *out_file = NULL;
 	/* Keep file as the caller-visible recording identity; file_open_path may
@@ -4094,6 +4098,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 
 	rh->fh = fh;
 	rh->file = switch_core_strdup(rh->helper_pool, file);
+	rh->log_file = switch_core_strdup(rh->helper_pool, switch_redact_file_target(file, redacted, sizeof(redacted)));
 	rh->packet_len = read_impl.decoded_bytes_per_packet;
 
 	if (file_flags & SWITCH_FILE_WRITE_APPEND) {

--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -3582,6 +3582,55 @@ SWITCH_DECLARE(char *) switch_url_encode(const char *url, char *buf, size_t len)
 	return switch_url_encode_opt(url, buf, len, SWITCH_FALSE);
 }
 
+SWITCH_DECLARE(const char *) switch_redact_file_target(const char *target, char *buf, switch_size_t buflen)
+{
+	const char *scheme_end, *host, *end, *e;
+
+	if (!buf || !buflen) {
+		return "(unknown)";
+	}
+
+	if (zstr(target)) {
+		return "(unknown)";
+	}
+
+	/* Leading {} and [] groups are caller-supplied parameters -- auth_username and
+	 * auth_password among them -- so they never belong in a log line. */
+	while (*target == '{' || *target == '[') {
+		if (!(e = switch_find_end_paren(target, *target, *target == '{' ? '}' : ']'))) {
+			return "(unknown)";
+		}
+
+		target = e + 1;
+
+		while (*target == ' ') {
+			target++;
+		}
+	}
+
+	if (!(scheme_end = strstr(target, SWITCH_URL_SEPARATOR))) {
+		/* A local path holds no secret, and the log is more useful naming it. */
+		switch_snprintf(buf, buflen, "%s", target);
+		return buf;
+	}
+
+	host = scheme_end + 3;
+
+	/* Stop at the path, the query, the fragment, or a space -- the last of which is
+	 * where mod_av's RTMP credentials begin.  Userinfo before an @ goes too. */
+	for (end = host; *end && *end != '/' && *end != '?' && *end != '#' && *end != ' '; end++) {
+		if (*end == '@') {
+			host = end + 1;
+		}
+	}
+
+	switch_snprintf(buf, buflen, "%.*s" SWITCH_URL_SEPARATOR "%.*s%s",
+					(int) (scheme_end - target), target, (int) (end - host), host,
+					*end ? "/..." : "");
+
+	return buf;
+}
+
 SWITCH_DECLARE(char *) switch_url_decode(char *s)
 {
 	char *o;

--- a/tests/unit/switch_utils.c
+++ b/tests/unit/switch_utils.c
@@ -127,6 +127,60 @@ FST_TEST_BEGIN(is_file_path)
 }
 FST_TEST_END()
 
+FST_TEST_BEGIN(redact_file_target)
+{
+    char buf[512];
+    const char *out;
+
+    /* mod_av appends "pubUser=... pubPasswd=..." to the RTMP target, and record_session
+     * carries its own {} parameters, so neither may reach a log verbatim. */
+    out = switch_redact_file_target("{auth_username=alice,auth_password=hunter2}"
+                                    "rtmp://recorder.example.com/live/streamkey", buf, sizeof(buf));
+    fst_check_string_equals(out, "rtmp://recorder.example.com/...");
+    fst_check(strstr(out, "hunter2") == NULL);
+    fst_check(strstr(out, "streamkey") == NULL);
+
+    out = switch_redact_file_target("rtmp://recorder.example.com/live/streamkey "
+                                    "pubUser=alice pubPasswd=hunter2 flashver=FMLE/3.0", buf, sizeof(buf));
+    fst_check_string_equals(out, "rtmp://recorder.example.com/...");
+    fst_check(strstr(out, "hunter2") == NULL);
+
+    /* Several parameter groups, and the [] form the record path also accepts. */
+    out = switch_redact_file_target("{a=1}{auth_password=hunter2} [b=2]rtmp://host.example.com/app", buf, sizeof(buf));
+    fst_check_string_equals(out, "rtmp://host.example.com/...");
+
+    /* Userinfo in the authority goes too. */
+    out = switch_redact_file_target("rtmps://bob:s3cret@recorder.example.com:1935/live/key", buf, sizeof(buf));
+    fst_check_string_equals(out, "rtmps://recorder.example.com:1935/...");
+    fst_check(strstr(out, "s3cret") == NULL);
+
+    /* So does a query string. */
+    out = switch_redact_file_target("rtmp://recorder.example.com?token=abc123", buf, sizeof(buf));
+    fst_check_string_equals(out, "rtmp://recorder.example.com/...");
+
+    /* A host-only target keeps its shape rather than gaining a phantom path. */
+    out = switch_redact_file_target("rtmp://recorder.example.com", buf, sizeof(buf));
+    fst_check_string_equals(out, "rtmp://recorder.example.com");
+
+    /* A local path holds no secret, and the log is more useful naming it. */
+    out = switch_redact_file_target("/var/lib/freeswitch/recordings/call.wav", buf, sizeof(buf));
+    fst_check_string_equals(out, "/var/lib/freeswitch/recordings/call.wav");
+
+    out = switch_redact_file_target("{av_record_audio_only=true}/tmp/call.mp4", buf, sizeof(buf));
+    fst_check_string_equals(out, "/tmp/call.mp4");
+
+    /* Nothing usable to render. */
+    out = switch_redact_file_target(NULL, buf, sizeof(buf));
+    fst_check_string_equals(out, "(unknown)");
+    out = switch_redact_file_target("", buf, sizeof(buf));
+    fst_check_string_equals(out, "(unknown)");
+
+    /* An unterminated parameter group would leave the secret in the remainder. */
+    out = switch_redact_file_target("{auth_password=hunter2 rtmp://host.example.com/app", buf, sizeof(buf));
+    fst_check_string_equals(out, "(unknown)");
+}
+FST_TEST_END()
+
 FST_SUITE_END()
 
 FST_MINCORE_END()


### PR DESCRIPTION
Recorder stalls should not cost a call its media.

## The problem

Recordings are started from `execute_on_*`, so `record_session` runs **on the session thread**:

```
execute_on_answer_100='record_session {stereo=false,rw_timeout=15000000,av_record_audio_only=true,
modname=mod_av,av_audio_codec=pcm_mulaw}rtmp://recorder...:1935/wav/...?...&source=Trunking'
```

`avio_open()` performs the TCP connect **and the full RTMP handshake** synchronously, so while the
recorder is unresponsive that thread is not forwarding RTP. The `rw_timeout` above bounds the handshake
at 15s but does **not** bound the connect — measured against an unroutable address it made no difference
(5008ms vs 5009ms) and the connect fell back to ffmpeg's own 5s tcp default. So a stalled recorder cost
up to ~15s of dead air per call, and hangup could block for as long as a write did.

Three further sites made it worse: the untimed `switch_thread_join()` at close, the drain loop that
follows it, and `thread_buffer`, which is created with no maximum and so grows for the rest of the call.

## What this does

Bound every recorder interaction, then move the one that matters off the media path:

| | |
|---|---|
| bound the connect | enforced through ffmpeg's interrupt callback rather than an ffmpeg option, since `rw_timeout` does not cover the connect and its handling of the handshake varies by build |
| bound header and frame writes | same mechanism, so a peer that accepts and then stops reading cannot park the writer indefinitely |
| clamp a caller's `rw_timeout` | the operative control in production, where callers ask for 15s |
| cap `thread_buffer` | drop-oldest, so a stall costs bounded memory rather than the whole call's audio |
| bound the close-path join | measures lack of *progress*, so a slow-but-draining recorder is not cut off; aborts via a new `SCFC_ABORT_IO` file command when it really is wedged |
| **connect on the writer's thread** | the actual fix: the session thread returns immediately and keeps forwarding RTP while the connection is established |
| stop retrying a dead destination | once writes fail fast, the recording thread would otherwise spin at frame rate for the rest of the call |

Everything is off by default. `network-rw-timeout`, `network-max-rw-timeout`, `network-connect-timeout`
and `network-async-open` all default to 0/false in `avformat.conf`; `record_buffer_max_ms` and
`record_close_timeout_ms` mean unbounded/wait-forever when unset. The one exception is
`record_write_error_grace_ms`, which defaults to 1s rather than off, because the alternative default is
retrying a dead destination on every frame — it is configurable, and a value longer than any call
restores the previous behaviour.

## Measured

Against a stand-in recorder that accepts the TCP connection and never answers the handshake (the
incident's shape), with a probe recording on the same channel so any shortfall against wall clock is
media the call did not process:

| | settings off | settings on, stalled recorder | settings on, healthy recorder |
|---|---|---|---|
| media gap | **12.13s of dead air** | **0.00s** | **0.00s** |
| hangup | **20s+, channel stuck** | 0.53s | 0.59s |
| recording | — | abandoned 1.0s after the first failure | 11.99s / 199KB written normally |

## Scope

- **RTMP only.** RTSP is excluded deliberately: its muxer is `AVFMT_NOFILE`, it connects from a different
  place, and there is no recording traffic on it to justify changing that path.
- **Local files are untouched** by the timeouts. A slow disk is not a stuck peer, and aborting a healthy
  local write would damage a good recording. An explicit `SCFC_ABORT_IO` does still apply to them, since
  refusing it would leave a genuinely hung write with nothing to interrupt it and the caller waiting
  forever.
- Video RTMP writes are covered as well as audio.

## Testing

- `test_avformat` gains two cases: an unreachable recorder must give up inside the configured budget
  (measured 1002ms against a 1000ms setting; without the budget this runs to ffmpeg's 5s default), and a
  local recording must be unaffected by the network settings. Suite passes 7/7.
- The incident's own shape needs a live call, so it ships as a stand-in server plus a written procedure
  (`test/blackhole_rtmp.py`, `test/README.stall-testing.md`) rather than an automated test.
- Full build clean; verified end to end against a real FreeSWITCH with a real RTMP server for the healthy
  case.

## Rollback

Config only: `network-async-open=false` and the timeouts to 0 restores current behaviour without
redeploying a binary.

## Follow-ups

RTSP coverage, per-recorder timeout metrics and events (input to the alerting and CDR detection tickets),
and a per-recorder circuit breaker so not every call pays the timeout during an outage.
