### PR TITLE
TELCORE-404: preserve AMR-WB SID during transcode

### DIFF
--- a/src/mod/codecs/mod_amrwb/amrwb_be.c
+++ b/src/mod/codecs/mod_amrwb/amrwb_be.c
@@ -38,6 +38,7 @@
 #include "amrwb_be.h"
 
 extern const int switch_amrwb_frame_sizes[];
+extern const int switch_amrwb_frame_bits[];
 
 /* Bandwidth Efficient AMR-WB */
 /* https://tools.ietf.org/html/rfc4867#page-17 */
@@ -99,6 +100,10 @@ extern switch_bool_t switch_amrwb_unpack_be(unsigned char *encoded_buf, uint8_t 
 	uint8_t shift_tocs[2] = {0x00, 0x00};
 	uint8_t *shift_buf;
 
+	if (!encoded_buf || !tmp || encoded_len < 2) {
+		return SWITCH_FALSE;
+	}
+
 	memcpy(shift_tocs, encoded_buf, 2);
 	/* shift for BE */
 	switch_amr_array_lshift(4, shift_tocs, 2);
@@ -107,14 +112,19 @@ extern switch_bool_t switch_amrwb_unpack_be(unsigned char *encoded_buf, uint8_t 
 	switch_amr_array_lshift(2, shift_buf, encoded_len - 1);
 	/* get frame size */
 	index = ((shift_tocs[0] >> 3) & 0x0f);
-	if (index > 10 && index != 0xe && index != 0xf) {
+	if (index >= 10 && index != 0xe && index != 0xf) {
 
 		return SWITCH_FALSE;
 	}
 
 	framesz = switch_amrwb_frame_sizes[index];
+	if (encoded_len * 8 < switch_amrwb_frame_bits[index] + 10) {
+		return SWITCH_FALSE;
+	}
 	tmp[0] = shift_tocs[0]; /* save TOC */
-	memcpy(&tmp[1], shift_buf, framesz);
+	if (framesz) {
+		memcpy(&tmp[1], shift_buf, framesz);
+	}
 
 	return SWITCH_TRUE;
 }

--- a/src/mod/codecs/mod_amrwb/amrwb_be.c
+++ b/src/mod/codecs/mod_amrwb/amrwb_be.c
@@ -75,7 +75,7 @@ extern switch_bool_t switch_amrwb_pack_be(unsigned char *shift_buf, int n)
 	*/
 
 	ft = save_toc >> 3 ; /* drop Q, P1, P2  */
-	ft &= ~(1 << 5); /* clear -  will mark just 1 frame - bit F */
+	ft &= ~(1 << 4); /* clear F: this encoder emits exactly one frame */
 
 	/* we only encode one frame, so bit 0 of TOC will be 0 */
 	shift_buf[0] |= (ft >> 1); /* first 3 bits of FT */
@@ -107,6 +107,10 @@ extern switch_bool_t switch_amrwb_unpack_be(unsigned char *encoded_buf, uint8_t 
 	memcpy(shift_tocs, encoded_buf, 2);
 	/* shift for BE */
 	switch_amr_array_lshift(4, shift_tocs, 2);
+	/* This implementation decodes exactly one 20 ms frame per payload. */
+	if (shift_tocs[0] & 0x80) {
+		return SWITCH_FALSE;
+	}
 	shift_buf = encoded_buf + 1; /* skip CMR */
 	/* shift for BE */
 	switch_amr_array_lshift(2, shift_buf, encoded_len - 1);

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -141,18 +141,24 @@ static struct {
 	switch_byte_t silence_supp_off;
 } globals;
 
-const int switch_amrwb_frame_sizes[] = {17, 23, 32, 36, 40, 46, 50, 58, 60, 5, 0, 0, 0, 0, 1, 1};
+const int switch_amrwb_frame_sizes[] = {17, 23, 32, 36, 40, 46, 50, 58, 60, 5, 0, 0, 0, 0, 0, 0};
+const int switch_amrwb_frame_bits[] = {132, 177, 253, 285, 317, 365, 397, 461, 477, 40, 0, 0, 0, 0, 0, 0};
 
 #define SWITCH_AMRWB_OUT_MAX_SIZE 62
 #define SWITCH_AMRWB_MODES 10 /* Silence Indicator (SID) included */
 
-#define invalid_frame_type (index > SWITCH_AMRWB_MODES && index != 0xe && index != 0xf) /* include SPEECH_LOST and NO_DATA*/
+#define invalid_frame_type (index >= SWITCH_AMRWB_MODES && index != 0xe && index != 0xf) /* include SPEECH_LOST and NO_DATA*/
 
 static switch_bool_t switch_amrwb_unpack_oa(unsigned char *buf, uint8_t *tmp, int encoded_data_len)
 {
 	uint8_t *tocs;
 	int index;
 	int framesz;
+
+	if (!buf || !tmp || encoded_data_len < 2) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder (OA): Invalid frame size: %d\n", encoded_data_len);
+		return SWITCH_FALSE;
+	}
 
 	buf++;/* CMR skip */
 	tocs = buf;
@@ -164,12 +170,14 @@ static switch_bool_t switch_amrwb_unpack_oa(unsigned char *buf, uint8_t *tmp, in
 		return SWITCH_FALSE;
 	}
 	framesz = switch_amrwb_frame_sizes[index];
-	if (framesz > encoded_data_len - 1) {
+	if (encoded_data_len < framesz + 2) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder (OA): Invalid frame size: %d\n", framesz);
 		return SWITCH_FALSE;
 	}
 	tmp[0] = tocs[0];
-	memcpy(&tmp[1], buf, framesz);
+	if (framesz) {
+		memcpy(&tmp[1], buf, framesz);
+	}
 
 	return SWITCH_TRUE;
 }
@@ -221,6 +229,11 @@ static switch_bool_t switch_amrwb_info(switch_codec_t *codec, unsigned char *enc
 	if (!encoded_buf) {
 		return SWITCH_FALSE;
 	}
+	if (encoded_data_len < 2) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(codec->session), SWITCH_LOG_ERROR,
+			"%s: Invalid AMR-WB payload size: %d\n", print_text, encoded_data_len);
+		return SWITCH_FALSE;
+	}
 
 	/* payload format can be OA (octed-aligned) or BE (bandwidth efficient)*/
 	if (payload_format) {
@@ -233,6 +246,11 @@ static switch_bool_t switch_amrwb_info(switch_codec_t *codec, unsigned char *enc
 			return SWITCH_FALSE;
 		}
 		framesz = switch_amrwb_frame_sizes[index];
+		if (encoded_data_len < framesz + 2) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(codec->session), SWITCH_LOG_ERROR,
+				"%s (OA): Invalid frame size: %d\n", print_text, encoded_data_len);
+			return SWITCH_FALSE;
+		}
 		not_last_frame = (tocs[0] >> 7) & 1;
 		q = (tocs[0] >> 2) & 1;
 		ft = tocs[0] >> 3;
