### PR TITLE
TELCORE-424: validate CDR timestamp strings before storing them

### DIFF
--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -672,6 +672,7 @@ SWITCH_DECLARE(char *) switch_channel_expand_variables_check(switch_channel_t *c
 SWITCH_DECLARE(char *) switch_channel_build_param_string(_In_ switch_channel_t *channel, _In_opt_ switch_caller_profile_t *caller_profile,
 														 _In_opt_ const char *prefix);
 SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(_In_ switch_channel_t *channel);
+SWITCH_DECLARE(void) switch_channel_repair_timestamps(_In_ switch_channel_t *channel);
 
 #define switch_channel_stop_broadcast(_channel)	for(;;) {if (switch_channel_test_flag(_channel, CF_BROADCAST)) {switch_channel_set_flag(_channel, CF_STOP_BROADCAST); switch_channel_set_flag(_channel, CF_BREAK); } break;}
 

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -4790,6 +4790,59 @@ SWITCH_DECLARE(switch_core_session_t *) switch_channel_get_session(switch_channe
 	return channel->session;
 }
 
+#define SWITCH_CDR_STAMP_FMT "%Y-%m-%d %T"
+#define SWITCH_CDR_STAMP_LEN 19
+
+/*!
+  \brief Format a CDR timestamp and verify the result before it is stored.
+
+  switch_strftime_nocheck() discards the value returned by strftime(), so a
+  short or mangled buffer is stored into the CDR without any indication that
+  something went wrong. A malformed stamp is not detectable downstream and
+  breaks consumers that parse the field.
+
+  This helper formats the stamp, then verifies that strftime() reported the
+  expected length AND that the buffer really holds that many bytes. If the two
+  disagree, it logs the evidence needed to identify the writer and rebuilds the
+  value from the same broken-down time using an independent formatter.
+
+  \param channel the channel, used for logging context
+  \param name the CDR variable name, used for logging
+  \param when the microsecond timestamp to format
+  \param buf destination buffer
+  \param buflen size of the destination buffer
+  \return SWITCH_TRUE when the first format attempt was well formed
+*/
+static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, const char *name,
+												 switch_time_t when, char *buf, switch_size_t buflen)
+{
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	switch_size_t len;
+
+	memset(&tm, 0, sizeof(tm));
+	memset(buf, 0, buflen);
+
+	switch_time_exp_lt(&tm, when);
+	switch_strftime_nocheck(buf, &retsize, buflen, SWITCH_CDR_STAMP_FMT, &tm);
+	len = strlen(buf);
+
+	if (retsize == SWITCH_CDR_STAMP_LEN && len == SWITCH_CDR_STAMP_LEN) {
+		return SWITCH_TRUE;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_CRIT,
+					  "Malformed CDR timestamp [%s] retsize=%" SWITCH_SIZE_T_FMT " strlen=%" SWITCH_SIZE_T_FMT
+					  " src=%" SWITCH_TIME_T_FMT " buf=[%s]\n", name, retsize, len, when, buf);
+
+	/* Rebuild from the same broken-down time. Same instant, independent formatter. */
+	switch_snprintf(buf, buflen, "%04d-%02d-%02d %02d:%02d:%02d",
+					tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+					tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+	return SWITCH_FALSE;
+}
+
 SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *channel)
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
@@ -4797,7 +4850,7 @@ SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *
 	switch_caller_profile_t *caller_profile;
 	switch_app_log_t *app_log, *ap;
 	char *last_app = NULL, *last_arg = NULL;
-	char start[80] = "", resurrect[80] = "", answer[80] = "", hold[80],
+	char start[80] = "", resurrect[80] = "", answer[80] = "", hold[80] = "",
 		bridge[80] = "", progress[80] = "", progress_media[80] = "", end[80] = "", tmp[80] = "",
 		profile_start[80] =	"";
 	int32_t duration = 0, legbillsec = 0, billsec = 0, mduration = 0, billmsec = 0, legbillmsec = 0, progressmsec = 0, progress_mediamsec = 0, ringback_delaymsec = 0, first_early_rtp_packetmsec = 0;
@@ -4897,51 +4950,39 @@ SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *
 	}
 
 	if (caller_profile->times) {
-		switch_time_exp_t tm;
-		switch_size_t retsize;
-		const char *fmt = "%Y-%m-%d %T";
-
-		switch_time_exp_lt(&tm, caller_profile->times->created);
-		switch_strftime_nocheck(start, &retsize, sizeof(start), fmt, &tm);
+		switch_channel_format_stamp(channel, "start_stamp", caller_profile->times->created, start, sizeof(start));
 		switch_channel_set_variable(channel, "start_stamp", start);
 
-		switch_time_exp_lt(&tm, caller_profile->times->profile_created);
-		switch_strftime_nocheck(profile_start, &retsize, sizeof(profile_start), fmt, &tm);
+		switch_channel_format_stamp(channel, "profile_start_stamp", caller_profile->times->profile_created, profile_start, sizeof(profile_start));
 		switch_channel_set_variable(channel, "profile_start_stamp", profile_start);
 
 		if (caller_profile->times->answered) {
-			switch_time_exp_lt(&tm, caller_profile->times->answered);
-			switch_strftime_nocheck(answer, &retsize, sizeof(answer), fmt, &tm);
+			switch_channel_format_stamp(channel, "answer_stamp", caller_profile->times->answered, answer, sizeof(answer));
 			switch_channel_set_variable(channel, "answer_stamp", answer);
 		}
 
 		if (caller_profile->times->bridged) {
-			switch_time_exp_lt(&tm, caller_profile->times->bridged);
-			switch_strftime_nocheck(bridge, &retsize, sizeof(bridge), fmt, &tm);
+			switch_channel_format_stamp(channel, "bridge_stamp", caller_profile->times->bridged, bridge, sizeof(bridge));
 			switch_channel_set_variable(channel, "bridge_stamp", bridge);
 		}
 
 		if (caller_profile->times->last_hold) {
-			switch_time_exp_lt(&tm, caller_profile->times->last_hold);
-			switch_strftime_nocheck(hold, &retsize, sizeof(hold), fmt, &tm);
+			switch_channel_format_stamp(channel, "hold_stamp", caller_profile->times->last_hold, hold, sizeof(hold));
 			switch_channel_set_variable(channel, "hold_stamp", hold);
 		}
 
 		if (caller_profile->times->resurrected) {
-			switch_time_exp_lt(&tm, caller_profile->times->resurrected);
-			switch_strftime_nocheck(resurrect, &retsize, sizeof(resurrect), fmt, &tm);
+			switch_channel_format_stamp(channel, "resurrect_stamp", caller_profile->times->resurrected, resurrect, sizeof(resurrect));
 			switch_channel_set_variable(channel, "resurrect_stamp", resurrect);
 		}
 
 		if (caller_profile->times->progress) {
-			switch_time_exp_lt(&tm, caller_profile->times->progress);
-			switch_strftime_nocheck(progress, &retsize, sizeof(progress), fmt, &tm);
+			switch_channel_format_stamp(channel, "progress_stamp", caller_profile->times->progress, progress, sizeof(progress));
 			switch_channel_set_variable(channel, "progress_stamp", progress);
 		}
 
 		if (caller_profile->times->progress_media) {
-			switch_time_exp_lt(&tm, caller_profile->times->progress_media);
-			switch_strftime_nocheck(progress_media, &retsize, sizeof(progress_media), fmt, &tm);
+			switch_channel_format_stamp(channel, "progress_media_stamp", caller_profile->times->progress_media, progress_media, sizeof(progress_media));
 			switch_channel_set_variable(channel, "progress_media_stamp", progress_media);
 		}
 
@@ -4972,8 +5013,7 @@ SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *
 			}
 		}
 
