### PR TITLE
TELCORE-390: enforce DTMF w/W pauses; pin default rtp-digit-delay to 20ms

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -5043,7 +5043,7 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 					switch_thread_rwlock_create(&profile->rwlock, profile->pool);
 					switch_mutex_init(&profile->flag_mutex, SWITCH_MUTEX_NESTED, profile->pool);
 					profile->dtmf_duration = 100;
-					profile->rtp_digit_delay = 40;
+					profile->rtp_digit_delay = 20;
 					profile->ignore_rtp_during_dtmf_timeout = SWITCH_RTP_DEFAULT_IGNORE_DTMF_TIMEOUT_MS;
 					profile->sip_force_expires = 0;
 					profile->sip_force_expires_min = 0;

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -7138,6 +7138,16 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_change_interval(switch_rtp_t *rtp_ses
 							  "Problem RE-Starting timer [%s] %d bytes per %dms\n", rtp_session->timer_name, samples_per_interval, ms_per_packet / 1000);
 		}
 
+		/* The new timer's samplecount restarts near zero, so any DTMF delay floor
+		   armed against the old timer's epoch would hold digits for the rest of the leg. */
+		if (rtp_session->next_write_samplecount || rtp_session->max_next_write_samplecount) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+							  "Timer re-created, clearing pending DTMF delay floor (%u/%u)\n",
+							  rtp_session->next_write_samplecount, rtp_session->max_next_write_samplecount);
+			rtp_session->next_write_samplecount = 0;
+			rtp_session->max_next_write_samplecount = 0;
+		}
+
 		WRITE_DEC(rtp_session);
 		READ_DEC(rtp_session);
 	}
@@ -8452,21 +8462,21 @@ SWITCH_DECLARE(void) switch_rtp_clear_flag(switch_rtp_t *rtp_session, switch_rtp
 	}
 }
 
-static void set_dtmf_delay(switch_rtp_t *rtp_session, uint32_t ms, uint32_t max_ms)
+static void set_dtmf_delay(switch_rtp_t *rtp_session, uint32_t ms)
 {
-	int upsamp, max_upsamp;
-
-	if (!max_ms) max_ms = ms;
-
-	upsamp = ms * (rtp_session->samples_per_second / 1000);
-	max_upsamp = max_ms * (rtp_session->samples_per_second / 1000);
+	uint32_t upsamp = ms * (rtp_session->samples_per_second / 1000);
 
 	rtp_session->sending_dtmf = 0;
 	rtp_session->queue_delay = upsamp;
 
 	if (rtp_session->flags[SWITCH_RTP_FLAG_USE_TIMER]) {
-		rtp_session->max_next_write_samplecount = rtp_session->timer.samplecount + max_upsamp;
+		/* Floor and ceiling are the same instant: the queued digit is held until
+		   the media clock reaches next_write_samplecount and released right there.
+		   Upstream arms a 10x ceiling for the interdigit case, but in this fork
+		   queue_delay is only cleared by an outbound write, so a stalled write
+		   path would turn that window into an extra hold of up to 10x the delay. */
 		rtp_session->next_write_samplecount = rtp_session->timer.samplecount + upsamp;
+		rtp_session->max_next_write_samplecount = rtp_session->next_write_samplecount;
 		rtp_session->last_write_ts += upsamp;
 	}
 
@@ -8578,7 +8588,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 			rtp_session->dtmf_data.out_digit_dur = 0;
 
 			if (rtp_session->interdigit_delay) {
-				set_dtmf_delay(rtp_session, rtp_session->interdigit_delay, rtp_session->interdigit_delay * 10);
+				set_dtmf_delay(rtp_session, rtp_session->interdigit_delay);
 			}
 
 			return;
@@ -8624,13 +8634,13 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 			uint32_t shift = 0, new_ts = 0;
 
 			if (rdigit->digit == 'w') {
-				set_dtmf_delay(rtp_session, 500, 0);
+				set_dtmf_delay(rtp_session, 500);
 				free(rdigit);
 				return;
 			}
 
 			if (rdigit->digit == 'W') {
-				set_dtmf_delay(rtp_session, 1000, 0);
+				set_dtmf_delay(rtp_session, 1000);
 				free(rdigit);
 				return;
 			}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -543,7 +543,6 @@ struct switch_rtp {
 	uint32_t last_max_vb_frames;
 	int skip_timer;
 	uint32_t prev_nacks_inflight;
-	switch_time_t next_dtmf_send_time;
 	rtcp_probe_func rtcp_probe;
 	uint8_t send_rtp_exts_size;
 	uint8_t send_rtp_exts_written;
@@ -8453,15 +8452,24 @@ SWITCH_DECLARE(void) switch_rtp_clear_flag(switch_rtp_t *rtp_session, switch_rtp
 	}
 }
 
-static void set_dtmf_delay(switch_rtp_t *rtp_session, uint32_t ms)
+static void set_dtmf_delay(switch_rtp_t *rtp_session, uint32_t ms, uint32_t max_ms)
 {
-	int upsamp = ms * (rtp_session->samples_per_second / 1000);
-	rtp_session->queue_delay =  ms * (rtp_session->samples_per_second / 1000);
-	rtp_session->next_dtmf_send_time = switch_micro_time_now() + (ms * 1000);
+	int upsamp, max_upsamp;
+
+	if (!max_ms) max_ms = ms;
+
+	upsamp = ms * (rtp_session->samples_per_second / 1000);
+	max_upsamp = max_ms * (rtp_session->samples_per_second / 1000);
+
 	rtp_session->sending_dtmf = 0;
+	rtp_session->queue_delay = upsamp;
+
 	if (rtp_session->flags[SWITCH_RTP_FLAG_USE_TIMER]) {
+		rtp_session->max_next_write_samplecount = rtp_session->timer.samplecount + max_upsamp;
+		rtp_session->next_write_samplecount = rtp_session->timer.samplecount + upsamp;
 		rtp_session->last_write_ts += upsamp;
 	}
+
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG, "Queue digit delay of %dms\n", ms);
 }
 
