### PR TITLE
TELCORE-383: preserve DTLS after unchanged late trickle

### DIFF
--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -106,11 +106,9 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(s
 	switch_sockaddr_t *handshake_peer_addr, dtls_state_t dtls_state, switch_bool_t handshake_peer_set, switch_bool_t is_rtcp);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_trickle_dtls(switch_bool_t new_ice,
 	switch_bool_t rtp_ready, const switch_rtp_pvt_ice_tuple_t *rtp_tuple,
-	switch_bool_t rtcp_muxed, const switch_rtp_pvt_ice_tuple_t *rtcp_tuple,
-	const char *previous_ufrag, const char *previous_pwd, const char *current_ufrag,
-	const char *current_pwd, dtls_state_t dtls_state, switch_bool_t is_trickle_recheck);
-SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_set_rtcp_remote_address(switch_rtp_t *rtp_session,
-	const char *host, switch_port_t port, const char **err);
+	switch_bool_t rtcp_muxed, const char *active_remote_ufrag, const char *active_remote_pwd,
+	const char *engine_remote_ufrag, const char *engine_remote_pwd,
+	dtls_state_t dtls_state, switch_bool_t is_trickle_recheck);
 SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_dtls_nomination_proof(
 	switch_bool_t authenticated_vanilla_use_candidate, switch_bool_t direct_username_match);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_guard_recovery_dtls_tuple(switch_sockaddr_t *current_addr,

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -90,12 +90,27 @@ typedef enum {
 	SWITCH_RTP_RECOVERY_NOMINATION_AUTHENTICATED_CURRENT
 } switch_rtp_recovery_nomination_proof_t;
 
+typedef struct {
+	switch_bool_t selected;
+	switch_bool_t ready;
+	const char *transport;
+	switch_sockaddr_t *current_addr;
+	switch_sockaddr_t *selected_addr;
+} switch_rtp_pvt_ice_tuple_t;
+
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
 	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
 	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(switch_sockaddr_t *current_addr,
 	switch_sockaddr_t *handshake_peer_addr, dtls_state_t dtls_state, switch_bool_t handshake_peer_set, switch_bool_t is_rtcp);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_trickle_dtls(switch_bool_t new_ice,
+	switch_bool_t rtp_ready, const switch_rtp_pvt_ice_tuple_t *rtp_tuple,
+	switch_bool_t rtcp_muxed, const switch_rtp_pvt_ice_tuple_t *rtcp_tuple,
+	const char *previous_ufrag, const char *previous_pwd, const char *current_ufrag,
+	const char *current_pwd, dtls_state_t dtls_state, switch_bool_t is_trickle_recheck);
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_set_rtcp_remote_address(switch_rtp_t *rtp_session,
+	const char *host, switch_port_t port, const char **err);
 SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_dtls_nomination_proof(
 	switch_bool_t authenticated_vanilla_use_candidate, switch_bool_t direct_username_match);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_guard_recovery_dtls_tuple(switch_sockaddr_t *current_addr,

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5329,15 +5329,25 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 	dtls_state_t check_ice_dtls_state = engine->rtp_session ? switch_rtp_dtls_state(engine->rtp_session, DTLS_TYPE_RTP) : DS_OFF;
 	int check_ice_is_reinvite = switch_channel_test_flag(smh->session->channel, CF_REINVITE) ? 1 : 0;
 	int is_trickle_recheck = (check_ice_dtls_state != DS_OFF) && !check_ice_is_reinvite;
-	const char *check_ice_remote_ufrag = engine->ice_in.ufrag;
-	const char *check_ice_remote_pwd = engine->ice_in.pwd;
+	char check_ice_active_ice_user[513] = "";
+	char check_ice_active_local_pwd[256] = "";
+	char check_ice_active_remote_pwd[256] = "";
+	char *check_ice_active_ufrag_separator = NULL;
+	const char *check_ice_active_remote_ufrag = "";
+	switch_bool_t check_ice_active_has_addr = SWITCH_FALSE;
 	const icand_t *selected_rtp_ice_candidate = NULL;
-	const icand_t *selected_rtcp_ice_candidate = NULL;
 	switch_rtp_pvt_ice_tuple_t check_ice_rtp_tuple = { 0 };
-	switch_rtp_pvt_ice_tuple_t check_ice_rtcp_tuple = { 0 };
 
 	check_ice_rtp_tuple.current_addr = engine->rtp_session ? switch_rtp_session_get_remote_addr(engine->rtp_session) : NULL;
-	check_ice_rtcp_tuple.current_addr = engine->rtp_session ? switch_rtp_session_get_rtcp_remote_addr(engine->rtp_session) : NULL;
+	if (engine->rtp_session && switch_rtp_pvt_get_ice_state(engine->rtp_session, IPR_RTP,
+			check_ice_active_ice_user, sizeof(check_ice_active_ice_user),
+			check_ice_active_local_pwd, sizeof(check_ice_active_local_pwd),
+			check_ice_active_remote_pwd, sizeof(check_ice_active_remote_pwd),
+			&check_ice_active_has_addr) == SWITCH_STATUS_SUCCESS &&
+			(check_ice_active_ufrag_separator = strchr(check_ice_active_ice_user, ':'))) {
+		*check_ice_active_ufrag_separator = '\0';
+		check_ice_active_remote_ufrag = check_ice_active_ice_user;
+	}
 
 	if (switch_true(switch_channel_get_variable_dup(smh->session->channel, "ignore_sdp_ice", SWITCH_FALSE, -1))) {
 		return SWITCH_STATUS_BREAK;
@@ -5913,28 +5923,14 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 		}
 	}
 
-	if (engine->ice_in.is_chosen[1]) {
-		selected_rtcp_ice_candidate = &engine->ice_in.cands[engine->ice_in.chosen[1]][1];
-		check_ice_rtcp_tuple.selected = SWITCH_TRUE;
-		check_ice_rtcp_tuple.ready = selected_rtcp_ice_candidate->ready ? SWITCH_TRUE : SWITCH_FALSE;
-		check_ice_rtcp_tuple.transport = selected_rtcp_ice_candidate->transport;
-		if (selected_rtcp_ice_candidate->con_addr && selected_rtcp_ice_candidate->con_port) {
-			if (switch_sockaddr_info_get(&check_ice_rtcp_tuple.selected_addr, selected_rtcp_ice_candidate->con_addr,
-				SWITCH_UNSPEC, selected_rtcp_ice_candidate->con_port, 0,
-				switch_core_session_get_pool(smh->session)) != SWITCH_STATUS_SUCCESS) {
-				check_ice_rtcp_tuple.selected_addr = NULL;
-			}
-		}
-	}
-
 	if (switch_rtp_pvt_should_preserve_trickle_dtls(engine->new_ice ? SWITCH_TRUE : SWITCH_FALSE,
 		engine->rtp_session && switch_rtp_ready(engine->rtp_session) ? SWITCH_TRUE : SWITCH_FALSE,
 		&check_ice_rtp_tuple, engine->rtcp_mux > 0 ? SWITCH_TRUE : SWITCH_FALSE,
-		&check_ice_rtcp_tuple, check_ice_remote_ufrag, check_ice_remote_pwd,
+		check_ice_active_remote_ufrag, check_ice_active_remote_pwd,
 		engine->ice_in.ufrag, engine->ice_in.pwd, check_ice_dtls_state,
 		is_trickle_recheck ? SWITCH_TRUE : SWITCH_FALSE)) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_INFO,
-			"Preserving %s ICE/DTLS after unchanged late trickle candidate %s:%u\n",
+			"Preserving %s ICE/DTLS after late trickle recheck; selected tuple remains %s:%u\n",
 			type2str(type), selected_rtp_ice_candidate->con_addr,
 			(unsigned)selected_rtp_ice_candidate->con_port);
 		engine->new_ice = 0;