@@ -252,6 +270,11 @@ static switch_bool_t switch_amrwb_info(switch_codec_t *codec, unsigned char *enc
 			return SWITCH_FALSE;
 		}
 		framesz = switch_amrwb_frame_sizes[index];
+		if (encoded_data_len * 8 < switch_amrwb_frame_bits[index] + 10) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(codec->session), SWITCH_LOG_ERROR,
+				"%s (BE): Invalid frame size: %d\n", print_text, encoded_data_len);
+			return SWITCH_FALSE;
+		}
 	}
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(codec->session), SWITCH_LOG_DEBUG, 
@@ -550,6 +573,7 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 #else
 	struct amrwb_context *context = codec->private_info;
 	int n;
+	int relayed_size;
 	unsigned char *shift_buf = encoded_data;
 	switch_bool_t relayed_sid = SWITCH_FALSE;
 
@@ -557,15 +581,18 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 		return SWITCH_STATUS_FALSE;
 	}
 
-	n = switch_amrwb_relay_sid(other_codec, decoded_data, decoded_data_len, encoded_data);
-	if (n) {
-		relayed_sid = SWITCH_TRUE;
-	} else {
-		n = E_IF_encode(context->encoder_state, context->enc_mode, (int16_t *) decoded_data, (switch_byte_t *) encoded_data + 1, 0);
-	}
+	/* Always advance the stateful encoder, even when the wire payload is replaced
+	 * with the source SID, so speech resumes from the correct encoder history. */
+	n = E_IF_encode(context->encoder_state, context->enc_mode, (int16_t *) decoded_data, (switch_byte_t *) encoded_data + 1, 0);
 	if (n < 0) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB encoder: E_IF_encode() ERROR!\n");
 		return SWITCH_STATUS_FALSE;