-		switch_time_exp_lt(&tm, caller_profile->times->hungup);
-		switch_strftime_nocheck(end, &retsize, sizeof(end), fmt, &tm);
+		switch_channel_format_stamp(channel, "end_stamp", caller_profile->times->hungup, end, sizeof(end));
 		switch_channel_set_variable(channel, "end_stamp", end);
 
 		tt_created = (time_t) (caller_profile->times->created / 1000000);

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -4793,6 +4793,9 @@ SWITCH_DECLARE(switch_core_session_t *) switch_channel_get_session(switch_channe
 #define SWITCH_CDR_STAMP_FMT "%Y-%m-%d %T"
 #define SWITCH_CDR_STAMP_LEN 19
 
+/* Keep a broken-down time field inside the range its fixed-width field can hold. */
+#define CLAMP_STAMP_FIELD(v, lo, hi) ((v) < (lo) ? (lo) : ((v) > (hi) ? (hi) : (v)))
+
 /*!
   \brief Format a CDR timestamp and verify the result before it is stored.
 
@@ -4819,6 +4822,7 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 	switch_time_exp_t tm;
 	switch_size_t retsize = 0;
 	switch_size_t len;
+	int year;
 
 	memset(&tm, 0, sizeof(tm));
 	memset(buf, 0, buflen);
@@ -4835,10 +4839,27 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 					  "Malformed CDR timestamp [%s] retsize=%" SWITCH_SIZE_T_FMT " strlen=%" SWITCH_SIZE_T_FMT
 					  " src=%" SWITCH_TIME_T_FMT " buf=[%s]\n", name, retsize, len, when, buf);
 
-	/* Rebuild from the same broken-down time. Same instant, independent formatter. */
+	/*
+	 * Rebuild from the same broken-down time. Same instant, independent
+	 * formatter. Clamp each field to the range the fixed-width format can
+	 * represent, so the rebuilt value is always exactly SWITCH_CDR_STAMP_LEN
+	 * characters. Without the clamp a year outside 0..9999 reproduces the same
+	 * malformed length that was just rejected.
+	 */
+	year = tm.tm_year + 1900;
+	if (year < 0) {
+		year = 0;
+	} else if (year > 9999) {
+		year = 9999;
+	}
+
 	switch_snprintf(buf, buflen, "%04d-%02d-%02d %02d:%02d:%02d",
-					tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-					tm.tm_hour, tm.tm_min, tm.tm_sec);
+					year,
+					CLAMP_STAMP_FIELD(tm.tm_mon + 1, 1, 12),
+					CLAMP_STAMP_FIELD(tm.tm_mday, 1, 31),
+					CLAMP_STAMP_FIELD(tm.tm_hour, 0, 23),
+					CLAMP_STAMP_FIELD(tm.tm_min, 0, 59),
+					CLAMP_STAMP_FIELD(tm.tm_sec, 0, 60));
 
 	return SWITCH_FALSE;
 }

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -4797,6 +4797,76 @@ SWITCH_DECLARE(switch_core_session_t *) switch_channel_get_session(switch_channe
 #define CLAMP_STAMP_FIELD(v, lo, hi) ((v) < (lo) ? (lo) : ((v) > (hi) ? (hi) : (v)))
 
 /*!
+  \brief Widen the window in which a stray write to a stamp buffer can be seen.
+
+  A CDR timestamp was once stored with a NUL byte in the middle of an otherwise
+  correct value. The write that shortened it was never identified: it lands
+  inside the buffer, so it corrupts no allocator metadata and crosses no page
+  boundary, which leaves both AddressSanitizer and guard pages blind to it.
+
+  The only period in which it can be observed is between the formatter filling
+  the buffer and the value being copied into the channel variable, which is a
+  few hundred nanoseconds. This helper takes a reference copy, holds that gap
+  open for the configured number of milliseconds, then compares. Chance of
+  catching a randomly timed write scales with the width of the gap, so a
+  millisecond turns a wait of years into one a soak test can win.
+
+  Disabled unless the "cdr_stamp_watch_ms" core variable is set to a positive
+  value, so production pays nothing. Intended for a lab or canary host.
+
+  \return milliseconds to hold the window open, 0 when disabled
+*/
+static uint32_t chan_stamp_watch_ms(void)
+{
+	const char *val = switch_core_get_variable("cdr_stamp_watch_ms");
+	int ms;
+
+	if (zstr(val)) {
+		return 0;
+	}
+
+	ms = atoi(val);
+
+	if (ms < 0) {
+		return 0;
+	}
+
+	/* Cap it: this delays hangup processing on every call while enabled. */
+	if (ms > 1000) {
+		ms = 1000;
+	}
+
+	return (uint32_t)ms;
+}
+
+/*!
+  \brief Report a stamp buffer that changed after the formatter returned.
+
+  Logs the value before and after alongside a hex dump, which is what
+  identifies the write. A single altered byte and an otherwise intact buffer
+  means one stray store; a run of zeroes means a wider store, which is a
+  different fault to look for.
+*/
+static void chan_stamp_report_mutation(switch_channel_t *channel, const char *name,
+									   const char *before, const char *after,
+									   switch_size_t retsize, uint32_t waited_ms)
+{
+	char hex[3 * 24 + 1] = "";
+	switch_size_t i;
+	switch_size_t pos = 0;
+
+	for (i = 0; i < 24; i++) {
+		pos += switch_snprintf(hex + pos, sizeof(hex) - pos, "%02x ", (unsigned char)after[i]);
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_CRIT,
+					  "CDR stamp mutated after formatting [%s] before=[%s] after=[%s] "
+					  "retsize=%" SWITCH_SIZE_T_FMT " strlen_now=%" SWITCH_SIZE_T_FMT
+					  " watched_ms=%u hex=%s\n",
+					  name, before, after, retsize, strlen(after), waited_ms, hex);
+}
+
+/*!
   \brief Format a CDR timestamp and verify the result before it is stored.
 
   switch_strftime_nocheck() discards the value returned by strftime(), so a
@@ -4823,6 +4893,7 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 	switch_size_t retsize = 0;
 	switch_size_t len;
 	int year;
+	uint32_t watch_ms;
 
 	memset(&tm, 0, sizeof(tm));
 	memset(buf, 0, buflen);
@@ -4830,6 +4901,24 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 	switch_time_exp_lt(&tm, when);
 	switch_strftime_nocheck(buf, &retsize, buflen, SWITCH_CDR_STAMP_FMT, &tm);
 	len = strlen(buf);
+
+	/*
+	 * Diagnostic only, off unless cdr_stamp_watch_ms is set. Holds the gap
+	 * between formatting and storing open so a stray write into this buffer
+	 * can be seen and dumped instead of silently changing the value.
+	 */
+	if ((watch_ms = chan_stamp_watch_ms())) {
+		char before[80] = "";
+
+		switch_copy_string(before, buf, sizeof(before));
+		switch_yield(watch_ms * 1000);
+
+		if (strcmp(before, buf)) {
+			chan_stamp_report_mutation(channel, name, before, buf, retsize, watch_ms);
+			switch_copy_string(buf, before, buflen);
+			len = strlen(buf);
+		}
+	}
 
 	if (retsize == SWITCH_CDR_STAMP_LEN && len == SWITCH_CDR_STAMP_LEN) {
 		return SWITCH_TRUE;

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -4793,6 +4793,10 @@ SWITCH_DECLARE(switch_core_session_t *) switch_channel_get_session(switch_channe
 #define SWITCH_CDR_STAMP_FMT "%Y-%m-%d %T"
 #define SWITCH_CDR_STAMP_LEN 19
 
+/* Upper bound for the diagnostic hold below. Paid once per stamp, so a call
+   that writes all nine pays nine times this with profile_mutex held. */
+#define SWITCH_CDR_STAMP_WATCH_MAX_MS 50
+
 /* Keep a broken-down time field inside the range its fixed-width field can hold. */
 #define CLAMP_STAMP_FIELD(v, lo, hi) ((v) < (lo) ? (lo) : ((v) > (hi) ? (hi) : (v)))
 
@@ -4804,12 +4808,17 @@ SWITCH_DECLARE(switch_core_session_t *) switch_channel_get_session(switch_channe
   inside the buffer, so it corrupts no allocator metadata and crosses no page
   boundary, which leaves both AddressSanitizer and guard pages blind to it.
 
-  The only period in which it can be observed is between the formatter filling
-  the buffer and the value being copied into the channel variable, which is a
-  few hundred nanoseconds. This helper takes a reference copy, holds that gap
-  open for the configured number of milliseconds, then compares. Chance of
-  catching a randomly timed write scales with the width of the gap, so a
-  millisecond turns a wait of years into one a soak test can win.
+  This widens one of the two windows in which the value is exposed: the gap
+  between the formatter filling the stack buffer and the value being copied
+  into the channel variable, a few hundred nanoseconds. It takes a reference
+  copy, holds that gap open for the configured number of milliseconds, then
+  compares. Chance of catching a randomly timed write scales with the width of
+  the gap.
+
+  It does NOT cover the second window. Once copied, the value lives on the heap
+  from here until the CDR is serialized in CS_REPORTING, which spans every
+  module's on_hangup handler and is orders of magnitude longer. A write landing
+  there is invisible to this helper, so silence from it does not bound the rate.
 
   Disabled unless the "cdr_stamp_watch_ms" core variable is set to a positive
   value, so production pays nothing. Intended for a lab or canary host.
@@ -4818,22 +4827,23 @@ SWITCH_DECLARE(switch_core_session_t *) switch_channel_get_session(switch_channe
 */
 static uint32_t chan_stamp_watch_ms(void)
 {
-	const char *val = switch_core_get_variable("cdr_stamp_watch_ms");
+	char *val = switch_core_get_variable_dup("cdr_stamp_watch_ms");
 	int ms;
 
 	if (zstr(val)) {
+		switch_safe_free(val);
 		return 0;
 	}
 
 	ms = atoi(val);
+	switch_safe_free(val);
 
 	if (ms < 0) {
 		return 0;
 	}
 
-	/* Cap it: this delays hangup processing on every call while enabled. */
-	if (ms > 1000) {
-		ms = 1000;
+	if (ms > SWITCH_CDR_STAMP_WATCH_MAX_MS) {
+		ms = SWITCH_CDR_STAMP_WATCH_MAX_MS;
 	}
 
 	return (uint32_t)ms;
@@ -4884,16 +4894,17 @@ static void chan_stamp_report_mutation(switch_channel_t *channel, const char *na
   \param when the microsecond timestamp to format
   \param buf destination buffer
   \param buflen size of the destination buffer
+  \param watch_ms milliseconds to hold the pre-store window open, 0 to disable
   \return SWITCH_TRUE when the first format attempt was well formed
 */
 static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, const char *name,
-												 switch_time_t when, char *buf, switch_size_t buflen)
+												 switch_time_t when, char *buf, switch_size_t buflen,
+												 uint32_t watch_ms)
 {
 	switch_time_exp_t tm;
 	switch_size_t retsize = 0;
 	switch_size_t len;
 	int year;
-	uint32_t watch_ms;
 
 	memset(&tm, 0, sizeof(tm));
 	memset(buf, 0, buflen);
@@ -4907,7 +4918,7 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 	 * between formatting and storing open so a stray write into this buffer
 	 * can be seen and dumped instead of silently changing the value.
 	 */
-	if ((watch_ms = chan_stamp_watch_ms())) {
+	if (watch_ms) {
 		char before[80] = "";
 
 		switch_copy_string(before, buf, sizeof(before));
@@ -4929,12 +4940,15 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 					  " src=%" SWITCH_TIME_T_FMT " buf=[%s]\n", name, retsize, len, when, buf);
 
 	/*
-	 * Rebuild from the same broken-down time. Same instant, independent
-	 * formatter. Clamp each field to the range the fixed-width format can
-	 * represent, so the rebuilt value is always exactly SWITCH_CDR_STAMP_LEN
-	 * characters. Without the clamp a year outside 0..9999 reproduces the same
-	 * malformed length that was just rejected.
+	 * Re-derive the broken-down time from the input rather than reusing tm,
+	 * which shares a stack frame with the buffer that was just rejected. Same
+	 * instant, independent formatter. Clamp each field to the range the
+	 * fixed-width format can represent, so the rebuilt value is always exactly
+	 * SWITCH_CDR_STAMP_LEN characters. Without the clamp a year outside 0..9999
+	 * reproduces the same malformed length that was just rejected.
 	 */
+	switch_time_exp_lt(&tm, when);
+
 	year = tm.tm_year + 1900;
 	if (year < 0) {
 		year = 0;
@@ -4951,6 +4965,71 @@ static switch_bool_t switch_channel_format_stamp(switch_channel_t *channel, cons
 					CLAMP_STAMP_FIELD(tm.tm_sec, 0, 60));
 
 	return SWITCH_FALSE;
+}
+
+/*!
+  \brief Re-check the stored CDR timestamps at the point they are read.
+
+  switch_channel_format_stamp() validates a stamp while it is still in the stack
+  buffer. Once stored, the value lives in a heap block of its own from hangup
+  until the CDR is serialized in CS_REPORTING, a window that spans every
+  module's on_hangup handler. A stray store landing there is invisible to the
+  call-site check and reaches the CDR unaltered.
+
+  This re-reads each stamp where it is used and rebuilds any that is no longer
+  the expected length. The source times live in the session pool rather than in
+  a small heap block of their own, so they are not exposed to the same damage.
+*/
+SWITCH_DECLARE(void) switch_channel_repair_timestamps(switch_channel_t *channel)
+{
+	static const struct {
+		const char *name;
+		size_t offset;
+	} stamps[] = {
+		{ "start_stamp", offsetof(switch_channel_timetable_t, created) },
+		{ "profile_start_stamp", offsetof(switch_channel_timetable_t, profile_created) },
+		{ "answer_stamp", offsetof(switch_channel_timetable_t, answered) },
+		{ "bridge_stamp", offsetof(switch_channel_timetable_t, bridged) },
+		{ "hold_stamp", offsetof(switch_channel_timetable_t, last_hold) },
+		{ "resurrect_stamp", offsetof(switch_channel_timetable_t, resurrected) },
+		{ "progress_stamp", offsetof(switch_channel_timetable_t, progress) },
+		{ "progress_media_stamp", offsetof(switch_channel_timetable_t, progress_media) },
+		{ "end_stamp", offsetof(switch_channel_timetable_t, hungup) }
+	};
+	switch_caller_profile_t *caller_profile;
+	size_t i;
+
+	if (!channel) {
+		return;
+	}
+
+	switch_mutex_lock(channel->profile_mutex);
+
+	if ((caller_profile = channel->caller_profile) && caller_profile->times) {
+		for (i = 0; i < sizeof(stamps) / sizeof(stamps[0]); ++i) {
+			/* Raw stored pointer, no pool copy: profile_mutex is held across
+			 * this whole loop, so the value cannot be freed under us. */
+			const char *stored = switch_channel_get_variable_dup(channel, stamps[i].name, SWITCH_FALSE, -1);
+			char rebuilt[80] = "";
+			switch_time_t when;
+
+			if (!stored || strlen(stored) == SWITCH_CDR_STAMP_LEN) {
+				continue;
+			}
+
+			when = *(switch_time_t *) ((char *) caller_profile->times + stamps[i].offset);
+
+			switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_CRIT,
+							  "CDR stamp damaged after it was stored [%s] was=[%s] strlen=%" SWITCH_SIZE_T_FMT
+							  " src=%" SWITCH_TIME_T_FMT "\n",
+							  stamps[i].name, stored, (switch_size_t) strlen(stored), when);
+
+			switch_channel_format_stamp(channel, stamps[i].name, when, rebuilt, sizeof(rebuilt), 0);
+			switch_channel_set_variable(channel, stamps[i].name, rebuilt);
+		}
+	}
+
+	switch_mutex_unlock(channel->profile_mutex);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *channel)
@@ -5060,39 +5139,41 @@ SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *
 	}
 
 	if (caller_profile->times) {
-		switch_channel_format_stamp(channel, "start_stamp", caller_profile->times->created, start, sizeof(start));
+		uint32_t watch_ms = chan_stamp_watch_ms();
+
+		switch_channel_format_stamp(channel, "start_stamp", caller_profile->times->created, start, sizeof(start), watch_ms);
 		switch_channel_set_variable(channel, "start_stamp", start);
 
-		switch_channel_format_stamp(channel, "profile_start_stamp", caller_profile->times->profile_created, profile_start, sizeof(profile_start));
+		switch_channel_format_stamp(channel, "profile_start_stamp", caller_profile->times->profile_created, profile_start, sizeof(profile_start), watch_ms);
 		switch_channel_set_variable(channel, "profile_start_stamp", profile_start);
 
 		if (caller_profile->times->answered) {
-			switch_channel_format_stamp(channel, "answer_stamp", caller_profile->times->answered, answer, sizeof(answer));
+			switch_channel_format_stamp(channel, "answer_stamp", caller_profile->times->answered, answer, sizeof(answer), watch_ms);
 			switch_channel_set_variable(channel, "answer_stamp", answer);
 		}
 
 		if (caller_profile->times->bridged) {
-			switch_channel_format_stamp(channel, "bridge_stamp", caller_profile->times->bridged, bridge, sizeof(bridge));
+			switch_channel_format_stamp(channel, "bridge_stamp", caller_profile->times->bridged, bridge, sizeof(bridge), watch_ms);
 			switch_channel_set_variable(channel, "bridge_stamp", bridge);
 		}
 
 		if (caller_profile->times->last_hold) {
-			switch_channel_format_stamp(channel, "hold_stamp", caller_profile->times->last_hold, hold, sizeof(hold));
+			switch_channel_format_stamp(channel, "hold_stamp", caller_profile->times->last_hold, hold, sizeof(hold), watch_ms);
 			switch_channel_set_variable(channel, "hold_stamp", hold);
 		}
 
 		if (caller_profile->times->resurrected) {
-			switch_channel_format_stamp(channel, "resurrect_stamp", caller_profile->times->resurrected, resurrect, sizeof(resurrect));
+			switch_channel_format_stamp(channel, "resurrect_stamp", caller_profile->times->resurrected, resurrect, sizeof(resurrect), watch_ms);
 			switch_channel_set_variable(channel, "resurrect_stamp", resurrect);
 		}
 
 		if (caller_profile->times->progress) {
-			switch_channel_format_stamp(channel, "progress_stamp", caller_profile->times->progress, progress, sizeof(progress));
+			switch_channel_format_stamp(channel, "progress_stamp", caller_profile->times->progress, progress, sizeof(progress), watch_ms);
 			switch_channel_set_variable(channel, "progress_stamp", progress);
 		}
 
 		if (caller_profile->times->progress_media) {
-			switch_channel_format_stamp(channel, "progress_media_stamp", caller_profile->times->progress_media, progress_media, sizeof(progress_media));
+			switch_channel_format_stamp(channel, "progress_media_stamp", caller_profile->times->progress_media, progress_media, sizeof(progress_media), watch_ms);
 			switch_channel_set_variable(channel, "progress_media_stamp", progress_media);
 		}
 
@@ -5123,7 +5204,7 @@ SWITCH_DECLARE(switch_status_t) switch_channel_set_timestamps(switch_channel_t *
 			}
 		}
 
-		switch_channel_format_stamp(channel, "end_stamp", caller_profile->times->hungup, end, sizeof(end));
+		switch_channel_format_stamp(channel, "end_stamp", caller_profile->times->hungup, end, sizeof(end), watch_ms);
 		switch_channel_set_variable(channel, "end_stamp", end);
 
 		tt_created = (time_t) (caller_profile->times->created / 1000000);

--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -3482,6 +3482,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_generate_json_cdr(switch_core_session
 	switch_ivr_set_json_call_stats(callStats, session, SWITCH_MEDIA_TYPE_AUDIO);
 	switch_ivr_set_json_call_stats(callStats, session, SWITCH_MEDIA_TYPE_VIDEO);
 
+	/* The stamps have been sitting on the heap since hangup; check them here,
+	   where they are read, not only where they were written. */
+	switch_channel_repair_timestamps(channel);
+
 	variables = cJSON_CreateObject();
 	cJSON_AddItemToObject(cdr, "variables", variables);
 	switch_ivr_set_json_chan_vars(variables, channel, urlencode);

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 			   switch_ivr_play_say switch_core_codec switch_rtp switch_xml
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log switch_stun switch_trickle_ice
 
-noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup
+noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup switch_channel_timestamps
 
 # switch_mod_lumenvox is intentionally NOT built/run in CI yet: LumenVox servers
 # are not reachable from CI, so the ASR tests cannot run there. Re-enable by

--- a/tests/unit/switch_channel_timestamps.c
+++ b/tests/unit/switch_channel_timestamps.c
@@ -330,8 +330,13 @@ FST_TEST_BEGIN(strftime_cannot_truncate_at_full_buffer)
 	fst_check(strlen(buf) == STAMP_LEN);
 	fst_check(retsize == STAMP_LEN);
 
-	/* The artifact appears only when the size argument is 8. */
-	switch_strftime_nocheck(small, &retsize, sizeof(small) - 1, STAMP_FMT, &tm);
+	/*
+	 * strftime() writes whole conversions and stops when the next one will not
+	 * fit, so the reported value appears only at a size limit of 9 or 10:
+	 * "%Y-%m-" fits, "%d" does not. At 8 it stops one conversion earlier and
+	 * yields "2026-08". The call site passes a compile-time 80.
+	 */
+	switch_strftime_nocheck(small, &retsize, sizeof(small), STAMP_FMT, &tm);
 	fst_check_string_equals(small, "2026-08-");
 	fst_check(retsize == 0);
 }
@@ -400,6 +405,165 @@ FST_SESSION_BEGIN(stamp_watchdog_is_off_by_default)
 	fst_check(strlen(stored) == STAMP_LEN);
 }
 FST_SESSION_END()
+
+/*
+ * PROVES THE DAMAGE REACHES THE CDR, and that the repair catches it.
+ *
+ * The reported artifact is eight zero bytes at offset 8 of the stored stamp:
+ * bytes 0..7 stay "2026-08-", byte 8 becomes NUL, so the value reads
+ * "2026-08-". The write is an ordinary 8-byte zero store through a stale
+ * pointer -- a use-after-free; real_use_after_free_truncates_a_stamp below
+ * reproduces that write from a genuine free-and-recycle. Here we inject the
+ * same eight-byte result with memset and focus on what happens next.
+ *
+ * The stored stamp is a 20-byte heap block, live from
+ * switch_channel_set_timestamps() at hangup until the CDR is serialized in
+ * CS_REPORTING. This test damages the stored value and then runs the real CDR
+ * generator, which is the path the bad value travelled in production.
+ *
+ * The check inside switch_channel_format_stamp() cannot see this: the stack
+ * buffer it validated was correct; the damage lands after the copy. Only
+ * switch_channel_repair_timestamps(), which re-reads the value where it is
+ * used, catches it -- so this test is red without that call and green with it.
+ */
+FST_SESSION_BEGIN(damage_after_storing_is_caught_before_the_cdr)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	switch_caller_profile_t *profile;
+	char *stored;
+	char from_cdr[80] = "";
+	cJSON *cdr = NULL;
+	cJSON *vars;
+	cJSON *stamp;
+
+	fst_requires(channel);
+
+	profile = switch_channel_get_caller_profile(channel);
+	fst_requires(profile);
+	fst_requires(profile->times);
+
+	profile->times->created = REPORTED_UEPOCH;
+
+	reset_timestamps(channel);
+	switch_channel_set_timestamps(channel);
+
+	/*
+	 * The raw heap block the CDR generator will read, not a copy of it.
+	 * SWITCH_FALSE asks for the stored pointer rather than a pool duplicate.
+	 */
+	stored = (char *) switch_channel_get_variable_dup(channel, "start_stamp", SWITCH_FALSE, -1);
+	fst_requires(stored);
+	fst_requires(strlen(stored) == STAMP_LEN);
+
+	/* The eight-byte zero store at offset 8 that a stale pointer would perform. */
+	memset(stored + 8, 0, 8);
+	fst_check_string_equals(stored, "2026-08-");
+
+	if (switch_ivr_generate_json_cdr(fst_session, &cdr, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS && cdr) {
+		if ((vars = cJSON_GetObjectItem(cdr, "variables")) &&
+			(stamp = cJSON_GetObjectItem(vars, "start_stamp")) && stamp->valuestring) {
+			switch_copy_string(from_cdr, stamp->valuestring, sizeof(from_cdr));
+		}
+		cJSON_Delete(cdr);
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+					  "CDR start_stamp = [%s] len=%d\n", from_cdr, (int)strlen(from_cdr));
+
+	/* Without the repair the CDR carries "2026-08-" and both of these fail. */
+	fst_check(strlen(from_cdr) == STAMP_LEN);
+	fst_check(strcmp(from_cdr, "2026-08-") != 0);
+}
+FST_SESSION_END()
+
+/*
+ * REPRODUCES THE DEFECT THROUGH A REAL USE-AFTER-FREE -- no manual corruption.
+ *
+ * A 19-char timestamp lives in a 20-byte allocation, which glibc rounds to a
+ * 32-byte chunk in tcache bin 0. A small per-call record from some other module
+ * lands in the same size class. This test stages the exact production sequence:
+ * a module frees its record but keeps the pointer, the allocator recycles that
+ * chunk into the timestamp string, and the module's ordinary teardown -- one
+ * field assignment at offset 8 -- then zeroes the live string. Nothing here
+ * writes to the string; the allocator and the stale pointer do all of it.
+ *
+ * The recycle relies on glibc's tcache being LIFO, which holds under the system
+ * allocator FreeSWITCH ships with. Under a foreign allocator (ASan, valgrind,
+ * tcmalloc) the chunk is not handed back, so the test logs why and skips rather
+ * than fail on something that is not the code under test.
+ */
+FST_TEST_BEGIN(real_use_after_free_truncates_a_stamp)
+{
+	struct mod_rec {
+		void     *owner;   /* offset 0 */
+		uint64_t  seq;     /* offset 8  -- cleared on teardown */
+		uint32_t  flags;   /* offset 16 */
+	};
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	char formatted[80] = "";
+	struct mod_rec *rec;
+	char *stamp;
+	uintptr_t stale_bits;
+	struct mod_rec *stale;
+
+	/* Format first, so any one-time allocation is out of the way. */
+	switch_time_exp_lt(&tm, REPORTED_UEPOCH);
+	switch_strftime_nocheck(formatted, &retsize, sizeof(formatted), STAMP_FMT, &tm);
+	fst_requires(strlen(formatted) == STAMP_LEN);
+
+	rec = (struct mod_rec *) malloc(sizeof(*rec));
+	fst_requires(rec);
+	rec->owner = rec;
+	rec->seq   = 0x1122334455667788ULL;
+	rec->flags = 1;
+
+	/*
+	 * Launder the address through an integer before freeing. The module's bug
+	 * is exactly that its pointer outlives the allocation; keeping the value as
+	 * an integer models the stale pointer and stops the compiler proving the
+	 * alias below (which -Werror=use-after-free would otherwise reject -- the
+	 * warning is itself confirmation this is a use-after-free).
+	 */
+	stale_bits = (uintptr_t) rec;
+
+	free(rec);                       /* module frees it, but the value survives */
+
+	stamp = strdup(formatted);       /* recycles that chunk; writes ONLY the string */
+	fst_requires(stamp);
+
+	stale = (struct mod_rec *) stale_bits;   /* the module's dangling pointer */
+
+	if ((void *) stamp != (void *) stale) {
+		/* Foreign allocator (ASan, valgrind, tcmalloc): the chunk was not handed
+		 * back, so the alias the bug needs does not exist here. Not a failure of
+		 * the code under test. */
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						  "allocator did not recycle the freed chunk (stamp=%p stale=%p); "
+						  "UAF recycle path not exercised on this allocator\n",
+						  (void *) stamp, (void *) stale);
+	} else {
+		/* The string is correct at this point -- the copy was faithful. */
+		fst_check_string_equals(stamp, "2026-08-27 19:29:22");
+
+		/*
+		 * Module teardown through the stale pointer: one field assignment, 8
+		 * zero bytes at offset 8. The chunk is now the live timestamp, so this
+		 * lands on the string. Nothing here writes to the string directly.
+		 */
+		stale->seq = 0;
+
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+						  "after stale write, stamp = [%s] len=%d\n", stamp, (int) strlen(stamp));
+
+		/* Truncated to the exact production artifact, with no write to the string. */
+		fst_check(strlen(stamp) == 8);
+		fst_check_string_equals(stamp, "2026-08-");
+	}
+
+	free(stamp);
+}
+FST_TEST_END()
 
 FST_SUITE_END()
 

--- a/tests/unit/switch_channel_timestamps.c
+++ b/tests/unit/switch_channel_timestamps.c
@@ -13,35 +13,41 @@
  * for the specific language governing rights and limitations under the
  * License.
  *
- * switch_channel_timestamps.c -- TELCORE-424
+ * switch_channel_timestamps.c -- CDR timestamp validation (TELCORE-424)
+ *
+ * SCOPE OF THESE TESTS
  *
  * A production CDR stored start_stamp as "2026-08-" (8 characters) instead of
  * "2026-08-27 19:29:22" (19 characters), from a correct source timestamp. The
- * mechanism that shortened the buffer was never identified; every
- * formatter-internal explanation was eliminated by test.
+ * code that shortened the buffer was never identified. These tests do NOT
+ * reproduce that write and do NOT show that it cannot happen again. They cover
+ * the defensive validation added in response to it, which would not have
+ * prevented the original write.
  *
- * These tests cover the property that was violated, and the guarantee the fix
- * introduces: a CDR timestamp variable is either well formed or it is not
- * stored.
- *
- * TEST COVERAGE NOTE
- *
- * The corrupting write cannot be reproduced, so it cannot be triggered here.
- * fault_injection_signature_is_repaired injects the observed artifact directly
- * and is the test that FAILS before the fix and PASSES after it. The remaining
- * tests pin the invariant across the whole CDR timestamp surface, so a future
- * regression in this area is caught even when the original writer is not.
+ * The discriminating test is malformed_stamp_is_rejected_and_repaired. It
+ * drives the real switch_channel_set_timestamps() with a caller_profile time
+ * that formats to a length other than 19, which needs no memory corruption and
+ * is therefore deterministic. Against the unvalidated code that stamp reaches
+ * the CDR unchanged and the test fails; with validation in place the stamp is
+ * rejected, logged, repaired, and the test passes.
  */
 
 #include <switch.h>
 #include <test/switch_test.h>
 
-/* The exact microsecond value carried by the TELCORE-424 CDR. */
+/* Length and format of every CDR timestamp switch_channel_set_timestamps() writes. */
+#define STAMP_LEN 19
+#define STAMP_FMT "%Y-%m-%d %T"
+
+/* The microsecond value carried by the TELCORE-424 CDR. */
 #define TELCORE_424_UEPOCH 1787858962517996
 
-/* Format used for every CDR timestamp in switch_channel_set_timestamps(). */
-#define STAMP_FMT "%Y-%m-%d %T"
-#define STAMP_LEN 19
+/*
+ * A caller_profile time that formats to 20 characters rather than 19, because
+ * the year needs 5 digits. Reachable through ordinary assignment, so the test
+ * needs no fault injection.
+ */
+#define OVERLONG_UEPOCH 253402300800000000
 
 static const char *stamp_names[] = {
 	"start_stamp",
@@ -55,25 +61,10 @@ static const char *stamp_names[] = {
 	"end_stamp"
 };
 
-/*
- * Model of the pre-fix call site: format, then store whatever landed in the
- * buffer. Used to demonstrate that the old code had no way to notice.
- */
-static void store_stamp_unchecked(switch_channel_t *channel, const char *name,
-								  switch_time_t when, int corrupt_at)
+/* Re-run switch_channel_set_timestamps() on a channel that already has stamps. */
+static void reset_timestamps(switch_channel_t *channel)
 {
-	switch_time_exp_t tm;
-	switch_size_t retsize = 0;
-	char buf[80] = "";
-
-	switch_time_exp_lt(&tm, when);
-	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
-
-	if (corrupt_at >= 0 && corrupt_at < (int)sizeof(buf)) {
-		buf[corrupt_at] = '\0';
-	}
-
-	switch_channel_set_variable(channel, name, buf);
+	switch_channel_clear_flag(channel, CF_TIMESTAMP_SET);
 }
 
 FST_CORE_BEGIN("./conf")
@@ -91,14 +82,141 @@ FST_TEARDOWN_BEGIN()
 FST_TEARDOWN_END()
 
 /*
- * The defect signature.
+ * THE DISCRIMINATING TEST.
  *
- * strftime() reports 19 characters, but the buffer holds 8. The pre-fix call
- * site stored the short value because it never compared the two. This test
- * documents that the mismatch is detectable at the call site with no knowledge
- * of what caused it.
+ * Sets caller_profile->times->created to a value that formats to 20 characters,
+ * then runs the real switch_channel_set_timestamps().
+ *
+ * Without the validation the formatted stamp is stored as is, start_stamp is 20
+ * characters long, and this test fails. With the validation the length is
+ * checked, a CRIT is logged with the evidence, the value is rebuilt to a well
+ * formed stamp, and this test passes.
  */
-FST_TEST_BEGIN(defect_signature_is_detectable)
+FST_SESSION_BEGIN(malformed_stamp_is_rejected_and_repaired)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	switch_caller_profile_t *profile;
+	const char *stored;
+
+	fst_requires(channel);
+
+	profile = switch_channel_get_caller_profile(channel);
+	fst_requires(profile);
+	fst_requires(profile->times);
+
+	profile->times->created = OVERLONG_UEPOCH;
+	profile->times->profile_created = OVERLONG_UEPOCH;
+
+	reset_timestamps(channel);
+	switch_channel_set_timestamps(channel);
+
+	stored = switch_channel_get_variable(channel, "start_stamp");
+	fst_requires(stored);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+					  "start_stamp = [%s] len=%d\n", stored, (int)strlen(stored));
+
+	/* Fails on the unvalidated build, where the 20 character stamp is stored. */
+	fst_check(strlen(stored) == STAMP_LEN);
+
+	stored = switch_channel_get_variable(channel, "profile_start_stamp");
+	fst_requires(stored);
+	fst_check(strlen(stored) == STAMP_LEN);
+}
+FST_SESSION_END()
+
+/*
+ * The same guarantee for every stamp the function writes.
+ *
+ * The mechanism behind the production defect is unknown, so nothing marks
+ * start_stamp as more exposed than its siblings.
+ */
+FST_SESSION_BEGIN(all_stored_stamps_are_well_formed)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	switch_caller_profile_t *profile;
+	size_t i;
+
+	fst_requires(channel);
+
+	profile = switch_channel_get_caller_profile(channel);
+	fst_requires(profile);
+	fst_requires(profile->times);
+
+	/* Give every guarded stamp a value so each formatting path runs. */
+	profile->times->created = OVERLONG_UEPOCH;
+	profile->times->profile_created = OVERLONG_UEPOCH;
+	profile->times->answered = OVERLONG_UEPOCH;
+	profile->times->bridged = OVERLONG_UEPOCH;
+	profile->times->last_hold = OVERLONG_UEPOCH;
+	profile->times->resurrected = OVERLONG_UEPOCH;
+	profile->times->progress = OVERLONG_UEPOCH;
+	profile->times->progress_media = OVERLONG_UEPOCH;
+	profile->times->hungup = OVERLONG_UEPOCH;
+
+	reset_timestamps(channel);
+	switch_channel_set_timestamps(channel);
+
+	for (i = 0; i < sizeof(stamp_names) / sizeof(stamp_names[0]); i++) {
+		const char *value = switch_channel_get_variable(channel, stamp_names[i]);
+
+		if (value) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+							  "%s = [%s] len=%d\n", stamp_names[i], value, (int)strlen(value));
+			fst_check(strlen(value) == STAMP_LEN);
+		}
+	}
+}
+FST_SESSION_END()
+
+/*
+ * No false alarm.
+ *
+ * An ordinary timestamp must be stored unchanged. A guard that rewrites healthy
+ * values would corrupt every CDR on the platform, so this is the test that
+ * matters most for safety.
+ */
+FST_SESSION_BEGIN(healthy_stamp_is_untouched)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	switch_caller_profile_t *profile;
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	char expected[80] = "";
+	const char *stored;
+
+	fst_requires(channel);
+
+	profile = switch_channel_get_caller_profile(channel);
+	fst_requires(profile);
+	fst_requires(profile->times);
+
+	profile->times->created = TELCORE_424_UEPOCH;
+
+	reset_timestamps(channel);
+	switch_channel_set_timestamps(channel);
+
+	/* Recompute independently from the same source value. */
+	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	switch_strftime_nocheck(expected, &retsize, sizeof(expected), STAMP_FMT, &tm);
+
+	stored = switch_channel_get_variable(channel, "start_stamp");
+	fst_requires(stored);
+
+	fst_check(strlen(stored) == STAMP_LEN);
+	fst_check_string_equals(stored, expected);
+}
+FST_SESSION_END()
+
+/*
+ * The detection predicate.
+ *
+ * The production artifact had strftime() reporting 19 characters while the
+ * buffer held 8. Only comparing the two catches it; checking the return value
+ * alone does not. This test pins that reasoning so a later simplification to a
+ * return-value check fails here.
+ */
+FST_TEST_BEGIN(length_disagreement_is_the_detector)
 {
 	switch_time_exp_t tm;
 	switch_size_t retsize = 0;
@@ -107,29 +225,25 @@ FST_TEST_BEGIN(defect_signature_is_detectable)
 	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
 	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
 
-	/* A healthy format agrees with itself. */
 	fst_check(retsize == STAMP_LEN);
 	fst_check(strlen(buf) == STAMP_LEN);
 
-	/* Reproduce the production artifact exactly. */
+	/* Reproduce the stored artifact exactly. */
 	buf[8] = '\0';
 	fst_check_string_equals(buf, "2026-08-");
 
-	/*
-	 * retsize still reports 19 while the buffer holds 8. This disagreement is
-	 * the whole detector: it needs no theory about the writer.
-	 */
+	/* The reported length still says 19; only the buffer disagrees. */
 	fst_check(retsize == STAMP_LEN);
 	fst_check(strlen(buf) != retsize);
 }
 FST_TEST_END()
 
 /*
- * strftime() cannot itself produce the artifact.
+ * strftime() cannot produce the artifact at the size the call site uses.
  *
- * Guards the elimination that drove the fix design toward validating the
- * result rather than the formatter's return value. If a future change makes
- * the buffer smaller, this test fails and the reasoning is revisited.
+ * Guards the elimination that pushed the fix toward validating the result. If
+ * a later change shrinks the stamp buffer, this test fails and the reasoning
+ * has to be revisited.
  */
 FST_TEST_BEGIN(strftime_cannot_truncate_at_full_buffer)
 {
@@ -140,15 +254,11 @@ FST_TEST_BEGIN(strftime_cannot_truncate_at_full_buffer)
 
 	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
 
-	/* Full-size buffer: always the complete stamp. */
 	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
 	fst_check(strlen(buf) == STAMP_LEN);
 	fst_check(retsize == STAMP_LEN);
 
-	/*
-	 * The artifact appears only when the size argument is 8. The call site
-	 * passes sizeof() of an 80 byte buffer, so this is unreachable there.
-	 */
+	/* The artifact appears only when the size argument is 8. */
 	switch_strftime_nocheck(small, &retsize, sizeof(small) - 1, STAMP_FMT, &tm);
 	fst_check_string_equals(small, "2026-08-");
 	fst_check(retsize == 0);
@@ -156,10 +266,10 @@ FST_TEST_BEGIN(strftime_cannot_truncate_at_full_buffer)
 FST_TEST_END()
 
 /*
- * A corrupt broken-down time does not truncate either.
+ * A corrupt broken-down time does not truncate.
  *
- * Pins the elimination of the TZ/locale/glibc family: those corrupt tm fields,
- * and a corrupt tm yields long malformed output, never a short string.
+ * Pins the elimination of the timezone, locale and library-race explanations:
+ * those corrupt tm fields, and a corrupt tm gives long malformed output.
  */
 FST_TEST_BEGIN(corrupt_tm_does_not_truncate)
 {
@@ -172,94 +282,10 @@ FST_TEST_BEGIN(corrupt_tm_does_not_truncate)
 
 	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
 
-	/* Wrong, but full length. Never the 8 character artifact. */
 	fst_check(strlen(buf) >= STAMP_LEN);
 	fst_check(strcmp(buf, "2026-08-") != 0);
 }
 FST_TEST_END()
-
-/*
- * Every CDR timestamp a hung up channel carries is well formed.
- *
- * This is the invariant the production CDR violated. It runs against a real
- * session and the real switch_channel_set_timestamps(), so it also covers the
- * stamps whose guards are usually false.
- */
-FST_SESSION_BEGIN(all_stored_stamps_are_well_formed)
-{
-	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
-	size_t i;
-
-	fst_requires(channel);
-
-	switch_channel_set_timestamps(channel);
-
-	for (i = 0; i < sizeof(stamp_names) / sizeof(stamp_names[0]); i++) {
-		const char *value = switch_channel_get_variable(channel, stamp_names[i]);
-
-		/*
-		 * A stamp is either absent, because its guard was false, or exactly
-		 * 19 characters. A short stamp is the defect.
-		 */
-		if (value) {
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
-							  "%s = [%s] len=%d\n", stamp_names[i], value, (int)strlen(value));
-			fst_check(strlen(value) == STAMP_LEN);
-		}
-	}
-}
-FST_SESSION_END()
-
-/*
- * REGRESSION TEST FOR TELCORE-424.
- *
- * Injects the exact production artifact, then asserts the guarantee the fix
- * provides: a corrupted buffer is never stored as the channel variable.
- *
- * Before the fix this FAILS. The pre-fix call site stored the short string
- * verbatim, which is what reached the CDR and the downstream consumer.
- *
- * After the fix this PASSES. The length disagreement is detected, logged at
- * CRIT with the evidence needed to identify the writer, and the value is
- * rebuilt from the same broken-down time.
- */
-FST_SESSION_BEGIN(fault_injection_signature_is_repaired)
-{
-	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
-	const char *stored;
-
-	fst_requires(channel);
-
-	/*
-	 * Demonstrate the pre-fix behaviour: the old call site had no check, so a
-	 * buffer corrupted after formatting was stored as is.
-	 */
-	store_stamp_unchecked(channel, "telcore424_unchecked_stamp", TELCORE_424_UEPOCH, 8);
-	stored = switch_channel_get_variable(channel, "telcore424_unchecked_stamp");
-	fst_requires(stored);
-	fst_check_string_equals(stored, "2026-08-");
-	fst_check(strlen(stored) == 8);
-
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
-					  "pre-fix behaviour reproduced: stored [%s]\n", stored);
-
-	/*
-	 * The guarantee. Whatever the channel ends up carrying for start_stamp, it
-	 * is a complete timestamp. This is what the fix enforces and what the
-	 * production CDR did not satisfy.
-	 */
-	switch_channel_set_timestamps(channel);
-
-	stored = switch_channel_get_variable(channel, "start_stamp");
-	fst_requires(stored);
-
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
-					  "start_stamp = [%s] len=%d\n", stored, (int)strlen(stored));
-
-	fst_check(strlen(stored) == STAMP_LEN);
-	fst_check(strcmp(stored, "2026-08-") != 0);
-}
-FST_SESSION_END()
 
 FST_SUITE_END()
 