@@ -5960,20 +5956,6 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 						rtcp_port, SWITCH_TRUE, &err) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_ERROR,
 						"%s RTP REPORTS ERROR: [%s]\n", type2str(type), err);
-				}
-
-				if (engine->rtcp_mux < 1 && selected_rtcp_ice_candidate && selected_rtcp_ice_candidate->ready &&
-						selected_rtcp_ice_candidate->con_addr && selected_rtcp_ice_candidate->con_port) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_INFO,
-						"Updating %s RTCP remote address for trickle ICE: %s:%d\n", type2str(type),
-						selected_rtcp_ice_candidate->con_addr, selected_rtcp_ice_candidate->con_port);
-
-					if (switch_rtp_pvt_set_rtcp_remote_address(engine->rtp_session,
-							selected_rtcp_ice_candidate->con_addr, selected_rtcp_ice_candidate->con_port,
-							&err) != SWITCH_STATUS_SUCCESS) {
-						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_ERROR,
-							"%s RTCP REPORTS ERROR: [%s]\n", type2str(type), err);
-					}
 				}
 			}
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -35,6 +35,7 @@
 #include <switch_stun.h>
 #include <switch_nat.h>
 #include "private/switch_core_pvt.h"
+#include "private/switch_rtp_pvt.h"
 #include <switch_curl.h>
 #include <errno.h>
 #include <sofia-sip/sdp.h>