+	}
+
+	relayed_size = switch_amrwb_relay_sid(other_codec, decoded_data, decoded_data_len, encoded_data);
+	if (relayed_size) {
+		n = relayed_size;
+		relayed_sid = SWITCH_TRUE;
 	}
 
 	/* set CMR + TOC (F + 3 bits of FT), 1111 = CMR: No mode request */
@@ -610,7 +637,19 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	uint8_t tmp[SWITCH_AMRWB_OUT_MAX_SIZE];
 	int frame_type;
 
-	if (!context || encoded_data_len > SWITCH_AMRWB_OUT_MAX_SIZE) {
+	if (!context) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid context or encoded data length %d\n", encoded_data_len);
+		goto decode_error;
+	}
+
+	/* Never let a failed or non-SID decode reuse a SID cached by the
+	 * preceding packet. */
+	switch_mutex_lock(context->decoded_sid_mutex);
+	context->decoded_sid_valid = SWITCH_FALSE;
+	context->decoded_sid_pcm_len = 0;
+	switch_mutex_unlock(context->decoded_sid_mutex);
+
+	if (!encoded_data || encoded_data_len > SWITCH_AMRWB_OUT_MAX_SIZE) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid context or encoded data length %d\n", encoded_data_len);
 		goto decode_error;
 	}
@@ -637,10 +676,6 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	}
 
 	frame_type = (tmp[0] >> 3) & 0x0f;
-	switch_mutex_lock(context->decoded_sid_mutex);
-	context->decoded_sid_valid = SWITCH_FALSE;
-	context->decoded_sid_pcm_len = 0;
-	switch_mutex_unlock(context->decoded_sid_mutex);
 
 	D_IF_decode(context->decoder_state, tmp, (int16_t *) decoded_data, 0);
 	*decoded_data_len = codec->implementation->decoded_bytes_per_packet;

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -102,6 +102,9 @@ typedef enum {
 	AMRWB_BITRATE_24K
 } amrwb_bitrate_t;
 