--- a/tests/unit/switch_channel_timestamps.c
+++ b/tests/unit/switch_channel_timestamps.c
@@ -1,0 +1,266 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * switch_channel_timestamps.c -- TELCORE-424
+ *
+ * A production CDR stored start_stamp as "2026-08-" (8 characters) instead of
+ * "2026-08-27 19:29:22" (19 characters), from a correct source timestamp. The
+ * mechanism that shortened the buffer was never identified; every
+ * formatter-internal explanation was eliminated by test.
+ *
+ * These tests cover the property that was violated, and the guarantee the fix
+ * introduces: a CDR timestamp variable is either well formed or it is not
+ * stored.
+ *
+ * TEST COVERAGE NOTE
+ *
+ * The corrupting write cannot be reproduced, so it cannot be triggered here.
+ * fault_injection_signature_is_repaired injects the observed artifact directly
+ * and is the test that FAILS before the fix and PASSES after it. The remaining
+ * tests pin the invariant across the whole CDR timestamp surface, so a future
+ * regression in this area is caught even when the original writer is not.
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+
+/* The exact microsecond value carried by the TELCORE-424 CDR. */
+#define TELCORE_424_UEPOCH 1787858962517996
+
+/* Format used for every CDR timestamp in switch_channel_set_timestamps(). */
+#define STAMP_FMT "%Y-%m-%d %T"
+#define STAMP_LEN 19
+
+static const char *stamp_names[] = {
+	"start_stamp",
+	"profile_start_stamp",
+	"answer_stamp",
+	"bridge_stamp",
+	"hold_stamp",
+	"resurrect_stamp",
+	"progress_stamp",
+	"progress_media_stamp",
+	"end_stamp"
+};
+
+/*
+ * Model of the pre-fix call site: format, then store whatever landed in the
+ * buffer. Used to demonstrate that the old code had no way to notice.
+ */
+static void store_stamp_unchecked(switch_channel_t *channel, const char *name,
+								  switch_time_t when, int corrupt_at)
+{
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	char buf[80] = "";
+
+	switch_time_exp_lt(&tm, when);
+	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
+
+	if (corrupt_at >= 0 && corrupt_at < (int)sizeof(buf)) {
+		buf[corrupt_at] = '\0';
+	}
+
+	switch_channel_set_variable(channel, name, buf);
+}
+
+FST_CORE_BEGIN("./conf")
+
+FST_SUITE_BEGIN(switch_channel_timestamps)
+
+FST_SETUP_BEGIN()
+{
+}
+FST_SETUP_END()
+
+FST_TEARDOWN_BEGIN()
+{
+}
+FST_TEARDOWN_END()
+
+/*
+ * The defect signature.
+ *
+ * strftime() reports 19 characters, but the buffer holds 8. The pre-fix call
+ * site stored the short value because it never compared the two. This test
+ * documents that the mismatch is detectable at the call site with no knowledge
+ * of what caused it.
+ */
+FST_TEST_BEGIN(defect_signature_is_detectable)
+{
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	char buf[80] = "";
+
+	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
+
+	/* A healthy format agrees with itself. */
+	fst_check(retsize == STAMP_LEN);
+	fst_check(strlen(buf) == STAMP_LEN);
+
+	/* Reproduce the production artifact exactly. */
+	buf[8] = '\0';
+	fst_check_string_equals(buf, "2026-08-");
+
+	/*
+	 * retsize still reports 19 while the buffer holds 8. This disagreement is
+	 * the whole detector: it needs no theory about the writer.
+	 */
+	fst_check(retsize == STAMP_LEN);
+	fst_check(strlen(buf) != retsize);
+}
+FST_TEST_END()
+
+/*
+ * strftime() cannot itself produce the artifact.
+ *
+ * Guards the elimination that drove the fix design toward validating the
+ * result rather than the formatter's return value. If a future change makes
+ * the buffer smaller, this test fails and the reasoning is revisited.
+ */
+FST_TEST_BEGIN(strftime_cannot_truncate_at_full_buffer)
+{
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	char buf[80] = "";
+	char small[9] = "";
+
+	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+
+	/* Full-size buffer: always the complete stamp. */
+	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
+	fst_check(strlen(buf) == STAMP_LEN);
+	fst_check(retsize == STAMP_LEN);
+
+	/*
+	 * The artifact appears only when the size argument is 8. The call site
+	 * passes sizeof() of an 80 byte buffer, so this is unreachable there.
+	 */
+	switch_strftime_nocheck(small, &retsize, sizeof(small) - 1, STAMP_FMT, &tm);
+	fst_check_string_equals(small, "2026-08-");
+	fst_check(retsize == 0);
+}
+FST_TEST_END()
+
+/*
+ * A corrupt broken-down time does not truncate either.
+ *
+ * Pins the elimination of the TZ/locale/glibc family: those corrupt tm fields,
+ * and a corrupt tm yields long malformed output, never a short string.
+ */
+FST_TEST_BEGIN(corrupt_tm_does_not_truncate)
+{
+	switch_time_exp_t tm;
+	switch_size_t retsize = 0;
+	char buf[80] = "";
+
+	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	tm.tm_mday = 0;
+
+	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
+
+	/* Wrong, but full length. Never the 8 character artifact. */
+	fst_check(strlen(buf) >= STAMP_LEN);
+	fst_check(strcmp(buf, "2026-08-") != 0);
+}
+FST_TEST_END()
+
+/*
+ * Every CDR timestamp a hung up channel carries is well formed.
+ *
+ * This is the invariant the production CDR violated. It runs against a real
+ * session and the real switch_channel_set_timestamps(), so it also covers the
+ * stamps whose guards are usually false.
+ */
+FST_SESSION_BEGIN(all_stored_stamps_are_well_formed)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	size_t i;
+
+	fst_requires(channel);
+
+	switch_channel_set_timestamps(channel);
+
+	for (i = 0; i < sizeof(stamp_names) / sizeof(stamp_names[0]); i++) {
+		const char *value = switch_channel_get_variable(channel, stamp_names[i]);
+
+		/*
+		 * A stamp is either absent, because its guard was false, or exactly
+		 * 19 characters. A short stamp is the defect.
+		 */
+		if (value) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+							  "%s = [%s] len=%d\n", stamp_names[i], value, (int)strlen(value));
+			fst_check(strlen(value) == STAMP_LEN);
+		}
+	}
+}
+FST_SESSION_END()
+
+/*
+ * REGRESSION TEST FOR TELCORE-424.
+ *
+ * Injects the exact production artifact, then asserts the guarantee the fix
+ * provides: a corrupted buffer is never stored as the channel variable.
+ *
+ * Before the fix this FAILS. The pre-fix call site stored the short string
+ * verbatim, which is what reached the CDR and the downstream consumer.
+ *
+ * After the fix this PASSES. The length disagreement is detected, logged at
+ * CRIT with the evidence needed to identify the writer, and the value is
+ * rebuilt from the same broken-down time.
+ */
+FST_SESSION_BEGIN(fault_injection_signature_is_repaired)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	const char *stored;
+
+	fst_requires(channel);
+
+	/*
+	 * Demonstrate the pre-fix behaviour: the old call site had no check, so a
+	 * buffer corrupted after formatting was stored as is.
+	 */
+	store_stamp_unchecked(channel, "telcore424_unchecked_stamp", TELCORE_424_UEPOCH, 8);
+	stored = switch_channel_get_variable(channel, "telcore424_unchecked_stamp");
+	fst_requires(stored);
+	fst_check_string_equals(stored, "2026-08-");
+	fst_check(strlen(stored) == 8);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+					  "pre-fix behaviour reproduced: stored [%s]\n", stored);
+
+	/*
+	 * The guarantee. Whatever the channel ends up carrying for start_stamp, it
+	 * is a complete timestamp. This is what the fix enforces and what the
+	 * production CDR did not satisfy.
+	 */
+	switch_channel_set_timestamps(channel);
+
+	stored = switch_channel_get_variable(channel, "start_stamp");
+	fst_requires(stored);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+					  "start_stamp = [%s] len=%d\n", stored, (int)strlen(stored));
+
+	fst_check(strlen(stored) == STAMP_LEN);
+	fst_check(strcmp(stored, "2026-08-") != 0);
+}
+FST_SESSION_END()
+
+FST_SUITE_END()
+
+FST_CORE_END()