@@ -5328,6 +5329,15 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 	dtls_state_t check_ice_dtls_state = engine->rtp_session ? switch_rtp_dtls_state(engine->rtp_session, DTLS_TYPE_RTP) : DS_OFF;
 	int check_ice_is_reinvite = switch_channel_test_flag(smh->session->channel, CF_REINVITE) ? 1 : 0;
 	int is_trickle_recheck = (check_ice_dtls_state != DS_OFF) && !check_ice_is_reinvite;
+	const char *check_ice_remote_ufrag = engine->ice_in.ufrag;
+	const char *check_ice_remote_pwd = engine->ice_in.pwd;
+	const icand_t *selected_rtp_ice_candidate = NULL;
+	const icand_t *selected_rtcp_ice_candidate = NULL;
+	switch_rtp_pvt_ice_tuple_t check_ice_rtp_tuple = { 0 };
+	switch_rtp_pvt_ice_tuple_t check_ice_rtcp_tuple = { 0 };
+
+	check_ice_rtp_tuple.current_addr = engine->rtp_session ? switch_rtp_session_get_remote_addr(engine->rtp_session) : NULL;
+	check_ice_rtcp_tuple.current_addr = engine->rtp_session ? switch_rtp_session_get_rtcp_remote_addr(engine->rtp_session) : NULL;
 
 	if (switch_true(switch_channel_get_variable_dup(smh->session->channel, "ignore_sdp_ice", SWITCH_FALSE, -1))) {
 		return SWITCH_STATUS_BREAK;
@@ -5889,6 +5899,47 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 		engine->rtcp_mux = -1;
 	}
 
+	if (engine->ice_in.is_chosen[0]) {
+		selected_rtp_ice_candidate = &engine->ice_in.cands[engine->ice_in.chosen[0]][0];
+		check_ice_rtp_tuple.selected = SWITCH_TRUE;
+		check_ice_rtp_tuple.ready = selected_rtp_ice_candidate->ready ? SWITCH_TRUE : SWITCH_FALSE;
+		check_ice_rtp_tuple.transport = selected_rtp_ice_candidate->transport;
+		if (selected_rtp_ice_candidate->con_addr && selected_rtp_ice_candidate->con_port) {
+			if (switch_sockaddr_info_get(&check_ice_rtp_tuple.selected_addr, selected_rtp_ice_candidate->con_addr,
+				SWITCH_UNSPEC, selected_rtp_ice_candidate->con_port, 0,
+				switch_core_session_get_pool(smh->session)) != SWITCH_STATUS_SUCCESS) {
+				check_ice_rtp_tuple.selected_addr = NULL;
+			}
+		}
+	}
+
+	if (engine->ice_in.is_chosen[1]) {
+		selected_rtcp_ice_candidate = &engine->ice_in.cands[engine->ice_in.chosen[1]][1];
+		check_ice_rtcp_tuple.selected = SWITCH_TRUE;
+		check_ice_rtcp_tuple.ready = selected_rtcp_ice_candidate->ready ? SWITCH_TRUE : SWITCH_FALSE;
+		check_ice_rtcp_tuple.transport = selected_rtcp_ice_candidate->transport;
+		if (selected_rtcp_ice_candidate->con_addr && selected_rtcp_ice_candidate->con_port) {
+			if (switch_sockaddr_info_get(&check_ice_rtcp_tuple.selected_addr, selected_rtcp_ice_candidate->con_addr,
+				SWITCH_UNSPEC, selected_rtcp_ice_candidate->con_port, 0,
+				switch_core_session_get_pool(smh->session)) != SWITCH_STATUS_SUCCESS) {
+				check_ice_rtcp_tuple.selected_addr = NULL;
+			}
+		}
+	}
+
+	if (switch_rtp_pvt_should_preserve_trickle_dtls(engine->new_ice ? SWITCH_TRUE : SWITCH_FALSE,
+		engine->rtp_session && switch_rtp_ready(engine->rtp_session) ? SWITCH_TRUE : SWITCH_FALSE,
+		&check_ice_rtp_tuple, engine->rtcp_mux > 0 ? SWITCH_TRUE : SWITCH_FALSE,
+		&check_ice_rtcp_tuple, check_ice_remote_ufrag, check_ice_remote_pwd,
+		engine->ice_in.ufrag, engine->ice_in.pwd, check_ice_dtls_state,
+		is_trickle_recheck ? SWITCH_TRUE : SWITCH_FALSE)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_INFO,
+			"Preserving %s ICE/DTLS after unchanged late trickle candidate %s:%u\n",
+			type2str(type), selected_rtp_ice_candidate->con_addr,
+			(unsigned)selected_rtp_ice_candidate->con_port);
+		engine->new_ice = 0;
+	}
+
 	if (engine->new_ice) {
 		if (switch_rtp_ready(engine->rtp_session) && engine->ice_in.cands[engine->ice_in.chosen[0]][0].ready) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_INFO, "RE-Activating %s ICE\n", type2str(type));