+#define SWITCH_AMRWB_SID_FRAME_TYPE 9
+#define SWITCH_AMRWB_SID_FRAME_SIZE 6
+
 struct amrwb_context {
 	void *encoder_state;
 	void *decoder_state;
@@ -114,6 +117,11 @@ struct amrwb_context {
 	switch_byte_t flags;
 	int max_red;
 	int debug;
+	switch_byte_t decoded_sid[SWITCH_AMRWB_SID_FRAME_SIZE];
+	void *decoded_sid_pcm;
+	uint32_t decoded_sid_pcm_len;
+	switch_bool_t decoded_sid_valid;
+	switch_mutex_t *decoded_sid_mutex;
 };
 
 #define SWITCH_AMRWB_DEFAULT_BITRATE AMRWB_BITRATE_24K
@@ -170,6 +178,38 @@ static switch_bool_t switch_amrwb_pack_oa(unsigned char *shift_buf, int n)
 {
 /* Interleaving code here */
 	return SWITCH_TRUE;
+}
+
+static int switch_amrwb_relay_sid(switch_codec_t *other_codec, void *decoded_data, uint32_t decoded_data_len, switch_byte_t *encoded_data)
+{
+	struct amrwb_context *other_context;
+	int size = 0;
+
+	if (!other_codec || !other_codec->implementation || !other_codec->implementation->iananame || !other_codec->implementation->modname ||
+		strcasecmp(other_codec->implementation->iananame, "AMR-WB") ||
+		strcmp(other_codec->implementation->modname, "mod_amrwb")) {
+		return 0;
+	}
+
+	other_context = other_codec->private_info;
+	if (!other_context || !other_context->decoded_sid_mutex) {
+		return 0;
+	}
+
+	switch_mutex_lock(other_context->decoded_sid_mutex);
+	if (!other_context->decoded_sid_valid ||
+		other_context->decoded_sid_pcm_len != decoded_data_len ||
+		memcmp(other_context->decoded_sid_pcm, decoded_data, decoded_data_len)) {
+		goto done;
+	}
+
+	encoded_data[0] = 0xf0;
+	memcpy(encoded_data + 1, other_context->decoded_sid, SWITCH_AMRWB_SID_FRAME_SIZE);
+	size = SWITCH_AMRWB_SID_FRAME_SIZE;
+
+done:
+	switch_mutex_unlock(other_context->decoded_sid_mutex);
+	return size;
 }
 
 static switch_bool_t switch_amrwb_info(switch_codec_t *codec, unsigned char *encoded_buf, int encoded_data_len, int payload_format, char *print_text)
@@ -471,6 +511,9 @@ static switch_status_t switch_amrwb_init(switch_codec_t *codec, switch_codec_fla
 			context->decoder_state = D_IF_init();
 		}
 
+		context->decoded_sid_pcm = switch_core_alloc(codec->memory_pool, codec->implementation->decoded_bytes_per_packet);
+		switch_mutex_init(&context->decoded_sid_mutex, SWITCH_MUTEX_UNNESTED, codec->memory_pool);
+
 		codec->private_info = context;
 
 		return SWITCH_STATUS_SUCCESS;
@@ -508,12 +551,18 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 	struct amrwb_context *context = codec->private_info;
 	int n;
 	unsigned char *shift_buf = encoded_data;
+	switch_bool_t relayed_sid = SWITCH_FALSE;
 
 	if (!context) {
 		return SWITCH_STATUS_FALSE;
 	}
 
-	n = E_IF_encode(context->encoder_state, context->enc_mode, (int16_t *) decoded_data, (switch_byte_t *) encoded_data + 1, 0);
+	n = switch_amrwb_relay_sid(other_codec, decoded_data, decoded_data_len, encoded_data);
+	if (n) {
+		relayed_sid = SWITCH_TRUE;
+	} else {
+		n = E_IF_encode(context->encoder_state, context->enc_mode, (int16_t *) decoded_data, (switch_byte_t *) encoded_data + 1, 0);
+	}
 	if (n < 0) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB encoder: E_IF_encode() ERROR!\n");
 		return SWITCH_STATUS_FALSE;
@@ -529,6 +578,9 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 		*encoded_data_len = n + 1;
 	} else {
 		switch_amrwb_pack_be(shift_buf, n);
+		if (relayed_sid) {
+			*encoded_data_len = n + 1;
+		}
 	}
 
 	switch_mutex_lock(global_lock);
@@ -556,6 +608,7 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	struct amrwb_context *context = codec->private_info;
 	unsigned char buf[SWITCH_AMRWB_OUT_MAX_SIZE];
 	uint8_t tmp[SWITCH_AMRWB_OUT_MAX_SIZE];
+	int frame_type;
 
 	if (!context || encoded_data_len > SWITCH_AMRWB_OUT_MAX_SIZE) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid context or encoded data length %d\n", encoded_data_len);
@@ -583,9 +636,24 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 		}
 	}
 
-	D_IF_decode(context->decoder_state, tmp, (int16_t *) decoded_data, 0);
+	frame_type = (tmp[0] >> 3) & 0x0f;
+	switch_mutex_lock(context->decoded_sid_mutex);
+	context->decoded_sid_valid = SWITCH_FALSE;
+	context->decoded_sid_pcm_len = 0;
+	switch_mutex_unlock(context->decoded_sid_mutex);
 
+	D_IF_decode(context->decoder_state, tmp, (int16_t *) decoded_data, 0);
 	*decoded_data_len = codec->implementation->decoded_bytes_per_packet;