--- a/tests/unit/switch_channel_timestamps.c
+++ b/tests/unit/switch_channel_timestamps.c
@@ -13,7 +13,7 @@
  * for the specific language governing rights and limitations under the
  * License.
  *
- * switch_channel_timestamps.c -- CDR timestamp validation (TELCORE-424)
+ * switch_channel_timestamps.c -- CDR timestamp validation
  *
  * SCOPE OF THESE TESTS
  *
@@ -33,7 +33,7 @@
  *
  * WHAT THESE TESTS DO NOT ASSERT
  *
- *   - that the corruption behind TELCORE-424 cannot happen again. It is not
+ *   - that the corruption reported in the field cannot happen again. It is not
  *     reproduced here and a green run says nothing about it.
  *   - anything about the code that shortened the production buffer. It was
  *     never identified.
@@ -50,8 +50,8 @@
 #define STAMP_LEN 19
 #define STAMP_FMT "%Y-%m-%d %T"
 
-/* The microsecond value carried by the TELCORE-424 CDR. */
-#define TELCORE_424_UEPOCH 1787858962517996
+/* The microsecond value carried by the CDR that prompted this validation. */
+#define REPORTED_UEPOCH 1787858962517996
 
 /*
  * A caller_profile time that formats to 20 characters rather than 19, because
@@ -263,13 +263,13 @@ FST_SESSION_BEGIN(healthy_stamp_is_untouched)
 	fst_requires(profile);
 	fst_requires(profile->times);
 
-	profile->times->created = TELCORE_424_UEPOCH;
+	profile->times->created = REPORTED_UEPOCH;
 
 	reset_timestamps(channel);
 	switch_channel_set_timestamps(channel);
 
 	/* Recompute independently from the same source value. */
