### PR TITLE
TELCORE-374: Stop broadcast on bridge partner during hangup

### DIFF
--- a/src/switch_core_state_machine.c
+++ b/src/switch_core_state_machine.c
@@ -871,8 +871,32 @@ SWITCH_DECLARE(void) switch_core_session_hangup_state(switch_core_session_t *ses
 	switch_channel_set_hangup_time(session->channel);
 
 	switch_core_media_bug_remove_all(session);
-
 	switch_channel_stop_broadcast(session->channel);
+
+	/* TELCORE-374: When a channel hangs up during a bridge, its partner may
+	 * be blocked inside a broadcast playback loop (e.g. uuid_broadcast with
+	 * loop=infinity). The bridge thread is stuck in the playback and cannot
+	 * detect the peer hangup through normal read/write failure. Stop the
+	 * partner's broadcast so CF_STOP_BROADCAST + CF_BREAK interrupt the
+	 * playback loop, letting the bridge thread exit and hangup_after_bridge
+	 * take effect. */
+	{
+		const char *partner_uuid = switch_channel_get_partner_uuid(session->channel);
+		switch_core_session_t *partner_session = NULL;
+
+		if (partner_uuid && (partner_session = switch_core_session_locate(partner_uuid))) {
+			switch_channel_t *partner_channel = switch_core_session_get_channel(partner_session);
+
+			if (switch_channel_test_flag(partner_channel, CF_BROADCAST)) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+								  "%s Stopping broadcast on bridge partner %s due to hangup\n",
+								  switch_channel_get_name(session->channel), switch_channel_get_name(partner_channel));
+				switch_channel_stop_broadcast(partner_channel);
+			}
+
+			switch_core_session_rwunlock(partner_session);
+		}
+	}
 
 	switch_channel_set_variable(session->channel, "hangup_cause", switch_channel_cause2str(cause));
 	switch_channel_set_variable_printf(session->channel, "hangup_cause_q850", "%d", cause_q850);


### PR DESCRIPTION
## TELCORE-374: Fix b2bua correctly hangup call from both leg during playback

### Problem

When uuid_broadcast is called with 'both' during an active bridge (e.g. playing MOH with loop: infinity), the bridge thread enters the playback loop and cannot detect when the peer leg hangs up. The A-leg keeps playing MOH after B-leg hangs up, causing zombie calls, continued RTP, billing, and recording.

### Root Cause

In switch_core_session_hangup_state(), switch_channel_stop_broadcast() is called on the hanging-up channel but NOT on its bridge partner. The partner bridge thread is blocked in the broadcast playback loop (switch_ivr.c:644) and has no way to learn the peer is gone.

### Fix

In switch_core_session_hangup_state(), after stopping broadcast on the hanging-up channel, also stop broadcast on the bridge partner via switch_channel_get_partner_uuid(). Setting CF_STOP_BROADCAST + CF_BREAK on the partner interrupts the playback loop, letting the bridge thread exit and hangup_after_bridge take effect.

### Scope

- Single file: src/switch_core_state_machine.c
- 25 lines added, 1 removed
- C90 compliant, no new variables or config flags
- Guards: only acts when partner exists AND has CF_BROADCAST

### Related

- Linear: TELCORE-374
- Short-term fix: TELCORE-334
