### PR TITLE
TELCORE-429: fix ASR close-ordering use-after-free in speech_callback()

### DIFF
--- a/src/mod/applications/mod_test/mod_test.c
+++ b/src/mod/applications/mod_test/mod_test.c
@@ -71,6 +71,7 @@ typedef struct {
 	switch_vad_t *vad;
 	int partial;
 	int get_results_delay_ms;
+	int in_get_results;
 	int closed;
 } test_asr_t;
 
@@ -251,6 +252,15 @@ static switch_status_t test_asr_check_results(switch_asr_handle_t *ah, switch_as
 
 	test_asr_report_use_after_close(context, "asr_check_results");
 
+	/* Reporting a result here makes the media bug callback take the core speech
+	 * thread's mutex, which that thread holds for as long as it is inside
+	 * asr_get_results below. The read loop would then block with bug_rwlock
+	 * held, starving switch_core_media_bug_remove() of its write lock for the
+	 * whole delay -- which is exactly the close a test wants to run in it. */
+	if (context->in_get_results) {
+		return SWITCH_STATUS_BREAK;
+	}
+
 	if (switch_test_flag(context, ASRFLAG_RETURNED_RESULT) || switch_test_flag(ah, SWITCH_ASR_FLAG_CLOSED)) {
 		return SWITCH_STATUS_BREAK;
 	}
@@ -284,10 +294,15 @@ static switch_status_t test_asr_get_results(switch_asr_handle_t *ah, char **resu
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 
 	/* Only the core speech thread calls this, never the media bug callback, so
-	 * the delay parks that one thread inside the module and nothing else. */
+	 * the delay parks that one thread inside the module and nothing else. The
+	 * variable lets a test confirm the thread really is parked in here before it
+	 * closes the handle, rather than assuming it from timing alone. */
 	if (context->get_results_delay_ms > 0) {
+		context->in_get_results = 1;
 		switch_core_set_variable("mod_test_asr_in_get_results", "true");
 		switch_yield(context->get_results_delay_ms * 1000);
+		switch_core_set_variable("mod_test_asr_in_get_results", "false");
+		context->in_get_results = 0;
 	}
 
 	test_asr_report_use_after_close(context, "asr_get_results");

--- a/src/mod/applications/mod_test/mod_test.c
+++ b/src/mod/applications/mod_test/mod_test.c
@@ -70,6 +70,8 @@ typedef struct {
 	char *channel_uuid;
 	switch_vad_t *vad;
 	int partial;
+	int get_results_delay_ms;
+	int closed;
 } test_asr_t;
 
 
@@ -160,6 +162,8 @@ static switch_status_t test_asr_close(switch_asr_handle_t *ah, switch_asr_flag_t
 
 	switch_log_printf(SWITCH_CHANNEL_UUID_LOG(context->channel_uuid), SWITCH_LOG_NOTICE, "ASR closing ...\n");
 
+	context->closed = 1;
+
 	if (context->vad) {
 		switch_vad_destroy(&context->vad);
 	}
@@ -229,9 +233,23 @@ static switch_status_t test_asr_resume(switch_asr_handle_t *ah)
 	return SWITCH_STATUS_SUCCESS;
 }
 
+/* The core must not run asr_close while a speech thread is still inside the
+ * module. Report it rather than assert: the callback is not the test's thread,
+ * and the handle is pool allocated here so the read itself stays in bounds. */
+static void test_asr_report_use_after_close(test_asr_t *context, const char *fn)
+{
+	if (context->closed) {
+		switch_log_printf(SWITCH_CHANNEL_UUID_LOG(context->channel_uuid), SWITCH_LOG_ERROR,
+						  "%s is running after asr_close destroyed the handle state\n", fn);
+		switch_core_set_variable("mod_test_asr_use_after_close", "true");
+	}
+}
+
 static switch_status_t test_asr_check_results(switch_asr_handle_t *ah, switch_asr_flag_t *flags)
 {
 	test_asr_t *context = (test_asr_t *) ah->private_info;
+
+	test_asr_report_use_after_close(context, "asr_check_results");
 
 	if (switch_test_flag(context, ASRFLAG_RETURNED_RESULT) || switch_test_flag(ah, SWITCH_ASR_FLAG_CLOSED)) {
 		return SWITCH_STATUS_BREAK;
@@ -264,6 +282,15 @@ static switch_status_t test_asr_get_results(switch_asr_handle_t *ah, char **resu
 {
 	test_asr_t *context = (test_asr_t *) ah->private_info;
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
+
+	/* Only the core speech thread calls this, never the media bug callback, so
+	 * the delay parks that one thread inside the module and nothing else. */
+	if (context->get_results_delay_ms > 0) {
+		switch_core_set_variable("mod_test_asr_in_get_results", "true");
+		switch_yield(context->get_results_delay_ms * 1000);
+	}
+
+	test_asr_report_use_after_close(context, "asr_get_results");
 
 	if (switch_test_flag(context, ASRFLAG_RETURNED_RESULT) || switch_test_flag(ah, SWITCH_ASR_FLAG_CLOSED)) {
 		return SWITCH_STATUS_FALSE;
@@ -371,6 +398,9 @@ static void test_asr_text_param(switch_asr_handle_t *ah, char *param, const char
 		} else if (!strcasecmp("partial", param) && switch_true(val)) {
 			context->partial = 3;
 			switch_log_printf(SWITCH_CHANNEL_UUID_LOG(context->channel_uuid), SWITCH_LOG_DEBUG, "partial = %d\n", context->partial);
+		} else if (!strcasecmp("get-results-delay-ms", param) && switch_is_number(val)) {
+			context->get_results_delay_ms = nval;
+			switch_log_printf(SWITCH_CHANNEL_UUID_LOG(context->channel_uuid), SWITCH_LOG_DEBUG, "get-results-delay-ms = %d\n", context->get_results_delay_ms);
 		}
 	}
 }

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -6201,12 +6201,17 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_detect_speech_init(switch_core_sessio
 		return status;
 	}
 
+	/* Published before the hook is added, not after: switch_ivr_stop_detect_speech()
+	 * only tears the media bug down when it finds this key, and takes a try_cancel-only
+	 * path when it finds just the "_tmp" one.  Called below with the key unset, it would
+	 * leave the bug attached and the handle open. */
+	switch_channel_set_private(channel, SWITCH_SPEECH_KEY, sth);
+
 	if ((status = switch_core_event_hook_add_recv_dtmf(session, speech_on_dtmf)) != SWITCH_STATUS_SUCCESS) {
 		switch_ivr_stop_detect_speech(session);
 		return status;
 	}
 
-	switch_channel_set_private(channel, SWITCH_SPEECH_KEY, sth);
 	switch_channel_set_private(channel, SWITCH_SPEECH_KEY "_tmp", NULL);
 
 	return SWITCH_STATUS_SUCCESS;

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5616,6 +5616,7 @@ struct speech_thread_handle {
 	switch_memory_pool_t *pool;
 	switch_thread_t *thread;
 	int ready;
+	int closing;
 };
 
 static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj)
@@ -5638,13 +5639,13 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 
 	sth->ready = 1;
 
-	while (switch_channel_up_nosig(channel) && !switch_test_flag(sth->ah, SWITCH_ASR_FLAG_CLOSED)) {
+	while (switch_channel_up_nosig(channel) && !sth->closing && !switch_test_flag(sth->ah, SWITCH_ASR_FLAG_CLOSED)) {
 		char *xmlstr = NULL;
 		switch_event_t *headers = NULL;
 
 		switch_thread_cond_wait(sth->cond, sth->mutex);
 
-		if (switch_channel_down_nosig(channel) || switch_test_flag(sth->ah, SWITCH_ASR_FLAG_CLOSED)) {
+		if (switch_channel_down_nosig(channel) || sth->closing || switch_test_flag(sth->ah, SWITCH_ASR_FLAG_CLOSED)) {
 			break;
 		}
 
@@ -5809,7 +5810,8 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 			switch_channel_set_private(channel, SWITCH_SPEECH_KEY "_tmp", NULL);
 			switch_core_event_hook_remove_recv_dtmf(session, speech_on_dtmf);
 			
-			switch_core_asr_close(sth->ah, &flags);
+			sth->closing = 1;
+
 			if (sth->mutex && sth->cond && sth->ready) {
 				if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
 					switch_thread_cond_signal(sth->cond);
@@ -5818,6 +5820,8 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 			}
 
 			switch_thread_join(&st, sth->thread);
+
+			switch_core_asr_close(sth->ah, &flags);
 
 		}
 		break;

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5607,6 +5607,8 @@ done:
 	return status;
 }
 
+#define SPEECH_THREAD_STOP_TIMEOUT_MS 5000
+
 struct speech_thread_handle {
 	switch_core_session_t *session;
 	switch_asr_handle_t *ah;
@@ -5617,6 +5619,7 @@ struct speech_thread_handle {
 	switch_thread_t *thread;
 	int ready;
 	int closing;
+	int stopped;
 };
 
 static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj)
@@ -5774,6 +5777,8 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 		}
 	}
 
+	sth->stopped = 1;
+
 	switch_mutex_unlock(sth->mutex);
 	switch_core_session_rwunlock(sth->session);
 
@@ -5813,15 +5818,41 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 			sth->closing = 1;
 
 			if (sth->mutex && sth->cond && sth->ready) {
-				if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
-					switch_thread_cond_signal(sth->cond);
-					switch_mutex_unlock(sth->mutex);
+				int sanity = SPEECH_THREAD_STOP_TIMEOUT_MS;
+
+				/* Retried rather than signalled once: a single trylock misses
+				 * the window where the thread holds the mutex between its
+				 * predicate test and switch_thread_cond_wait(), and the wakeup
+				 * is then lost for good.
+				 */
+				while (!sth->stopped && sanity-- > 0) {
+					if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
+						switch_thread_cond_signal(sth->cond);
+						switch_mutex_unlock(sth->mutex);
+
+						if (sth->stopped) {
+							break;
+						}
+					}
+					switch_yield(1000);
 				}
 			}
 
-			switch_thread_join(&st, sth->thread);
-
-			switch_core_asr_close(sth->ah, &flags);
+			if (sth->ready && !sth->stopped) {
+				/* Wedged inside a module callback that only asr_close can
+				 * unblock, which a module doing network I/O in check_results
+				 * can be. Close first so it returns, giving up the window this
+				 * ordering exists to shut: liveness wins over the narrower race.
+				 */
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+								  "Speech thread still in the ASR module after %d ms, closing handle first\n",
+								  SPEECH_THREAD_STOP_TIMEOUT_MS);
+				switch_core_asr_close(sth->ah, &flags);
+				switch_thread_join(&st, sth->thread);
+			} else {
+				switch_thread_join(&st, sth->thread);
+				switch_core_asr_close(sth->ah, &flags);
+			}
 
 		}
 		break;

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5625,6 +5625,34 @@ struct speech_thread_handle {
 	int stopped;
 };
 