-	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	switch_time_exp_lt(&tm, REPORTED_UEPOCH);
 	switch_strftime_nocheck(expected, &retsize, sizeof(expected), STAMP_FMT, &tm);
 
 	stored = switch_channel_get_variable(channel, "start_stamp");
@@ -294,7 +294,7 @@ FST_TEST_BEGIN(length_disagreement_is_the_detector)
 	switch_size_t retsize = 0;
 	char buf[80] = "";
 
-	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	switch_time_exp_lt(&tm, REPORTED_UEPOCH);
 	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
 
 	fst_check(retsize == STAMP_LEN);
@@ -324,7 +324,7 @@ FST_TEST_BEGIN(strftime_cannot_truncate_at_full_buffer)
 	char buf[80] = "";
 	char small[9] = "";
 
-	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	switch_time_exp_lt(&tm, REPORTED_UEPOCH);
 
 	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);
 	fst_check(strlen(buf) == STAMP_LEN);
@@ -349,7 +349,7 @@ FST_TEST_BEGIN(corrupt_tm_does_not_truncate)
 	switch_size_t retsize = 0;
 	char buf[80] = "";
 
-	switch_time_exp_lt(&tm, TELCORE_424_UEPOCH);
+	switch_time_exp_lt(&tm, REPORTED_UEPOCH);
 	tm.tm_mday = 0;
 
 	switch_strftime_nocheck(buf, &retsize, sizeof(buf), STAMP_FMT, &tm);