+
+	if (frame_type == SWITCH_AMRWB_SID_FRAME_TYPE) {
+		switch_mutex_lock(context->decoded_sid_mutex);
+		memcpy(context->decoded_sid, tmp, SWITCH_AMRWB_SID_FRAME_SIZE);
+		context->decoded_sid[0] &= 0xfc;
+		memcpy(context->decoded_sid_pcm, decoded_data, *decoded_data_len);
+		context->decoded_sid_pcm_len = *decoded_data_len;
+		context->decoded_sid_valid = SWITCH_TRUE;
+		switch_mutex_unlock(context->decoded_sid_mutex);
+	}
 
 	return SWITCH_STATUS_SUCCESS;
 

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -162,6 +162,10 @@ static switch_bool_t switch_amrwb_unpack_oa(unsigned char *buf, uint8_t *tmp, in
 
 	buf++;/* CMR skip */
 	tocs = buf;
+	if (tocs[0] & 0x80) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder (OA): Multiple frames per payload are not supported\n");
+		return SWITCH_FALSE;
+	}
 	index = ((tocs[0]>>3) & 0xf);
 	buf++; /* point to voice payload */
 
@@ -205,6 +209,9 @@ static int switch_amrwb_relay_sid(switch_codec_t *other_codec, void *decoded_dat
 	}
 
 	switch_mutex_lock(other_context->decoded_sid_mutex);
+	/* Relay is safe only while the PCM is byte-identical to the source
+	 * decoder output. Denoising, volume changes, resampling, or PLC must
+	 * use the target encoder output instead of the cached source SID. */
 	if (!other_context->decoded_sid_valid ||
 		other_context->decoded_sid_pcm_len != decoded_data_len ||
 		memcmp(other_context->decoded_sid_pcm, decoded_data, decoded_data_len)) {
@@ -574,8 +581,8 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 	struct amrwb_context *context = codec->private_info;
 	int n;
 	int relayed_size;
+	int frame_type;
 	unsigned char *shift_buf = encoded_data;
-	switch_bool_t relayed_sid = SWITCH_FALSE;
 
 	if (!context) {
 		return SWITCH_STATUS_FALSE;
@@ -592,11 +599,11 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 	relayed_size = switch_amrwb_relay_sid(other_codec, decoded_data, decoded_data_len, encoded_data);
 	if (relayed_size) {
 		n = relayed_size;
-		relayed_sid = SWITCH_TRUE;
 	}
 
 	/* set CMR + TOC (F + 3 bits of FT), 1111 = CMR: No mode request */
 	*(switch_byte_t *) encoded_data = 0xf0;
+	frame_type = (shift_buf[1] >> 3) & 0x0f;
 	*encoded_data_len  = n;
 
 	if (switch_test_flag(context, AMRWB_OPT_OCTET_ALIGN)) {
@@ -605,9 +612,7 @@ static switch_status_t switch_amrwb_encode(switch_codec_t *codec,
 		*encoded_data_len = n + 1;
 	} else {
 		switch_amrwb_pack_be(shift_buf, n);
-		if (relayed_sid) {
-			*encoded_data_len = n + 1;
-		}
+		*encoded_data_len = (switch_amrwb_frame_bits[frame_type] + 10 + 7) / 8;
 	}
 
 	switch_mutex_lock(global_lock);
@@ -633,12 +638,12 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	return SWITCH_STATUS_FALSE;
 #else
 	struct amrwb_context *context = codec->private_info;
-	unsigned char buf[SWITCH_AMRWB_OUT_MAX_SIZE];
-	uint8_t tmp[SWITCH_AMRWB_OUT_MAX_SIZE];
+	unsigned char buf[SWITCH_AMRWB_OUT_MAX_SIZE] = { 0 };
+	uint8_t tmp[SWITCH_AMRWB_OUT_MAX_SIZE] = { 0 };
 	int frame_type;
 
 	if (!context) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid context or encoded data length %d\n", encoded_data_len);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid context\n");
 		goto decode_error;
 	}
 
@@ -650,7 +655,7 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	switch_mutex_unlock(context->decoded_sid_mutex);
 
 	if (!encoded_data || encoded_data_len > SWITCH_AMRWB_OUT_MAX_SIZE) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid context or encoded data length %d\n", encoded_data_len);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "AMRWB decoder: Invalid encoded data or length: %d\n", encoded_data_len);
 		goto decode_error;
 	}
 