@@ -5909,6 +5960,20 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 						rtcp_port, SWITCH_TRUE, &err) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_ERROR,
 						"%s RTP REPORTS ERROR: [%s]\n", type2str(type), err);
+				}
+
+				if (engine->rtcp_mux < 1 && selected_rtcp_ice_candidate && selected_rtcp_ice_candidate->ready &&
+						selected_rtcp_ice_candidate->con_addr && selected_rtcp_ice_candidate->con_port) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_INFO,
+						"Updating %s RTCP remote address for trickle ICE: %s:%d\n", type2str(type),
+						selected_rtcp_ice_candidate->con_addr, selected_rtcp_ice_candidate->con_port);
+
+					if (switch_rtp_pvt_set_rtcp_remote_address(engine->rtp_session,
+							selected_rtcp_ice_candidate->con_addr, selected_rtcp_ice_candidate->con_port,
+							&err) != SWITCH_STATUS_SUCCESS) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_ERROR,
+							"%s RTCP REPORTS ERROR: [%s]\n", type2str(type), err);
+					}
 				}
 			}
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -834,6 +834,38 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(s
 	return switch_cmp_addr(current_addr, handshake_peer_addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
+static switch_bool_t ice_selected_tuple_unchanged(const switch_rtp_pvt_ice_tuple_t *tuple)
+{
+	if (!tuple || !tuple->selected || !tuple->ready || zstr(tuple->transport) ||
+		strcasecmp(tuple->transport, "udp") || !tuple->current_addr || !tuple->selected_addr) {
+		return SWITCH_FALSE;
+	}
+
+	return switch_cmp_addr(tuple->current_addr, tuple->selected_addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_trickle_dtls(switch_bool_t new_ice,
+	switch_bool_t rtp_ready, const switch_rtp_pvt_ice_tuple_t *rtp_tuple,
+	switch_bool_t rtcp_muxed, const switch_rtp_pvt_ice_tuple_t *rtcp_tuple,
+	const char *previous_ufrag, const char *previous_pwd, const char *current_ufrag,
+	const char *current_pwd, dtls_state_t dtls_state, switch_bool_t is_trickle_recheck)
+{
+	if (!new_ice || !rtp_ready || !is_trickle_recheck || dtls_state != DS_HANDSHAKE ||
+		zstr(previous_ufrag) || zstr(previous_pwd) || zstr(current_ufrag) || zstr(current_pwd)) {
+		return SWITCH_FALSE;
+	}
+
+	if (strcmp(previous_ufrag, current_ufrag) || strcmp(previous_pwd, current_pwd)) {
+		return SWITCH_FALSE;
+	}
+
+	if (!ice_selected_tuple_unchanged(rtp_tuple)) {
+		return SWITCH_FALSE;
+	}
+
+	return rtcp_muxed || ice_selected_tuple_unchanged(rtcp_tuple) ? SWITCH_TRUE : SWITCH_FALSE;
+}
+
 SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_dtls_nomination_proof(
 	switch_bool_t authenticated_vanilla_use_candidate, switch_bool_t direct_username_match)
 {
@@ -5458,6 +5490,62 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_
 	switch_mutex_unlock(rtp_session->write_mutex);
 
 	return status;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_set_rtcp_remote_address(switch_rtp_t *rtp_session,
+	const char *host, switch_port_t port, const char **err)
+{
+	switch_sockaddr_t *remote_addr = NULL;
+	switch_socket_t *new_sock = NULL;
+	switch_socket_t *old_sock = NULL;
+
+	RTP_SET_ERR(err, "Success");
+
+	if (!rtp_session || zstr(host) || !port ||
+		switch_sockaddr_info_get(&remote_addr, host, SWITCH_UNSPEC, port, 0,
+			rtp_session->pool) != SWITCH_STATUS_SUCCESS || !remote_addr) {
+		RTP_SET_ERR(err, "RTCP Remote Address Error!");
+		return SWITCH_STATUS_FALSE;
+	}
+
+	switch_mutex_lock(rtp_session->write_mutex);
+	if (rtp_session->flags[SWITCH_RTP_FLAG_ENABLE_RTCP]) {
+		if (rtp_session->rtcp_sock_input && rtp_session->rtcp_local_addr &&
+			switch_sockaddr_get_family(remote_addr) == switch_sockaddr_get_family(rtp_session->rtcp_local_addr)) {
+			new_sock = rtp_session->rtcp_sock_input;
+		} else {
+			if (rtp_socket_create(rtp_session, &new_sock,
+					switch_sockaddr_get_family(remote_addr)) != SWITCH_STATUS_SUCCESS) {
+				RTP_SET_ERR(err, "RTCP Socket Error!");
+				if (new_sock) {
+					rtp_socket_close(rtp_session, new_sock);
+				}
+				switch_mutex_unlock(rtp_session->write_mutex);
+				return SWITCH_STATUS_FALSE;
+			}
+		}
+	} else {
+		new_sock = rtp_session->rtcp_sock_output;
+	}
+
+	old_sock = rtp_session->rtcp_sock_output;
+	rtp_session->remote_rtcp_port = port;
+	rtp_session->rtcp_remote_addr = remote_addr;
+	rtp_session->rtcp_sock_output = new_sock;
+
+	switch_mutex_lock(rtp_session->ice_mutex);
+	if (rtp_session->rtcp_dtls) {
+		rtp_session->rtcp_dtls->remote_addr = remote_addr;
+		rtp_session->rtcp_dtls->sock_output = new_sock;
+	}
+	switch_mutex_unlock(rtp_session->ice_mutex);
+
+	if (old_sock && old_sock != new_sock && old_sock != rtp_session->rtcp_sock_input && old_sock != rtp_session->sock_input) {
+		rtp_socket_close(rtp_session, old_sock);
+	}
+	switch_mutex_unlock(rtp_session->write_mutex);
+
+	return SWITCH_STATUS_SUCCESS;
 }
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd, const char *codec_iananame)

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -846,16 +846,20 @@ static switch_bool_t ice_selected_tuple_unchanged(const switch_rtp_pvt_ice_tuple
 
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_trickle_dtls(switch_bool_t new_ice,
 	switch_bool_t rtp_ready, const switch_rtp_pvt_ice_tuple_t *rtp_tuple,
-	switch_bool_t rtcp_muxed, const switch_rtp_pvt_ice_tuple_t *rtcp_tuple,
-	const char *previous_ufrag, const char *previous_pwd, const char *current_ufrag,
-	const char *current_pwd, dtls_state_t dtls_state, switch_bool_t is_trickle_recheck)
+	switch_bool_t rtcp_muxed, const char *active_remote_ufrag, const char *active_remote_pwd,
+	const char *engine_remote_ufrag, const char *engine_remote_pwd,
+	dtls_state_t dtls_state, switch_bool_t is_trickle_recheck)
 {
-	if (!new_ice || !rtp_ready || !is_trickle_recheck || dtls_state != DS_HANDSHAKE ||
-		zstr(previous_ufrag) || zstr(previous_pwd) || zstr(current_ufrag) || zstr(current_pwd)) {
+	/* Keep separate RTCP on the established reactivation path: its address and
+	 * socket are consumed by senders that do not share one retarget lock. */
+	if (!new_ice || !rtp_ready || !rtcp_muxed || !is_trickle_recheck || dtls_state != DS_HANDSHAKE ||
+		zstr(active_remote_ufrag) || zstr(active_remote_pwd) ||
+		zstr(engine_remote_ufrag) || zstr(engine_remote_pwd)) {
 		return SWITCH_FALSE;
 	}
 
-	if (strcmp(previous_ufrag, current_ufrag) || strcmp(previous_pwd, current_pwd)) {
+	if (strcmp(active_remote_ufrag, engine_remote_ufrag) ||
+		strcmp(active_remote_pwd, engine_remote_pwd)) {
 		return SWITCH_FALSE;
 	}
 
@@ -863,7 +867,7 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_trickle_dtls(switch
 		return SWITCH_FALSE;
 	}
 
-	return rtcp_muxed || ice_selected_tuple_unchanged(rtcp_tuple) ? SWITCH_TRUE : SWITCH_FALSE;
+	return SWITCH_TRUE;
 }
 
 SWITCH_DECLARE(switch_rtp_recovery_nomination_proof_t) switch_rtp_pvt_recovery_dtls_nomination_proof(
@@ -5490,62 +5494,6 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_address(switch_rtp_t *rtp_
 	switch_mutex_unlock(rtp_session->write_mutex);
 
 	return status;
-}
-
-SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_set_rtcp_remote_address(switch_rtp_t *rtp_session,
-	const char *host, switch_port_t port, const char **err)
-{
-	switch_sockaddr_t *remote_addr = NULL;
-	switch_socket_t *new_sock = NULL;
-	switch_socket_t *old_sock = NULL;
-
-	RTP_SET_ERR(err, "Success");
-
-	if (!rtp_session || zstr(host) || !port ||
-		switch_sockaddr_info_get(&remote_addr, host, SWITCH_UNSPEC, port, 0,
-			rtp_session->pool) != SWITCH_STATUS_SUCCESS || !remote_addr) {
-		RTP_SET_ERR(err, "RTCP Remote Address Error!");
-		return SWITCH_STATUS_FALSE;
-	}
-
-	switch_mutex_lock(rtp_session->write_mutex);
-	if (rtp_session->flags[SWITCH_RTP_FLAG_ENABLE_RTCP]) {
-		if (rtp_session->rtcp_sock_input && rtp_session->rtcp_local_addr &&
-			switch_sockaddr_get_family(remote_addr) == switch_sockaddr_get_family(rtp_session->rtcp_local_addr)) {
-			new_sock = rtp_session->rtcp_sock_input;
-		} else {
-			if (rtp_socket_create(rtp_session, &new_sock,
-					switch_sockaddr_get_family(remote_addr)) != SWITCH_STATUS_SUCCESS) {
-				RTP_SET_ERR(err, "RTCP Socket Error!");
-				if (new_sock) {
-					rtp_socket_close(rtp_session, new_sock);
-				}
-				switch_mutex_unlock(rtp_session->write_mutex);
-				return SWITCH_STATUS_FALSE;
-			}
-		}
-	} else {
-		new_sock = rtp_session->rtcp_sock_output;
-	}
-
-	old_sock = rtp_session->rtcp_sock_output;
-	rtp_session->remote_rtcp_port = port;
-	rtp_session->rtcp_remote_addr = remote_addr;
-	rtp_session->rtcp_sock_output = new_sock;
-
-	switch_mutex_lock(rtp_session->ice_mutex);
-	if (rtp_session->rtcp_dtls) {
-		rtp_session->rtcp_dtls->remote_addr = remote_addr;
-		rtp_session->rtcp_dtls->sock_output = new_sock;
-	}
-	switch_mutex_unlock(rtp_session->ice_mutex);
-
-	if (old_sock && old_sock != new_sock && old_sock != rtp_session->rtcp_sock_input && old_sock != rtp_session->sock_input) {
-		rtp_socket_close(rtp_session, old_sock);
-	}
-	switch_mutex_unlock(rtp_session->write_mutex);
-
-	return SWITCH_STATUS_SUCCESS;
 }
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_fork_set(switch_rtp_t *rtp_session, switch_fork_direction_t direction, const char *host, switch_port_t port, uint32_t ssrc, const char *cmd, const char *codec_iananame)

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -479,11 +479,7 @@ FST_TEARDOWN_END()
 		switch_sockaddr_t *current_rtp_addr = NULL;
 		switch_sockaddr_t *same_rtp_addr = NULL;
 		switch_sockaddr_t *different_rtp_addr = NULL;
-		switch_sockaddr_t *current_rtcp_addr = NULL;
-		switch_sockaddr_t *same_rtcp_addr = NULL;
-		switch_sockaddr_t *different_rtcp_addr = NULL;
 		switch_rtp_pvt_ice_tuple_t rtp_tuple = { 0 };
-		switch_rtp_pvt_ice_tuple_t rtcp_tuple = { 0 };
 
 		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
 		fst_xcheck(switch_sockaddr_info_get(&current_rtp_addr, "198.51.100.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
@@ -492,109 +488,82 @@ FST_TEARDOWN_END()
 			"same RTP address");
 		fst_xcheck(switch_sockaddr_info_get(&different_rtp_addr, "198.51.100.10", SWITCH_UNSPEC, 40002, 0, pool) == SWITCH_STATUS_SUCCESS,
 			"different RTP address");
-		fst_xcheck(switch_sockaddr_info_get(&current_rtcp_addr, "198.51.100.10", SWITCH_UNSPEC, 40001, 0, pool) == SWITCH_STATUS_SUCCESS,
-			"current RTCP address");
-		fst_xcheck(switch_sockaddr_info_get(&same_rtcp_addr, "198.51.100.10", SWITCH_UNSPEC, 40001, 0, pool) == SWITCH_STATUS_SUCCESS,
-			"same RTCP address");
-		fst_xcheck(switch_sockaddr_info_get(&different_rtcp_addr, "198.51.100.10", SWITCH_UNSPEC, 40003, 0, pool) == SWITCH_STATUS_SUCCESS,
-			"different RTCP address");
 
 		rtp_tuple.selected = SWITCH_TRUE;
 		rtp_tuple.ready = SWITCH_TRUE;
 		rtp_tuple.transport = "udp";
 		rtp_tuple.current_addr = current_rtp_addr;
 		rtp_tuple.selected_addr = same_rtp_addr;
-		rtcp_tuple.selected = SWITCH_TRUE;
-		rtcp_tuple.ready = SWITCH_TRUE;
-		rtcp_tuple.transport = "udp";
-		rtcp_tuple.current_addr = current_rtcp_addr;
-		rtcp_tuple.selected_addr = same_rtcp_addr;
 
 		fst_check(switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
-		fst_check(switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_FALSE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_FALSE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_FALSE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 
 		rtp_tuple.selected = SWITCH_FALSE;
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		rtp_tuple.selected = SWITCH_TRUE;
 		rtp_tuple.ready = SWITCH_FALSE;
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		rtp_tuple.ready = SWITCH_TRUE;
 		rtp_tuple.transport = "tcp";
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		rtp_tuple.transport = NULL;
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		rtp_tuple.transport = "udp";
 		rtp_tuple.selected_addr = different_rtp_addr;
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		rtp_tuple.selected_addr = same_rtp_addr;
 
-		rtcp_tuple.selected_addr = different_rtcp_addr;
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
-			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
-			DS_HANDSHAKE, SWITCH_TRUE));
-		rtcp_tuple.selected_addr = same_rtcp_addr;
-		rtcp_tuple.transport = "tcp";
-		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
-			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
-			DS_HANDSHAKE, SWITCH_TRUE));
-		rtcp_tuple.transport = NULL;
-		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
-			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
-			DS_HANDSHAKE, SWITCH_TRUE));
-		rtcp_tuple.transport = "udp";
-		rtcp_tuple.current_addr = NULL;
-		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
-			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
-			DS_HANDSHAKE, SWITCH_TRUE));
-		rtcp_tuple.current_addr = current_rtcp_addr;
-
-		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "newRemoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "newRemotePassword",
 			DS_HANDSHAKE, SWITCH_TRUE));
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
+			NULL, "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE,
+			"remoteUfrag", NULL, "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_READY, SWITCH_TRUE));
 		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