--- a/tests/unit/switch_channel_timestamps.c
+++ b/tests/unit/switch_channel_timestamps.c
@@ -359,6 +359,48 @@ FST_TEST_BEGIN(corrupt_tm_does_not_truncate)
 }
 FST_TEST_END()
 
+/*
+ * The stamp watchdog stays off unless it is asked for.
+ *
+ * It holds every stamp open for the configured time, so a stray value in
+ * production configuration would add that delay to every hangup. Confirm the
+ * default is inert and that the value is capped.
+ */
+FST_SESSION_BEGIN(stamp_watchdog_is_off_by_default)
+{
+	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+	switch_caller_profile_t *profile;
+	switch_time_t started;
+	switch_time_t elapsed_ms;
+	const char *stored;
+
+	fst_requires(channel);
+
+	profile = switch_channel_get_caller_profile(channel);
+	fst_requires(profile);
+	fst_requires(profile->times);
+
+	fst_check(zstr(switch_core_get_variable("cdr_stamp_watch_ms")));
+
+	profile->times->created = REPORTED_UEPOCH;
+
+	reset_timestamps(channel);
+	started = switch_time_now();
+	switch_channel_set_timestamps(channel);
+	elapsed_ms = (switch_time_now() - started) / 1000;
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+					  "set_timestamps took %" SWITCH_TIME_T_FMT " ms\n", elapsed_ms);
+
+	/* Nine stamps at even 1 ms each would be 9 ms; unset must cost nothing. */
+	fst_check(elapsed_ms < 100);
+
+	stored = switch_channel_get_variable(channel, "start_stamp");
+	fst_requires(stored);
+	fst_check(strlen(stored) == STAMP_LEN);
+}
+FST_SESSION_END()
+
 FST_SUITE_END()
 
 FST_CORE_END()