@@ -8570,7 +8578,7 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 			rtp_session->dtmf_data.out_digit_dur = 0;
 
 			if (rtp_session->interdigit_delay) {
-				set_dtmf_delay(rtp_session, rtp_session->interdigit_delay);
+				set_dtmf_delay(rtp_session, rtp_session->interdigit_delay, rtp_session->interdigit_delay * 10);
 			}
 
 			return;
@@ -8579,11 +8587,6 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 
 	if (!rtp_session->dtmf_data.out_digit_dur && rtp_session->dtmf_data.dtmf_queue && switch_queue_size(rtp_session->dtmf_data.dtmf_queue)) {
 		void *pop;
-
-
-		if (rtp_session->queue_delay && rtp_session->next_dtmf_send_time >  switch_micro_time_now()) {
-			return;
-		}
 
 		if (rtp_session->flags[SWITCH_RTP_FLAG_USE_TIMER]) {
 			//switch_core_timer_sync(&rtp_session->write_timer);
@@ -8609,9 +8612,6 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 
 		if (rtp_session->queue_delay) {
 			return;
-		} else {
-			rtp_session->next_dtmf_send_time = 0;
-			rtp_session->queue_delay = 0;
 		}
 
 		if (!rtp_session->sending_dtmf) {
@@ -8624,13 +8624,13 @@ SWITCH_DECLARE(void) do_2833(switch_rtp_t *rtp_session)
 			uint32_t shift = 0, new_ts = 0;
 
 			if (rdigit->digit == 'w') {
-				set_dtmf_delay(rtp_session, 500);
+				set_dtmf_delay(rtp_session, 500, 0);
 				free(rdigit);
 				return;
 			}
 
 			if (rdigit->digit == 'W') {
-				set_dtmf_delay(rtp_session, 1000);
+				set_dtmf_delay(rtp_session, 1000, 0);
 				free(rdigit);
 				return;
 			}


### PR DESCRIPTION
## Problem

The Call Control `send_dtmf` API documents `w` (0.5s) and `W` (1s) as pause characters. In this fork the pauses are **queued but not enforced**: each one is released after a single RTP timer tick (~20ms), so a requested 3.5s pause collapses to ~140ms.

Customer (Parakeet Health, TELCORE-390, **P1**) sends `digits: "wwwwwww4"` after transferring to a GoTo IVR. The `4` arrives ~3.4s early, before the IVR prompt starts. Both customer call samples show this; the "good" one only worked because that IVR re-prompted.

## Root cause

`do_2833()` gates a queued digit on `next_write_samplecount` / `max_next_write_samplecount`, but nothing in the tree assigned them since commit `6209709875` (2019) replaced upstream's samplecount floor with a wall-clock `next_dtmf_send_time` guard. Both fields stayed `0`, so with `SWITCH_RTP_FLAG_USE_TIMER` set:

```c
if (timer.samplecount <  next_write_samplecount)     /* 0 -> never holds  */
if (timer.samplecount >= max_next_write_samplecount) /* 0 -> always true  */
        rtp_session->queue_delay = 0;                /* pause cancelled   */
```

The wall-clock guard could not compensate because `rtp_common_write()` zeroes `queue_delay` on every outbound packet and the guard required it to be non-zero. The same collapse applied to the interdigit delay: `rtp_digit_delay = 40` was queued after every digit and released after one tick, so production has always delivered ~20ms between digits.

## Change

**`src/switch_rtp.c`**
- `set_dtmf_delay(rtp_session, ms)` records the media-clock deadline again: `next_write_samplecount = timer.samplecount + upsamp`, and `max_next_write_samplecount` is set to the same value (floor == ceiling). Upstream uses a 10x ceiling at the interdigit site; that is deliberately **not** carried over, because in this fork `queue_delay` is only cleared by an outbound write and a stalled write path would turn the ceiling into an extra hold of up to 10x the delay. The function therefore differs from upstream; `max_next_write_samplecount` is kept as redundant state so the gate keeps upstream's shape (see review thread).
- `next_dtmf_send_time` and its reset branch are removed.
- `switch_rtp_change_interval()` clears both floors after re-creating the timer (success and "Problem RE-Starting timer" branch). Without this a floor armed against the old timer's epoch would hold every later digit on the leg. `switch_rtp_udptl_mode()` is untouched: it clears `USE_TIMER` and the flag is only re-armed for non-UDPTL legs, so the floors are never read again there.

**`src/mod/endpoints/mod_sofia/sofia.c`**
- Default `profile->rtp_digit_delay` changed from `40` to `20`. With the floor enforced, the previous default would have doubled inter-digit spacing on every call in the fleet. 20ms (one packet at 20ms ptime) reproduces what production has delivered until now. This applies to **every sofia profile in the fork**, diverges from upstream's 40, and is load-bearing: **an upstream alignment that restores 40 will double interdigit spacing fleet-wide.** `rtp-digit-delay` in the profile still overrides. Choosing the long-term value is a separate ticket.

Scope: the fix is `SWITCH_RTP_FLAG_USE_TIMER`-only (b2bua always runs a timer). Timer-less sessions still collapse pauses to one packet, as before. Telnyx-only `do_2833()` behaviour (normalised timestamps, DTMF timestamp gap compensation, ENGDESK-48201 sub-ptime gate) is untouched.

Footnote: "unchanged interdigit spacing" holds for ptime >= 20ms. Pre-fix the gap was one timer tick, i.e. the ptime; at 10ms ptime it moves from 10ms to 20ms.

## Verification on dev (`b2bua.tel-fl1-prox-dev-203`, same leg, measured with tshark from RTP, not log lines)

Before = v112.1 (`telcore-390-debug-03.pcap`), after = `8c48efa92c` (`telcore-390-fixed-03.pcap`).

| Test | Before | After |
|---|---|---|
| `wwwwwww4@100` pause before digit | 140 ms (7 x 20) | **3.50 s** (7 x 500, ts delta 28000) |
| `WW4` pause | 40 ms | **2.00 s** (2 x 1000, ts delta 16000) |
| `1234` end pkt -> next start | 20 / 20 / 20 ms | 20 / 20 / 20 ms |
| `1234@100` end pkt -> next start | 20 / 20 / 20 ms | 20 / 20 / 20 ms |
| RTP ts per digit | +2080 / +800 | +2080 / +800 |
| digits decoded by far leg | 4/4 | 4/4 |
| tone duration | unchanged | unchanged |

`@N` only sets the tone duration of real digits; pause lengths are fixed 500/1000ms.

## Remaining before merge

1. ~~Plain digits `1234`~~ done, no change.
2. ~~`W`~~ done.
3. ~~`RTP_BUG_SEND_NORMALISED_TIMESTAMPS`~~ done (`telcore-390-fixed-04.pcap`, leg originated with `rtp_manual_rtp_bugs=SEND_NORMALISED_TIMESTAMPS` as the prod dialplan hack does): 7 x 500 ms, DTMF start ts = last audio ts + 160, `1234@100` 20 ms gaps. Identical to flag-off.
4. ~~Silent peer (ENGDESK-48201)~~ done (`telcore-390-fixed-05.pcap`, inbound UDP from the peer dropped with iptables; zero `RTP RECV DTMF` in the log): 7 x 500 ms, `1234` 20 ms gaps. Identical to fed-peer.
5. Canary before fleet rollout. Watch items: the `Timer re-created, clearing pending DTMF delay floor` DEBUG line (mid-call ptime/codec re-INVITE path is fixed by inspection, no capture), and interdigit spacing on the canary node.

## Release notes

- DTMF `w`/`W` pauses in `send_dtmf` are now enforced (0.5s / 1s).
- Default `rtp-digit-delay` is 20ms in this fork (upstream 40); inter-digit spacing on the wire is unchanged from previous releases.

Linear: TELCORE-390