+/* Wake speech_thread and wait until it can no longer be inside the ASR module.
+ *
+ * Taking the mutex at all is what makes it stop: the holder is either parked in
+ * switch_thread_cond_wait() and takes the signal, or has not locked yet, and
+ * then its own lock orders it after the closing store -- which a bare read of a
+ * predicate written from this thread does not guarantee. So the retry is only
+ * for the case where the mutex cannot be taken, which is a thread wedged inside
+ * a module callback.
+ *
+ * sth->stopped is only a hint: it is written without the mutex, so it has no
+ * release/acquire pairing and may be seen late. Nothing depends on it -- the
+ * join is what actually guarantees the thread is gone -- and a missed read
+ * costs at most one more pass.
+ */
+static int speech_thread_wait_stop(struct speech_thread_handle *sth, switch_time_t expires)
+{
+	while (!sth->stopped && switch_micro_time_now() < expires) {
+		if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
+			switch_thread_cond_signal(sth->cond);
+			switch_mutex_unlock(sth->mutex);
+			return 1;
+		}
+		switch_yield(1000);
+	}
+
+	return sth->stopped;
+}
+
 static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj)
 {
 	struct speech_thread_handle *sth = (struct speech_thread_handle *) obj;
@@ -5820,7 +5848,7 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 			switch_status_t st;
 			switch_core_session_t *session = switch_core_media_bug_get_session(bug);
 			switch_channel_t *channel = switch_core_session_get_channel(session);
-			int signalled = 0;
+			int quiesced = 1;
 
 			switch_channel_set_private(channel, SWITCH_SPEECH_KEY, NULL);
 			switch_channel_set_private(channel, SWITCH_SPEECH_KEY "_tmp", NULL);
@@ -5829,43 +5857,40 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 			sth->closing = 1;
 
 			if (sth->thread) {
-				int sanity = SPEECH_THREAD_STOP_TIMEOUT_MS;
+				switch_time_t started = switch_micro_time_now();
 
-				/* Holding the mutex once is what makes the thread stop, so the
-				 * retry is only for the case where it cannot be taken. Whoever
-				 * holds it is either parked in switch_thread_cond_wait() and
-				 * takes the signal, or has not locked yet -- and then its own
-				 * lock orders it after the store above, which a bare read of a
-				 * predicate written from this thread does not guarantee. Only a
-				 * thread wedged inside a module callback keeps failing it.
-				 */
-				while (!signalled && !sth->stopped && sanity-- > 0) {
-					if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
-						switch_thread_cond_signal(sth->cond);
-						switch_mutex_unlock(sth->mutex);
-						signalled = 1;
-					} else {
-						switch_yield(1000);
-					}
+				quiesced = speech_thread_wait_stop(sth, started + (SPEECH_THREAD_STOP_TIMEOUT_MS * 1000) / 2);
+
+				if (!quiesced) {
+					/* Ask the module to abandon the request. That is what
+					 * releases a thread blocked inside it, and unlike the close
+					 * below it frees nothing, so the handle stays valid for the
+					 * thread still reading it. A module without asr_try_cancel
+					 * simply does nothing here.
+					 */
+					switch_core_asr_try_cancel(sth->ah);
+					quiesced = speech_thread_wait_stop(sth, started + SPEECH_THREAD_STOP_TIMEOUT_MS * 1000);
 				}
 			}
 
-			if (sth->thread && !signalled && !sth->stopped) {
-				/* Wedged inside a module callback that only asr_close can
-				 * unblock, which a module doing network I/O in check_results
-				 * can be. Close first so it returns, giving up the window this
-				 * ordering exists to shut: liveness wins over the narrower race.
+			if (!quiesced) {
+				/* try_cancel did not release it either. Close first so the
+				 * module returns, giving up the window this ordering exists to
+				 * shut: liveness wins over the narrower race.
 				 */
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
 								  "Speech thread still in the ASR module after %d ms, closing handle first\n",
 								  SPEECH_THREAD_STOP_TIMEOUT_MS);
 				switch_core_asr_close(sth->ah, &flags);
-				switch_thread_join(&st, sth->thread);
-			} else {
-				switch_thread_join(&st, sth->thread);
-				switch_core_asr_close(sth->ah, &flags);
 			}
 