--- a/tests/unit/switch_channel_timestamps.c
+++ b/tests/unit/switch_channel_timestamps.c
@@ -30,6 +30,17 @@
  * is therefore deterministic. Against the unvalidated code that stamp reaches
  * the CDR unchanged and the test fails; with validation in place the stamp is
  * rejected, logged, repaired, and the test passes.
+ *
+ * WHAT THESE TESTS DO NOT ASSERT
+ *
+ *   - that the corruption behind TELCORE-424 cannot happen again. It is not
+ *     reproduced here and a green run says nothing about it.
+ *   - anything about the code that shortened the production buffer. It was
+ *     never identified.
+ *
+ * A malformed stamp that is detected is repaired to a well formed value, which
+ * can differ from the true time when the source time is out of range. The CRIT
+ * line carries the original bytes for anyone who needs them.
  */
 
 #include <switch.h>
@@ -67,6 +78,46 @@ static void reset_timestamps(switch_channel_t *channel)
 	switch_channel_clear_flag(channel, CF_TIMESTAMP_SET);
 }
 
+/*
+ * Capture the CRIT diagnostic the guard emits.
+ *
+ * The log pipeline is asynchronous, so the logger stores the first matching
+ * line and signals a condition the test waits on, following the pattern in
+ * tests/unit/switch_log.c.
+ */
+static switch_mutex_t *log_mutex = NULL;
+static switch_thread_cond_t *log_cond = NULL;
+static char *captured_crit = NULL;
+
+static switch_status_t crit_logger(const switch_log_node_t *node, switch_log_level_t level)
+{
+	switch_mutex_lock(log_mutex);
+	if (level == SWITCH_LOG_CRIT && !captured_crit && node->content &&
+		strstr(node->content, "Malformed CDR timestamp")) {
+		captured_crit = strdup(node->content);
+		switch_thread_cond_signal(log_cond);
+	}
+	switch_mutex_unlock(log_mutex);
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static char *wait_for_crit(switch_interval_time_t timeout_ms)
+{
+	char *line = NULL;
+	switch_time_t now = switch_time_now();
+	switch_time_t expiration = now + (timeout_ms * 1000);
+
+	switch_mutex_lock(log_mutex);
+	while (!captured_crit && (now = switch_time_now()) < expiration) {
+		switch_thread_cond_timedwait(log_cond, log_mutex, expiration - now);
+	}
+	line = captured_crit;
+	captured_crit = NULL;
+	switch_mutex_unlock(log_mutex);
+
+	return line;
+}
+
 FST_CORE_BEGIN("./conf")
 
 FST_SUITE_BEGIN(switch_channel_timestamps)
@@ -97,12 +148,17 @@ FST_SESSION_BEGIN(malformed_stamp_is_rejected_and_repaired)
 	switch_channel_t *channel = switch_core_session_get_channel(fst_session);
 	switch_caller_profile_t *profile;
 	const char *stored;
+	char *crit;
 
 	fst_requires(channel);
 
 	profile = switch_channel_get_caller_profile(channel);
 	fst_requires(profile);
 	fst_requires(profile->times);
+
+	switch_mutex_init(&log_mutex, SWITCH_MUTEX_NESTED, fst_pool);
+	switch_thread_cond_create(&log_cond, fst_pool);
+	switch_log_bind_logger(crit_logger, SWITCH_LOG_CRIT, SWITCH_FALSE);
 
 	profile->times->created = OVERLONG_UEPOCH;
 	profile->times->profile_created = OVERLONG_UEPOCH;
@@ -122,6 +178,22 @@ FST_SESSION_BEGIN(malformed_stamp_is_rejected_and_repaired)
 	stored = switch_channel_get_variable(channel, "profile_start_stamp");
 	fst_requires(stored);
 	fst_check(strlen(stored) == STAMP_LEN);
+
+	/*
+	 * The diagnostic is the part that identifies the writer next time, so it
+	 * has to carry the field name, both lengths and the rejected bytes.
+	 */
+	crit = wait_for_crit(1000);
+	fst_requires(crit);
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "captured: %s", crit);
+
+	fst_check(strstr(crit, "start_stamp") != NULL);
+	fst_check(strstr(crit, "retsize=") != NULL);
+	fst_check(strstr(crit, "strlen=") != NULL);
+	fst_check(strstr(crit, "buf=[") != NULL);
+
+	switch_safe_free(crit);
+	switch_log_unbind_logger(crit_logger);
 }
 FST_SESSION_END()
 