@@ -683,7 +688,7 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	if (frame_type == SWITCH_AMRWB_SID_FRAME_TYPE) {
 		switch_mutex_lock(context->decoded_sid_mutex);
 		memcpy(context->decoded_sid, tmp, SWITCH_AMRWB_SID_FRAME_SIZE);
-		context->decoded_sid[0] &= 0xfc;
+		context->decoded_sid[0] &= 0x7c; /* clear F and OA padding */
 		memcpy(context->decoded_sid_pcm, decoded_data, *decoded_data_len);
 		context->decoded_sid_pcm_len = *decoded_data_len;
 		context->decoded_sid_valid = SWITCH_TRUE;

--- a/src/mod/codecs/mod_amrwb/test/test_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/test/test_amrwb.c
@@ -56,13 +56,13 @@ FST_CORE_BEGIN(".")
 			switch_status_t status;
 			switch_codec_settings_t codec_settings = {{ 0 }};
 			uint32_t flags = 0;
-			uint32_t rate;
+			uint32_t rate = 16000;
 			/*amrwb frame types*/
 			static char no_data[] = "\x77\xc0";
 			static char speech_lost[] = "\x77\x00";
 			static char fail[] = "\x76\xc0";
 			/*decode*/
-			uint32_t decoded_len;
+			uint32_t decoded_len = SWITCH_RECOMMENDED_BUFFER_SIZE;
 			unsigned char decbuf[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
 			switch_stream_handle_t stream = { 0 };
 
@@ -95,6 +95,113 @@ FST_CORE_BEGIN(".")
 			fst_check(status != SWITCH_STATUS_SUCCESS);
 
 			switch_core_codec_destroy(&read_codec);
+		}
+
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(amrwb_sid_transcode)
+		{
+			switch_codec_t source_be = { 0 };
+			switch_codec_t source_oa = { 0 };
+			switch_codec_t target_be = { 0 };
+			switch_codec_t target_oa = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+			uint32_t flags = 0;
+			uint32_t rate = 16000;
+			unsigned char decoded[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			unsigned char encoded[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			unsigned char speech_oa[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			uint32_t decoded_len = sizeof(decoded);
+			uint32_t encoded_len = sizeof(encoded);
+			uint32_t speech_oa_len;
+			static unsigned char sid_be[] = "\xf4\xf8\xf7\xcf\x78\x00\x80";
+			static unsigned char sid_oa[] = "\xf0\x4c\xe3\xdf\x3d\xe0\x02";
+
+			status = switch_core_codec_init(&source_be,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=0",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_codec_init(&source_oa,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_codec_init(&target_be,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=0",
+				16000, 20, 1, SWITCH_CODEC_FLAG_ENCODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_codec_init(&target_oa,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_ENCODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_be, NULL, sid_be, sizeof(sid_be) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			memset(encoded, 0, sizeof(encoded));
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_oa, &source_be, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(encoded_len == sizeof(sid_oa) - 1);
+			fst_check(!memcmp(encoded, sid_oa, sizeof(sid_oa) - 1));
+
+			decoded[0] ^= 1;
+			memset(encoded, 0, sizeof(encoded));
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_oa, &source_be, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check((encoded[1] >> 3 & 0x0f) != 9);
+			decoded[0] ^= 1;
+			memset(encoded, 0, sizeof(encoded));
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_be, &source_be, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(encoded_len == sizeof(sid_be) - 1);
+			fst_check(!memcmp(encoded, sid_be, sizeof(sid_be) - 1));
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, sid_oa, sizeof(sid_oa) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			memset(encoded, 0, sizeof(encoded));
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_be, &source_oa, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(encoded_len == sizeof(sid_be) - 1);
+			fst_check(!memcmp(encoded, sid_be, sizeof(sid_be) - 1));
+
+			speech_oa_len = sizeof(speech_oa);
+			status = switch_core_codec_encode(&target_oa, NULL, decoded, decoded_len,
+				16000, speech_oa, &speech_oa_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check((speech_oa[1] >> 3 & 0x0f) != 9);
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, speech_oa, speech_oa_len,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			memset(encoded, 0, sizeof(encoded));
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_be, &source_oa, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(encoded_len != sizeof(sid_be) - 1 || memcmp(encoded, sid_be, sizeof(sid_be) - 1));
+
+			switch_core_codec_destroy(&target_oa);
+			switch_core_codec_destroy(&target_be);
+			switch_core_codec_destroy(&source_oa);
+			switch_core_codec_destroy(&source_be);
 		}
 
 		FST_TEST_END()

--- a/src/mod/codecs/mod_amrwb/test/test_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/test/test_amrwb.c
@@ -205,6 +205,161 @@ FST_CORE_BEGIN(".")
 		}
 
 		FST_TEST_END()
+
+		FST_TEST_BEGIN(amrwb_rejects_truncated_sid)
+		{
+			switch_codec_t source_be = { 0 };
+			switch_codec_t source_oa = { 0 };
+			switch_codec_t target_oa = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+			uint32_t flags = 0;
+			uint32_t rate = 16000;
+			unsigned char decoded[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			unsigned char encoded[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			uint32_t decoded_len;
+			uint32_t cached_pcm_len;
+			uint32_t encoded_len;
+			static unsigned char sid_be[] = "\xf4\xf8\xf7\xcf\x78\x00\x80";
+			static unsigned char sid_oa[] = "\xf0\x4c\xe3\xdf\x3d\xe0\x02";
+			static unsigned char short_payload[] = "\xf0";
+			static unsigned char reserved_oa[] = "\xf0\x54";
+			static unsigned char reserved_be_ft10[] = "\xf5\x40";
+
+			status = switch_core_codec_init(&source_be,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=0",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			status = switch_core_codec_init(&source_oa,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			status = switch_core_codec_init(&target_oa,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_ENCODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_be, NULL, sid_be, sizeof(sid_be) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			cached_pcm_len = decoded_len;
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_be, NULL, sid_be, sizeof(sid_be) - 2,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_be, NULL, short_payload, sizeof(short_payload) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_be, NULL, reserved_be_ft10, sizeof(reserved_be_ft10) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+
+			decoded_len = cached_pcm_len;
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_oa, &source_be, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check((encoded[1] >> 3 & 0x0f) != 9);
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, sid_oa, sizeof(sid_oa) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			cached_pcm_len = decoded_len;
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, sid_oa, sizeof(sid_oa) - 2,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, short_payload, sizeof(short_payload) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, reserved_oa, sizeof(reserved_oa) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+
+			decoded_len = cached_pcm_len;
+			encoded_len = sizeof(encoded);
+			status = switch_core_codec_encode(&target_oa, &source_oa, decoded, decoded_len,
+				16000, encoded, &encoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check((encoded[1] >> 3 & 0x0f) != 9);
+
+			switch_core_codec_destroy(&target_oa);
+			switch_core_codec_destroy(&source_oa);
+			switch_core_codec_destroy(&source_be);
+		}
+
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(amrwb_sid_advances_encoder_state)
+		{
+			switch_codec_t source_be = { 0 };
+			switch_codec_t target_relay = { 0 };
+			switch_codec_t target_control = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+			uint32_t flags = 0;
+			uint32_t rate = 16000;
+			unsigned char decoded[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			unsigned char relayed[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			unsigned char control[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			uint32_t decoded_len = sizeof(decoded);
+			uint32_t relayed_len;
+			uint32_t control_len;
+			static unsigned char sid_be[] = "\xf4\xf8\xf7\xcf\x78\x00\x80";
+
+			status = switch_core_codec_init(&source_be,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=0",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			status = switch_core_codec_init(&target_relay,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_ENCODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			status = switch_core_codec_init(&target_control,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_ENCODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_codec_decode(&source_be, NULL, sid_be, sizeof(sid_be) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			relayed_len = sizeof(relayed);
+			status = switch_core_codec_encode(&target_relay, &source_be, decoded, decoded_len,
+				16000, relayed, &relayed_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check((relayed[1] >> 3 & 0x0f) == 9);
+			control_len = sizeof(control);
+			status = switch_core_codec_encode(&target_control, NULL, decoded, decoded_len,
+				16000, control, &control_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			memset(decoded, 0, decoded_len);
+			relayed_len = sizeof(relayed);
+			control_len = sizeof(control);
+			status = switch_core_codec_encode(&target_relay, NULL, decoded, decoded_len,
+				16000, relayed, &relayed_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			status = switch_core_codec_encode(&target_control, NULL, decoded, decoded_len,
+				16000, control, &control_len, &rate, &flags);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			fst_check(relayed_len == control_len);
+			fst_check(!memcmp(relayed, control, control_len));
+
+			switch_core_codec_destroy(&target_control);
+			switch_core_codec_destroy(&target_relay);
+			switch_core_codec_destroy(&source_be);
+		}
+
+		FST_TEST_END()
+
 	}
 	FST_SUITE_END()
 }

--- a/src/mod/codecs/mod_amrwb/test/test_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/test/test_amrwb.c
@@ -206,6 +206,44 @@ FST_CORE_BEGIN(".")
 
 		FST_TEST_END()
 
+		FST_TEST_BEGIN(amrwb_rejects_multiple_frames)
+		{
+			switch_codec_t source_be = { 0 };
+			switch_codec_t source_oa = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+			uint32_t flags = 0;
+			uint32_t rate = 16000;
+			unsigned char decoded[SWITCH_RECOMMENDED_BUFFER_SIZE] = { 0 };
+			uint32_t decoded_len;
+			static unsigned char multiframes_be[] = "\xfc\xf8\xf7\xcf\x78\x00\x80";
+			static unsigned char multiframes_oa[] = "\xf0\xcc\x4c\xe3\xdf\x3d\xe0\x02\xe3\xdf\x3d\xe0\x02";
+
+			status = switch_core_codec_init(&source_be,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=0",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			status = switch_core_codec_init(&source_oa,
+				"AMR-WB", "mod_amrwb", "mode-set=0,1,2;octet-align=1",
+				16000, 20, 1, SWITCH_CODEC_FLAG_DECODE, &codec_settings, fst_pool);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_be, NULL, multiframes_be, sizeof(multiframes_be) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+
+			decoded_len = sizeof(decoded);
+			status = switch_core_codec_decode(&source_oa, NULL, multiframes_oa, sizeof(multiframes_oa) - 1,
+				16000, decoded, &decoded_len, &rate, &flags);
+			fst_check(status != SWITCH_STATUS_SUCCESS);
+
+			switch_core_codec_destroy(&source_oa);
+			switch_core_codec_destroy(&source_be);
+		}
+
+		FST_TEST_END()
+
 		FST_TEST_BEGIN(amrwb_rejects_truncated_sid)
 		{
 			switch_codec_t source_be = { 0 };


### PR DESCRIPTION
## Problem

Outbound AMR-WB calls through AT&T convert carrier SID frames into isolated speech frames on the customer leg. The RTP sequence is lossless, but the preserved timestamp gaps create 80-280 ms audio holes and audible pumping.

## Evidence

- Customer to B2BUA: 3,536 FT=8 packets; B2BUA to AT&T: 3,647 FT=2 packets, both with zero loss.
- AT&T to B2BUA: 429 FT=9 SID packets.
- 425 of those SID packets map within 40 ms to customer-facing FT=2 packets; zero map to FT=9.
- The customer-facing stream has timestamp jumps up to 4,480 samples while reporting zero RTP sequence loss.

## Fix

Cache the AMR-WB SID payload together with its exact decoded PCM output. Relay SID only when another `mod_amrwb` encoder receives that same decoded frame. Clear the cache on every non-SID decode and protect it with a dedicated mutex. This preserves SID across bandwidth-efficient and octet-aligned transcoding without enabling VAD/DTX globally.

## Tests

- Added regression coverage for BE to OA, BE to BE, and OA to BE SID transcoding.
- Added mismatched-PCM and following-speech checks so stale SID state cannot replace speech.
- Module and test sources pass syntax compilation with declaration-after-statement errors enabled.
- Full Linux/unit and DEV call/load validation will follow review.