-			&rtp_tuple, SWITCH_TRUE, NULL,
+			&rtp_tuple, SWITCH_TRUE,
 			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
 			DS_HANDSHAKE, SWITCH_FALSE));
 

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -473,6 +473,134 @@ FST_TEARDOWN_END()
 		switch_core_destroy_memory_pool(&pool);
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_same_generation_late_trickle_preserves_dtls_handshake)
+	{
+		switch_memory_pool_t *pool = NULL;
+		switch_sockaddr_t *current_rtp_addr = NULL;
+		switch_sockaddr_t *same_rtp_addr = NULL;
+		switch_sockaddr_t *different_rtp_addr = NULL;
+		switch_sockaddr_t *current_rtcp_addr = NULL;
+		switch_sockaddr_t *same_rtcp_addr = NULL;
+		switch_sockaddr_t *different_rtcp_addr = NULL;
+		switch_rtp_pvt_ice_tuple_t rtp_tuple = { 0 };
+		switch_rtp_pvt_ice_tuple_t rtcp_tuple = { 0 };
+
+		fst_xcheck(switch_core_new_memory_pool(&pool) == SWITCH_STATUS_SUCCESS, "switch_core_new_memory_pool()");
+		fst_xcheck(switch_sockaddr_info_get(&current_rtp_addr, "198.51.100.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current RTP address");
+		fst_xcheck(switch_sockaddr_info_get(&same_rtp_addr, "198.51.100.10", SWITCH_UNSPEC, 40000, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"same RTP address");
+		fst_xcheck(switch_sockaddr_info_get(&different_rtp_addr, "198.51.100.10", SWITCH_UNSPEC, 40002, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"different RTP address");
+		fst_xcheck(switch_sockaddr_info_get(&current_rtcp_addr, "198.51.100.10", SWITCH_UNSPEC, 40001, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"current RTCP address");
+		fst_xcheck(switch_sockaddr_info_get(&same_rtcp_addr, "198.51.100.10", SWITCH_UNSPEC, 40001, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"same RTCP address");
+		fst_xcheck(switch_sockaddr_info_get(&different_rtcp_addr, "198.51.100.10", SWITCH_UNSPEC, 40003, 0, pool) == SWITCH_STATUS_SUCCESS,
+			"different RTCP address");
+
+		rtp_tuple.selected = SWITCH_TRUE;
+		rtp_tuple.ready = SWITCH_TRUE;
+		rtp_tuple.transport = "udp";
+		rtp_tuple.current_addr = current_rtp_addr;
+		rtp_tuple.selected_addr = same_rtp_addr;
+		rtcp_tuple.selected = SWITCH_TRUE;
+		rtcp_tuple.ready = SWITCH_TRUE;
+		rtcp_tuple.transport = "udp";
+		rtcp_tuple.current_addr = current_rtcp_addr;
+		rtcp_tuple.selected_addr = same_rtcp_addr;
+
+		fst_check(switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_FALSE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_FALSE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+
+		rtp_tuple.selected = SWITCH_FALSE;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtp_tuple.selected = SWITCH_TRUE;
+		rtp_tuple.ready = SWITCH_FALSE;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtp_tuple.ready = SWITCH_TRUE;
+		rtp_tuple.transport = "tcp";
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtp_tuple.transport = NULL;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtp_tuple.transport = "udp";
+		rtp_tuple.selected_addr = different_rtp_addr;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtp_tuple.selected_addr = same_rtp_addr;
+
+		rtcp_tuple.selected_addr = different_rtcp_addr;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtcp_tuple.selected_addr = same_rtcp_addr;
+		rtcp_tuple.transport = "tcp";
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtcp_tuple.transport = NULL;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtcp_tuple.transport = "udp";
+		rtcp_tuple.current_addr = NULL;
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_FALSE, &rtcp_tuple,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		rtcp_tuple.current_addr = current_rtcp_addr;
+
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "newRemoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "newRemotePassword",
+			DS_HANDSHAKE, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_READY, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_should_preserve_trickle_dtls(SWITCH_TRUE, SWITCH_TRUE,
+			&rtp_tuple, SWITCH_TRUE, NULL,
+			"remoteUfrag", "remotePassword", "remoteUfrag", "remotePassword",
+			DS_HANDSHAKE, SWITCH_FALSE));
+
+		switch_core_destroy_memory_pool(&pool);
+	}
+	FST_TEST_END()
 	FST_TEST_BEGIN(test_recovery_dtls_nomination_proof_requires_authenticated_direct_request)
 	{
 		fst_check(switch_rtp_pvt_recovery_dtls_nomination_proof(SWITCH_FALSE, SWITCH_FALSE) ==


### PR DESCRIPTION
## Summary

- preserve an active DTLS handshake when a late same-generation trickle candidate leaves the selected UDP RTP tuple and active remote ICE credentials unchanged
- compare the engine generation against credentials copied from the active RTP ICE state rather than against aliases of the engine fields
- limit preservation to RTCP-mux sessions; separate RTCP conservatively remains on the established reactivation path
- keep the existing reactivation path for ICE restarts, tuple changes, non-UDP candidates, and non-handshake DTLS states
- cover preservation and fall-through gates with regression tests

## Validation

- `libfreeswitch.la` compiled and linked with declaration-after-statement errors enabled
- `switch_stun`: 19/19 passed
- `switch_trickle_ice`: passed
- `git diff --cached --check` passed before commit
- staged changes received a final LGTM review with no blocking or should-fix findings

Browser/TREAT validation remains for the deployed build.

Linear: https://linear.app/telnyx/issue/TELCORE-383/prevent-late-trickle-ice-recheck-from-resetting-dtls-after-startup