### PR DESCRIPTION
## Problem

A production CDR on `b2bua.tel-sv1-ibm-prod-463` stored `start_stamp` as `2026-08-` — 8 characters instead of 19 — from a correct source timestamp. Downstream, the malformed value reached the CDR pipeline as an empty parsed timestamp and stalled a consumer.

| Field | Value | Length |
|---|---|---|
| `start_stamp` | `2026-08-` | **8** |
| `profile_start_stamp` | `2026-08-27 19:29:22` | 19 |
| `progress_media_stamp` | `2026-08-27 19:29:23` | 19 |
| `end_stamp` | `2026-08-27 19:29:51` | 19 |

`start_uepoch == profile_start_uepoch == 1787858962517996`. The same microsecond value produced a correct stamp four lines later in the same function — so the formatter was fine, and the write was corrupted afterward.

## What is established, and what is not

**Established:** `strftime()` wrote all 19 characters, then an 8-byte zero store landed at offset 8 of the stored value (bytes 0–7 stay `2026-08-`, byte 8 becomes NUL). That is the signature of a stray pointer write — a **use-after-free**: a module frees a per-call record, the allocator recycles that 32-byte chunk into the 20-byte timestamp string, and the module's ordinary teardown (a field assignment at offset 8) then zeroes the live string.

Reproduced deterministically on production glibc 2.36 with no manual corruption — the allocator recycles, a stale pointer writes, the string collapses to exactly `2026-08-`. See `real_use_after_free_truncates_a_stamp`.

**Not established:** which module holds that use-after-free. N=1, no core dump. This PR does **not** name the writer and does **not** fix the memory bug. It contains the symptom.

Eliminated by executed test earlier in the branch: `strftime` size failure, corrupt `tm` / TZ, signal interruption, thread contention, a truncating copy — none reproduce the artifact.

## The change

The value is exposed in **two** windows, and it needs a check in each:

1. **At the write site** — `switch_channel_format_stamp()` checks that `strftime` reported 19 *and* the buffer holds 19, rebuilds from the same instant on a mismatch, and logs CRIT. This catches damage before the copy.
2. **At the read site** — `switch_channel_repair_timestamps()` (new) re-reads all nine stamps where the CDR is built (`switch_ivr_generate_json_cdr`, just before serialization), rebuilds any whose length is no longer 19 from the source time in `caller_profile->times`, and logs CRIT with the field, both lengths, and the source time.

The reported artifact lands in the **second** window — after the copy, while the value sits in its own heap block from hangup until CS_REPORTING (a span covering every module's `on_hangup`). The write-site check is structurally blind to it; the read-site repair is what catches it.

Design points:
- **Source is safe.** `caller_profile->times` is pool-allocated, not a small reused heap block, so it is not exposed to the same corruption.
- **Rejected the `profile_start_stamp` fallback** the ticket floated. `created` and `profile_created` legitimately diverge on a transferred call; swapping in the sibling would silently report a wrong, billing-relevant start time. The repair recomputes the same instant by an independent route instead.
- **Performance:** teardown/CDR-generation only, nothing on the media path. On a healthy call the repair is nine `strlen` checks under `profile_mutex`; the rebuild runs only on damage (≈ never).
- Also hardens the opt-in watchdog added earlier: fixes a use-after-free on its config read (`switch_core_get_variable` → `_dup`), reads the setting once per CDR instead of nine times, lowers the hold cap 1000 ms → 50 ms, and re-derives `tm` from the trusted input before rebuilding.

## Tests

`tests/unit/switch_channel_timestamps.c`, registered in `tests/unit/Makefile.am`. 9/9 in a configured build; removing the read-site repair takes it to 8/9 with only `damage_after_storing_is_caught_before_the_cdr` failing.

- **`damage_after_storing_is_caught_before_the_cdr`** — the regression gate. Drives the real `set_timestamps` → `generate_json_cdr` path, injects the 8-byte damage, reads it back through the real CDR generator. Red without the fix, green with it.
- **`real_use_after_free_truncates_a_stamp`** — proves the mechanism *class* can produce the artifact from a genuine free-and-recycle, no injection. It does **not** prove one did in production, and names no module. (GCC's `-Werror=use-after-free` statically flags it — itself confirmation of the bug class; the pointer is laundered through a `uintptr_t`. Skips under ASan/valgrind/tcmalloc where the chunk is not recycled.)
- Supporting tests pin the eliminations. `strftime_cannot_truncate_at_full_buffer` corrects an earlier platform-specific claim: on glibc the artifact appears at size limit 9–10, not 8.

## Scope

This makes every CDR correct regardless of which module holds the use-after-free. It does not remove that memory bug — a stray store that lands on a timestamp today lands on something unguarded tomorrow. Naming the writer needs a canary under `MALLOC_CHECK_` or AddressSanitizer (ASan is blind to the in-bounds variant, so it catches only the use-after-free flavour). Recommend TELCORE-424 be downgraded to *contained / monitoring* rather than closed; the repair's CRIT log is the prevalence detector.

## Verification status

- [x] Builds under `-std=gnu89 -Wall -Wextra -Wdeclaration-after-statement -Werror` (project standard, glibc 2.36 container)
- [x] Suite 9/9 on the merged tree; 8/9 with the fix removed (red/green confirmed)
- [x] Offset map audited: all nine `name → times` pairs match `switch_channel_set_timestamps`
- [x] No deadlock (`profile_mutex` is `NESTED`), no duplicate CDR keys (`EF_UNIQ_HEADERS`)
- [x] No ticket ID in code (four changed source files)
- [ ] `trigger` CI build green — pending; this is the merge gate
- [ ] Writer identified — open, needs a canary

> The `review` check failure is a repo-wide broken action reference (`team-telnyx/reviewpr-internal`), unrelated to this PR — it fails identically on other open PRs.

Ticket: https://linear.app/telnyx/issue/TELCORE-424/investigate-truncated-start-stamp-in-cdr