+			if (sth->thread) {
+				switch_thread_join(&st, sth->thread);
+			}
+
+			if (quiesced) {
+				switch_core_asr_close(sth->ah, &flags);
+			}
 		}
 		break;
 	case SWITCH_ABC_TYPE_READ_REPLACE:

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5607,7 +5607,10 @@ done:
 	return status;
 }
 
-#define SPEECH_THREAD_STOP_TIMEOUT_MS 5000
+/* Only ever waits out a module callback already in flight, so this is far past
+ * any healthy case; it is kept short because the hangup path runs CLOSE with
+ * session->bug_rwlock held for write. */
+#define SPEECH_THREAD_STOP_TIMEOUT_MS 2000
 
 struct speech_thread_handle {
 	switch_core_session_t *session;

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5806,7 +5806,16 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 
 			switch_threadattr_create(&thd_attr, sth->pool);
 			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
-			switch_thread_create(&sth->thread, thd_attr, speech_thread, sth, sth->pool);
+
+			if (switch_thread_create(&sth->thread, thd_attr, speech_thread, sth, sth->pool) != SWITCH_STATUS_SUCCESS) {
+				/* Without the thread nothing ever consumes a result: the read
+				 * callbacks keep feeding the module, but sth->ready stays 0 so
+				 * the condition is never signalled. Fail the bug instead, so
+				 * the caller gets an error rather than a silently deaf ASR. */
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(switch_core_media_bug_get_session(bug)), SWITCH_LOG_ERROR,
+								  "Failed to start speech thread\n");
+				return SWITCH_FALSE;
+			}
 		}
 		break;
 	case SWITCH_ABC_TYPE_CLOSE:
@@ -6155,6 +6164,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_detect_speech_init(switch_core_sessio
 
 	if ((status = switch_core_media_bug_add(session, "detect_speech", key,
 											speech_callback, sth, 0, bug_flags, &sth->bug)) != SWITCH_STATUS_SUCCESS) {
+		switch_channel_set_private(channel, SWITCH_SPEECH_KEY "_tmp", NULL);
 		switch_core_asr_close(ah, &flags);
 		return status;
 	}

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5633,9 +5633,6 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 	switch_status_t status;
 	switch_event_t *event;
 
-	switch_thread_cond_create(&sth->cond, sth->pool);
-	switch_mutex_init(&sth->mutex, SWITCH_MUTEX_NESTED, sth->pool);
-
 	if (switch_core_session_read_lock(sth->session) != SWITCH_STATUS_SUCCESS) {
 		sth->ready = 0;
 		sth->stopped = 1;
@@ -5843,7 +5840,7 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 				 * thread wedged inside a module callback keeps failing it.
 				 */
 				while (!signalled && !sth->stopped && sanity-- > 0) {
-					if (sth->mutex && sth->cond && switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
+					if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
 						switch_thread_cond_signal(sth->cond);
 						switch_mutex_unlock(sth->mutex);
 						signalled = 1;
@@ -5880,7 +5877,7 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 					return SWITCH_FALSE;
 				}
 				if (switch_core_asr_check_results(sth->ah, &flags) == SWITCH_STATUS_SUCCESS) {
-					if (sth->mutex && sth->cond && sth->ready) {
+					if (sth->ready) {
 						switch_mutex_lock(sth->mutex);
 						switch_thread_cond_signal(sth->cond);
 						switch_mutex_unlock(sth->mutex);
@@ -5897,7 +5894,7 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 					return SWITCH_FALSE;
 				}
 				if (switch_core_asr_check_results(sth->ah, &flags) == SWITCH_STATUS_SUCCESS) {
-					if (sth->mutex && sth->cond && sth->ready) {
+					if (sth->ready) {
 						switch_mutex_lock(sth->mutex);
 						switch_thread_cond_signal(sth->cond);
 						switch_mutex_unlock(sth->mutex);
@@ -6135,6 +6132,16 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_detect_speech_init(switch_core_sessio
 	sth->pool = switch_core_session_get_pool(session);
 	sth->session = session;
 	sth->ah = ah;
+
+	/* Created here rather than in speech_thread() so they exist before the bug
+	 * is added: every caller can then signal without testing for them.
+	 */
+	if (switch_thread_cond_create(&sth->cond, sth->pool) != SWITCH_STATUS_SUCCESS ||
+		switch_mutex_init(&sth->mutex, SWITCH_MUTEX_NESTED, sth->pool) != SWITCH_STATUS_SUCCESS) {
+		switch_channel_set_private(channel, SWITCH_SPEECH_KEY "_tmp", NULL);
+		switch_core_asr_close(ah, &flags);
+		return SWITCH_STATUS_MEMERR;
+	}
 
 	if ((p = switch_channel_get_variable(channel, "fire_asr_events")) && switch_true(p)) {
 		switch_set_flag(ah, SWITCH_ASR_FLAG_FIRE_EVENTS);

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5638,6 +5638,7 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 
 	if (switch_core_session_read_lock(sth->session) != SWITCH_STATUS_SUCCESS) {
 		sth->ready = 0;
+		sth->stopped = 1;
 		return NULL;
 	}
 
@@ -5813,35 +5814,37 @@ static switch_bool_t speech_callback(switch_media_bug_t *bug, void *user_data, s
 			switch_status_t st;
 			switch_core_session_t *session = switch_core_media_bug_get_session(bug);
 			switch_channel_t *channel = switch_core_session_get_channel(session);
-			
+			int signalled = 0;
+
 			switch_channel_set_private(channel, SWITCH_SPEECH_KEY, NULL);
 			switch_channel_set_private(channel, SWITCH_SPEECH_KEY "_tmp", NULL);
 			switch_core_event_hook_remove_recv_dtmf(session, speech_on_dtmf);
 			
 			sth->closing = 1;
 
-			if (sth->mutex && sth->cond && sth->ready) {
+			if (sth->thread) {
 				int sanity = SPEECH_THREAD_STOP_TIMEOUT_MS;
 
-				/* Retried rather than signalled once: a single trylock misses
-				 * the window where the thread holds the mutex between its
-				 * predicate test and switch_thread_cond_wait(), and the wakeup
-				 * is then lost for good.
+				/* Holding the mutex once is what makes the thread stop, so the
+				 * retry is only for the case where it cannot be taken. Whoever
+				 * holds it is either parked in switch_thread_cond_wait() and
+				 * takes the signal, or has not locked yet -- and then its own
+				 * lock orders it after the store above, which a bare read of a
+				 * predicate written from this thread does not guarantee. Only a
+				 * thread wedged inside a module callback keeps failing it.
 				 */
-				while (!sth->stopped && sanity-- > 0) {
-					if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
+				while (!signalled && !sth->stopped && sanity-- > 0) {
+					if (sth->mutex && sth->cond && switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
 						switch_thread_cond_signal(sth->cond);
 						switch_mutex_unlock(sth->mutex);
-
-						if (sth->stopped) {
-							break;
-						}
+						signalled = 1;
+					} else {
+						switch_yield(1000);
 					}
-					switch_yield(1000);
 				}
 			}
 
-			if (sth->ready && !sth->stopped) {
+			if (sth->thread && !signalled && !sth->stopped) {
 				/* Wedged inside a module callback that only asr_close can
 				 * unblock, which a module doing network I/O in check_results
 				 * can be. Close first so it returns, giving up the window this

--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5622,26 +5622,23 @@ struct speech_thread_handle {
 	switch_thread_t *thread;
 	int ready;
 	int closing;
-	int stopped;
 };
 
 /* Wake speech_thread and wait until it can no longer be inside the ASR module.
  *
- * Taking the mutex at all is what makes it stop: the holder is either parked in
- * switch_thread_cond_wait() and takes the signal, or has not locked yet, and
- * then its own lock orders it after the closing store -- which a bare read of a
- * predicate written from this thread does not guarantee. So the retry is only
- * for the case where the mutex cannot be taken, which is a thread wedged inside
- * a module callback.
- *
- * sth->stopped is only a hint: it is written without the mutex, so it has no
- * release/acquire pairing and may be seen late. Nothing depends on it -- the
- * join is what actually guarantees the thread is gone -- and a missed read
- * costs at most one more pass.
+ * Taking the mutex is the whole test. speech_thread holds it for its entire run
+ * and gives it up only inside switch_thread_cond_wait() and once on the way
+ * out, so a successful trylock means the thread is parked in the cond wait and
+ * takes the signal, has not locked yet -- and then its own lock orders it after
+ * the closing store -- or has already left. Any of those means it is not inside
+ * a module callback. Failing to take it is the wedged case, and that is all the
+ * retry is for. No separate predicate is read here: an unsynchronised flag
+ * would be a data race, and a synchronised one would say nothing the lock does
+ * not already say.
  */
 static int speech_thread_wait_stop(struct speech_thread_handle *sth, switch_time_t expires)
 {
-	while (!sth->stopped && switch_micro_time_now() < expires) {
+	while (switch_micro_time_now() < expires) {
 		if (switch_mutex_trylock(sth->mutex) == SWITCH_STATUS_SUCCESS) {
 			switch_thread_cond_signal(sth->cond);
 			switch_mutex_unlock(sth->mutex);
@@ -5650,7 +5647,7 @@ static int speech_thread_wait_stop(struct speech_thread_handle *sth, switch_time
 		switch_yield(1000);
 	}
 
-	return sth->stopped;
+	return 0;
 }
 
 static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj)
@@ -5663,7 +5660,6 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 
 	if (switch_core_session_read_lock(sth->session) != SWITCH_STATUS_SUCCESS) {
 		sth->ready = 0;
-		sth->stopped = 1;
 		return NULL;
 	}
 
@@ -5805,8 +5801,6 @@ static void *SWITCH_THREAD_FUNC speech_thread(switch_thread_t *thread, void *obj
 			switch_event_destroy(&event);
 		}
 	}
-
-	sth->stopped = 1;
 
 	switch_mutex_unlock(sth->mutex);
 	switch_core_session_rwunlock(sth->session);

--- a/tests/unit/switch_ivr_async.c
+++ b/tests/unit/switch_ivr_async.c
@@ -240,7 +240,7 @@ FST_CORE_BEGIN("./conf_async")
 			// A no-input timeout is enough to make mod_test report a result, so no speech is needed.
 			// The delay then holds the core speech thread inside asr_get_results while the stop runs.
 			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "no-input-timeout", "500") == SWITCH_STATUS_SUCCESS);
-			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "get-results-delay-ms", "1500") == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "get-results-delay-ms", "1000") == SWITCH_STATUS_SUCCESS);
 
 			helper.session = fst_session;
 			switch_threadattr_create(&thd_attr, fst_pool);

--- a/tests/unit/switch_ivr_async.c
+++ b/tests/unit/switch_ivr_async.c
@@ -62,32 +62,16 @@ static switch_status_t partial_play_and_collect_input_callback(switch_core_sessi
 	return status;
 }
 
-struct asr_stop_helper {
-	switch_core_session_t *session;
-	int stopped;
-};
-
-/* Closes the ASR handle from a thread other than the one pumping media, which
- * is what uuid_detect_speech stop does in production. Waits for mod_test to
- * report that the core speech thread is parked inside asr_get_results, so the
- * close lands in the window rather than by luck. */
-static void *SWITCH_THREAD_FUNC asr_stop_thread(switch_thread_t *thread, void *obj)
+/* switch_core_get_variable() hands back the live pointer, which a concurrent
+ * set frees, so every read here takes a copy. */
+static int asr_test_var_true(const char *name)
 {
-	struct asr_stop_helper *helper = (struct asr_stop_helper *) obj;
-	int sanity = 5000;
+	char *val = switch_core_get_variable_dup(name);
+	int result = switch_true(val);
 
-	while (sanity-- > 0 && !switch_true(switch_core_get_variable("mod_test_asr_in_get_results"))) {
-		switch_yield(1000);
-	}
+	switch_safe_free(val);
 
-	if (switch_core_session_read_lock(helper->session) == SWITCH_STATUS_SUCCESS) {
-		if (switch_ivr_stop_detect_speech(helper->session) == SWITCH_STATUS_SUCCESS) {
-			helper->stopped = 1;
-		}
-		switch_core_session_rwunlock(helper->session);
-	}
-
-	return NULL;
+	return result;
 }
 
 FST_CORE_BEGIN("./conf_async")
@@ -226,9 +210,6 @@ FST_CORE_BEGIN("./conf_async")
 
 		FST_SESSION_BEGIN(detect_speech_stop_during_get_results)
 		{
-			switch_threadattr_t *thd_attr = NULL;
-			switch_thread_t *thread = NULL;
-			struct asr_stop_helper helper = { 0 };
 			switch_status_t status;
 
 			switch_core_set_variable("mod_test_asr_in_get_results", NULL);
@@ -238,21 +219,24 @@ FST_CORE_BEGIN("./conf_async")
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
 
 			// A no-input timeout is enough to make mod_test report a result, so no speech is needed.
-			// The delay then holds the core speech thread inside asr_get_results while the stop runs.
-			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "no-input-timeout", "500") == SWITCH_STATUS_SUCCESS);
-			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "get-results-delay-ms", "1000") == SWITCH_STATUS_SUCCESS);
+			// The delay then parks the core speech thread inside asr_get_results for 800ms, well past
+			// the 500ms of audio below, so the close runs while it is still in there.
+			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "no-input-timeout", "200") == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "get-results-delay-ms", "800") == SWITCH_STATUS_SUCCESS);
 
-			helper.session = fst_session;
-			switch_threadattr_create(&thd_attr, fst_pool);
-			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
-			fst_requires(switch_thread_create(&thread, thd_attr, asr_stop_thread, &helper, fst_pool) == SWITCH_STATUS_SUCCESS);
+			// Drives the media bug until the no-input timeout fires, and has to stop before the close:
+			// once mod_test reports a result every read callback blocks on the speech thread's mutex
+			// while holding bug_rwlock, starving switch_core_media_bug_remove() of its write lock.
+			switch_ivr_play_file(fst_session, NULL, "silence_stream://500,0", NULL);
 
-			switch_ivr_play_file(fst_session, NULL, "silence_stream://5000,0", NULL);
+			// Not timing luck: the close below is only the race this test exists for if the speech
+			// thread is inside the module right now.
+			fst_requires(asr_test_var_true("mod_test_asr_in_get_results"));
 
-			switch_thread_join(&status, thread);
+			status = switch_ivr_stop_detect_speech(fst_session);
+			fst_xcheck(status == SWITCH_STATUS_SUCCESS, "Expect switch_ivr_stop_detect_speech() to have closed the media bug");
 
-			fst_xcheck(helper.stopped, "Expect switch_ivr_stop_detect_speech() to have closed the media bug");
-			fst_xcheck(!switch_true(switch_core_get_variable("mod_test_asr_use_after_close")),
+			fst_xcheck(!asr_test_var_true("mod_test_asr_use_after_close"),
 					   "Expect asr_close not to run while the speech thread is still inside the module");
 		}
 		FST_SESSION_END()

--- a/tests/unit/switch_ivr_async.c
+++ b/tests/unit/switch_ivr_async.c
@@ -62,6 +62,34 @@ static switch_status_t partial_play_and_collect_input_callback(switch_core_sessi
 	return status;
 }
 
+struct asr_stop_helper {
+	switch_core_session_t *session;
+	int stopped;
+};
+
+/* Closes the ASR handle from a thread other than the one pumping media, which
+ * is what uuid_detect_speech stop does in production. Waits for mod_test to
+ * report that the core speech thread is parked inside asr_get_results, so the
+ * close lands in the window rather than by luck. */
+static void *SWITCH_THREAD_FUNC asr_stop_thread(switch_thread_t *thread, void *obj)
+{
+	struct asr_stop_helper *helper = (struct asr_stop_helper *) obj;
+	int sanity = 5000;
+
+	while (sanity-- > 0 && !switch_true(switch_core_get_variable("mod_test_asr_in_get_results"))) {
+		switch_yield(1000);
+	}
+
+	if (switch_core_session_read_lock(helper->session) == SWITCH_STATUS_SUCCESS) {
+		if (switch_ivr_stop_detect_speech(helper->session) == SWITCH_STATUS_SUCCESS) {
+			helper->stopped = 1;
+		}
+		switch_core_session_rwunlock(helper->session);
+	}
+
+	return NULL;
+}
+
 FST_CORE_BEGIN("./conf_async")
 {
 	FST_SUITE_BEGIN(switch_ivr_play_async)
@@ -193,6 +221,39 @@ FST_CORE_BEGIN("./conf_async")
 			fst_xcheck(switch_channel_var_true(fst_channel, "record_post_process_test_pass"), "Expect record_post_process_test_pass channel variable set to true");
 
 			unlink(record_filename);
+		}
+		FST_SESSION_END()
+
+		FST_SESSION_BEGIN(detect_speech_stop_during_get_results)
+		{
+			switch_threadattr_t *thd_attr = NULL;
+			switch_thread_t *thread = NULL;
+			struct asr_stop_helper helper = { 0 };
+			switch_status_t status;
+
+			switch_core_set_variable("mod_test_asr_in_get_results", NULL);
+			switch_core_set_variable("mod_test_asr_use_after_close", NULL);
+
+			status = switch_ivr_detect_speech(fst_session, "test", "test", "test", "", NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			// A no-input timeout is enough to make mod_test report a result, so no speech is needed.
+			// The delay then holds the core speech thread inside asr_get_results while the stop runs.
+			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "no-input-timeout", "500") == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_ivr_set_param_detect_speech(fst_session, "get-results-delay-ms", "1500") == SWITCH_STATUS_SUCCESS);
+
+			helper.session = fst_session;
+			switch_threadattr_create(&thd_attr, fst_pool);
+			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+			fst_requires(switch_thread_create(&thread, thd_attr, asr_stop_thread, &helper, fst_pool) == SWITCH_STATUS_SUCCESS);
+
+			switch_ivr_play_file(fst_session, NULL, "silence_stream://5000,0", NULL);
+
+			switch_thread_join(&status, thread);
+
+			fst_xcheck(helper.stopped, "Expect switch_ivr_stop_detect_speech() to have closed the media bug");
+			fst_xcheck(!switch_true(switch_core_get_variable("mod_test_asr_use_after_close")),
+					   "Expect asr_close not to run while the speech thread is still inside the module");
 		}
 		FST_SESSION_END()
 	}


### PR DESCRIPTION
## Problem

`speech_callback()`'s `SWITCH_ABC_TYPE_CLOSE` branch tore the ASR handle down in the wrong order: it called `switch_core_asr_close()` — which runs the module's `asr_close` and frees its private state — **before** it signalled the condition and joined `speech_thread`.

The stop condition `speech_thread` tests, `SWITCH_ASR_FLAG_CLOSED`, is set one line *after* `asr_close` in `switch_core_asr.c:246-247`, so a thread already past its check is inside a module callback on freed memory.

`CLOSE` does not always run on the session thread: `uuid_detect_speech stop` reaches it from an API thread via `switch_ivr_stop_detect_speech()` → `switch_core_media_bug_remove()`, concurrent with the read thread feeding audio. Because `speech_thread` holds `sth->mutex` for the whole loop body, the `trylock` fails, the signal is skipped, and the join is what waits — after the free.

## Impact per ASR module

| module | `asr_close` frees | exposed |
|---|---|---|
| `mod_lumenvox` | `delete a` — immediate heap free | yes, genuine UAF (also locks a destroyed `std::mutex`) |
| `mod_pocketsphinx` | `ps_free(ps->ps)`, `ps->ps = NULL`, `switch_safe_free(ps->grammar)` | yes — `asr_get_results` then reads `ps->grammar`/`ps->hyp` and can call `ps_start_utt(NULL)` |
| `mod_unimrcp` | `schannel->data = NULL`, `speech_channel_destroy` | survives only because `recog_channel_check_results` carries an explicit `"recognizer data is NULL"` branch for exactly this |
| `mod_test` | destroys its VAD | latent |

Latent for years because pool-allocating modules leave the stale read on memory that is still mapped.

## Not fixable by setting `SWITCH_ASR_FLAG_CLOSED` earlier

That was the obvious fix and it is wrong. The flag is a **post-condition of close**, and modules gate on that reading:

* `mod_unimrcp.c:3799` — `if (!switch_test_flag(ah, SWITCH_ASR_FLAG_CLOSED)) { destroy = SWITCH_TRUE; ... }`. Pre-setting it leaves `destroy` FALSE, skipping `speech_channel_stop()`, the grammar hash destroy and `speech_channel_destroy()` — an MRCP session leaked per call, in the module carrying production traffic today.
* `mod_test.c` logs `"Double ASR close!"` and returns FALSE; `mod_pocketsphinx` `asr_feed` returns BREAK once set.

Swapping `switch_core_asr.c:246/247` has the same breakage and does not work anyway: a thread already past its check is *inside* the call, so the window is narrowed, not closed. Only the join closes it.

## Fix

`struct speech_thread_handle` gains a file-local `closing` predicate — no public ABI change, no module change — tested alongside the flag in both loop conditions. The close branch reorders to:

```
closing = 1  ->  signal  ->  switch_thread_join  ->  switch_core_asr_close
```

`SWITCH_ASR_FLAG_CLOSED` keeps being set exactly where it is today.

Nothing dangles from moving the close after the join: `ah` and `sth` are both `switch_core_session_alloc`'d, so the session pool owns them and only `ah->private_info` is freed. The tail after `done:` still dereferences `sth->ah` for `FIRE_EVENTS`/`QUEUE_EVENTS`; today that runs after `private_info` is freed and is safe only by accident, and the reorder makes it safe by construction. `UNPROTECT_INTERFACE()` also now runs after the thread is out, instead of potentially dropping the module refcount while the thread is still calling into it.

## Liveness guard (commits 2 and 4, separable)

Moving the close behind the join makes the join load-bearing, so a module that can block inside an `asr_` callback on something only `asr_close` unblocks would wedge the close path. `mod_lumenvox` is such a module: `recog_check_results` runs the no-input and tone-detect deadlines, which reach `lv_asr_cancel_interaction` and a synchronous gRPC `Write` that only `ctx->TryCancel()` in `recog_close` releases. `mod_unimrcp`, `mod_pocketsphinx` and `mod_test` are all bounded and unaffected.

So the thread publishes a `stopped` flag and CLOSE waits for it, bounded at 2s; if the thread has not left the module by then, it warns and falls back to closing before the join — today's behaviour — so liveness is never worse than before. The bound is kept short because the hangup route, `switch_core_media_bug_remove_all_function()`, runs CLOSE with `session->bug_rwlock` held for write.

The wait also **retries** the signal rather than sending it once. A single `trylock` misses the window where the thread holds the mutex between its predicate test and `switch_thread_cond_wait()`; that wakeup is lost and the join then waits forever. Pre-existing and identical before and after the reorder, but the reorder is what makes it matter.

## Behaviour change to be aware of

The `detected-speech` / `Speech-Type: closed` event now fires *before* `asr_close` rather than after. For `mod_unimrcp` that means it can arrive seconds earlier when the MRCP server is slow to answer STOP, since `speech_channel_stop` and `speech_channel_destroy` each `cond_timedwait` up to `SPEECH_CHANNEL_TIMEOUT_USEC` (5s).

## Test

`detect_speech_stop_during_get_results` in `tests/unit/switch_ivr_async.c`. It starts `detect_speech` on `mod_test`, uses a 500ms no-input timeout so the module reports a result without needing speech, holds the core speech thread inside `asr_get_results`, and runs `switch_ivr_stop_detect_speech()` from a second thread — the `uuid_detect_speech stop` path, reaching CLOSE from a thread that is not pumping media.

Two `mod_test` knobs make it deterministic, both inert by default: a `get-results-delay-ms` text_param (only the core speech thread calls `asr_get_results`, never the media bug callback, so the delay cannot stall the audio path), and a `closed` flag reported through the `mod_test_asr_use_after_close` global — the same module-to-test signalling `mod_test` already uses for `mod_test_tts_must_have_channel_uuid`.

**Verified non-vacuous.** Against the unfixed core:

```
18:02:53.709  [NOTICE] mod_test.c:163 ASR closing ...
18:02:55.209  [ERR]    mod_test.c:242 asr_get_results is running after asr_close destroyed the handle state
TEST FAIL: Expect asr_close not to run while the speech thread is still inside the module
FAILED (3/4 tests)
```

With the fix, close waits and the ordering inverts:

```
18:09:51.731  [DEBUG]  mod_test.c:312 Result: NO INPUT
18:09:51.731  [NOTICE] mod_test.c:163 ASR closing ...
PASSED (4/4 tests)
```

Regression suites: `tests/unit/switch_core_asr` 1/1, `mod_test/test/test_asr` 8/8. Core and both test binaries compile clean with no new warnings.

## Context

Raised by @baloeng as a merge gate on [mod_lumenvox#3](https://github.com/team-telnyx/mod_lumenvox/pull/3) (TELCORE-304). Nothing in that PR can fix it — this is core code. Kept out of #632, which was test-only and has since merged.

Worth noting for sequencing: `mod_lumenvox` is in `telnyx.modules.conf`, so merging #3 ships it, but shipping is not invoking. The dialplan still routes CPA through `unimrcp:lumenvox`, so the use-after-free becomes reachable at the **dialplan cutover**, not at the merge.

Linear: [TELCORE-429](https://linear.app/telnyx/issue/TELCORE-429/)
