### PR TITLE
TELCORE-386: preserve in-flight DTLS on late trickle

### DIFF
--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -105,6 +105,7 @@ typedef struct {
 	switch_bool_t rtp_chosen;
 	switch_bool_t rtcp_chosen;
 	dtls_state_t dtls_state;
+	const void *dtls_context;
 	const void *dtls_ssl;
 	const void *socket;
 } switch_rtp_pvt_transport_snapshot_t;

--- a/src/include/private/switch_rtp_pvt.h
+++ b/src/include/private/switch_rtp_pvt.h
@@ -98,12 +98,28 @@ typedef struct {
 	switch_sockaddr_t *selected_addr;
 } switch_rtp_pvt_ice_tuple_t;
 
+typedef struct {
+	switch_core_media_ice_type_t ice_type;
+	switch_bool_t ice_ready;
+	switch_bool_t ice_rready;
+	switch_bool_t rtp_chosen;
+	switch_bool_t rtcp_chosen;
+	dtls_state_t dtls_state;
+	const void *dtls_ssl;
+	const void *socket;
+} switch_rtp_pvt_transport_snapshot_t;
+
 SWITCH_DECLARE(void) switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice, void *data, switch_size_t len);
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_handle_ice_from(switch_rtp_t *rtp_session, ice_proto_t proto,
+	const char *host, switch_port_t port, void *data, switch_size_t len);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_session, ice_proto_t proto,
 	char *ice_user, switch_size_t ice_user_len, char *local_pwd, switch_size_t local_pwd_len,
 	char *remote_pwd, switch_size_t remote_pwd_len, switch_bool_t *has_addr);
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_transport_snapshot(switch_rtp_t *rtp_session,
+	ice_proto_t proto, switch_rtp_pvt_transport_snapshot_t *snapshot);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(switch_sockaddr_t *current_addr,
 	switch_sockaddr_t *handshake_peer_addr, dtls_state_t dtls_state, switch_bool_t handshake_peer_set, switch_bool_t is_rtcp);
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_selection_complete(const ice_t *ice, switch_bool_t rtcp_muxed);
 SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_trickle_dtls(switch_bool_t new_ice,
 	switch_bool_t rtp_ready, const switch_rtp_pvt_ice_tuple_t *rtp_tuple,
 	switch_bool_t rtcp_muxed, const char *active_remote_ufrag, const char *active_remote_pwd,

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5369,7 +5369,8 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 		//return SWITCH_STATUS_SUCCESS;
 	//}
 
-	if (trickle_on && engine->ice_in.is_chosen[0] && engine->ice_in.is_chosen[1] &&
+	if (trickle_on && switch_rtp_pvt_ice_selection_complete(&engine->ice_in,
+		engine->rtcp_mux > 0 ? SWITCH_TRUE : SWITCH_FALSE) &&
 		!switch_channel_test_flag(smh->session->channel, CF_REINVITE)) {
 		/* Accumulate candidates; skip shortcut on reinvite (stale chosen pair). */
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(smh->session), SWITCH_LOG_DEBUG,
@@ -5669,7 +5670,8 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 	}
 
 	/* Candidates already chosen; skip re-selection. USE-CANDIDATE handles switching. */
-	if (trickle_on && engine->ice_in.is_chosen[0] && engine->ice_in.is_chosen[1]) {
+	if (trickle_on && switch_rtp_pvt_ice_selection_complete(&engine->ice_in,
+		engine->rtcp_mux > 0 ? SWITCH_TRUE : SWITCH_FALSE)) {
 		return SWITCH_STATUS_SUCCESS;
 	}
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -835,6 +835,15 @@ SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_should_preserve_active_dtls_tuple(s
 	return switch_cmp_addr(current_addr, handshake_peer_addr, SWITCH_FALSE) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
+SWITCH_DECLARE(switch_bool_t) switch_rtp_pvt_ice_selection_complete(const ice_t *ice, switch_bool_t rtcp_muxed)
+{
+	if (!ice || !ice->is_chosen[IPR_RTP]) {
+		return SWITCH_FALSE;
+	}
+
+	return (rtcp_muxed || ice->is_chosen[IPR_RTCP]) ? SWITCH_TRUE : SWITCH_FALSE;
+}
+
 static switch_bool_t ice_selected_tuple_unchanged(const switch_rtp_pvt_ice_tuple_t *tuple)
 {
 	if (!tuple || !tuple->selected || !tuple->ready || zstr(tuple->transport) ||
@@ -2019,6 +2028,39 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_ice_state(switch_rtp_t *rtp_s
 	switch_snprintf(local_pwd, local_pwd_len, "%s", ice->pass ? ice->pass : "");
 	switch_snprintf(remote_pwd, remote_pwd_len, "%s", ice->rpass ? ice->rpass : "");
 	*has_addr = ice->addr ? SWITCH_TRUE : SWITCH_FALSE;
+	switch_mutex_unlock(rtp_session->ice_mutex);
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_transport_snapshot(switch_rtp_t *rtp_session,
+	ice_proto_t proto, switch_rtp_pvt_transport_snapshot_t *snapshot)
+{
+	switch_rtp_ice_t *ice;
+	switch_dtls_t *dtls;
+
+	if (!rtp_session || (proto != IPR_RTP && proto != IPR_RTCP) || !snapshot) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	memset(snapshot, 0, sizeof(*snapshot));
+	switch_mutex_lock(rtp_session->ice_mutex);
+	ice = proto == IPR_RTP ? &rtp_session->ice : &rtp_session->rtcp_ice;
+	snapshot->ice_type = ice->type;
+	snapshot->ice_ready = ice->ready ? SWITCH_TRUE : SWITCH_FALSE;
+	snapshot->ice_rready = ice->rready ? SWITCH_TRUE : SWITCH_FALSE;
+	if (ice->ice_params) {
+		snapshot->rtp_chosen = ice->ice_params->is_chosen[IPR_RTP] ? SWITCH_TRUE : SWITCH_FALSE;
+		snapshot->rtcp_chosen = ice->ice_params->is_chosen[IPR_RTCP] ? SWITCH_TRUE : SWITCH_FALSE;
+	}
+
+	dtls = proto == IPR_RTP ? rtp_session->dtls : rtp_session->rtcp_dtls;
+	if (dtls) {
+		snapshot->dtls_state = dtls->state;
+		snapshot->dtls_ssl = dtls->ssl;
+	}
+	snapshot->socket = proto == IPR_RTP ?
+		(const void *)rtp_session->sock_input : (const void *)rtp_session->rtcp_sock_input;
 	switch_mutex_unlock(rtp_session->ice_mutex);
 
 	return SWITCH_STATUS_SUCCESS;
@@ -3489,6 +3531,39 @@ void switch_rtp_pvt_handle_ice(switch_rtp_t *rtp_session, switch_rtp_ice_t *ice,
 	switch_mutex_unlock(rtp_session->ice_mutex);
 	WRITE_DEC(rtp_session);
 	READ_DEC(rtp_session);
+}
+
+SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_handle_ice_from(switch_rtp_t *rtp_session, ice_proto_t proto,
+	const char *host, switch_port_t port, void *data, switch_size_t len)
+{
+	switch_rtp_ice_t *ice;
+	switch_sockaddr_t *from_addr = NULL;
+	switch_sockaddr_t *saved_addr;
+	switch_sockaddr_t **active_addr;
+
+	if (!rtp_session || (proto != IPR_RTP && proto != IPR_RTCP) || zstr(host) || !port || !data || !len) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	if (switch_sockaddr_info_get(&from_addr, host, SWITCH_UNSPEC, port, 0, rtp_session->pool) != SWITCH_STATUS_SUCCESS ||
+		!from_addr) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	if (proto == IPR_RTP) {
+		ice = &rtp_session->ice;
+		active_addr = &rtp_session->from_addr;
+	} else {
+		ice = &rtp_session->rtcp_ice;
+		active_addr = &rtp_session->rtcp_from_addr;
+	}
+
+	saved_addr = *active_addr;
+	*active_addr = from_addr;
+	switch_rtp_pvt_handle_ice(rtp_session, ice, data, len);
+	*active_addr = saved_addr;
+
+	return SWITCH_STATUS_SUCCESS;
 }
 
 #ifdef ENABLE_SRTP

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -2057,6 +2057,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_pvt_get_transport_snapshot(switch_rtp
 	dtls = proto == IPR_RTP ? rtp_session->dtls : rtp_session->rtcp_dtls;
 	if (dtls) {
 		snapshot->dtls_state = dtls->state;
+		snapshot->dtls_context = dtls;
 		snapshot->dtls_ssl = dtls->ssl;
 	}
 	snapshot->socket = proto == IPR_RTP ?

--- a/tests/unit/switch_stun.c
+++ b/tests/unit/switch_stun.c
@@ -473,6 +473,24 @@ FST_TEARDOWN_END()
 		switch_core_destroy_memory_pool(&pool);
 	}
 	FST_TEST_END()
+	FST_TEST_BEGIN(test_rtcp_mux_prflx_selection_blocks_late_candidate_reselection)
+	{
+		ice_t ice = { 0 };
+
+		fst_check(!switch_rtp_pvt_ice_selection_complete(NULL, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_ice_selection_complete(&ice, SWITCH_TRUE));
+
+		/* Production ordering: authenticated peer-reflexive nomination selects
+		 * RTP before the late advertised host/srflx candidate is processed.
+		 * RTCP-mux makes that one selected component a complete ICE transport. */
+		ice.is_chosen[IPR_RTP] = 1;
+		fst_check(switch_rtp_pvt_ice_selection_complete(&ice, SWITCH_TRUE));
+		fst_check(!switch_rtp_pvt_ice_selection_complete(&ice, SWITCH_FALSE));
+
+		ice.is_chosen[IPR_RTCP] = 1;
+		fst_check(switch_rtp_pvt_ice_selection_complete(&ice, SWITCH_FALSE));
+	}
+	FST_TEST_END()
 	FST_TEST_BEGIN(test_same_generation_late_trickle_preserves_dtls_handshake)
 	{
 		switch_memory_pool_t *pool = NULL;

--- a/tests/unit/switch_trickle_ice.c
+++ b/tests/unit/switch_trickle_ice.c
@@ -1,5 +1,6 @@
 #include <switch.h>
 #include <switch_rtp.h>
+#include <switch_stun.h>
 #include <test/switch_test.h>
 #include <private/switch_rtp_pvt.h>
 #include "switch_telnyx.h"
@@ -10,6 +11,69 @@
 extern char *fst_getenv_default(const char *, char *, switch_bool_t);
 static void _silence_unused(void) { (void)fst_getenv_default; }
 static const char *rx_host = "127.0.0.1";
+
+static switch_size_t build_authenticated_ice_request(uint8_t *buf, switch_size_t buflen,
+	const char *username, const char *password)
+{
+	static const char tie_breaker[8] = { 0x01, 0x23, 0x45, 0x67, 0x11, 0x22, 0x33, 0x44 };
+	switch_stun_packet_t *packet;
+	switch_size_t bytes;
+
+	switch_assert(buf);
+	switch_assert(buflen >= 128);
+	switch_assert(username);
+	switch_assert(password);
+	memset(buf, 0, buflen);
+	packet = switch_stun_packet_build_header(SWITCH_STUN_BINDING_REQUEST, NULL, buf);
+	switch_stun_packet_attribute_add_priority(packet, 0x6e0001ff);
+	switch_stun_packet_attribute_add_username(packet, (char *)username, (uint16_t)strlen(username));
+	switch_stun_packet_attribute_add_use_candidate(packet);
+	switch_stun_packet_attribute_add_controlling_value(packet, tie_breaker);
+	switch_stun_packet_attribute_add_integrity(packet, password);
+	switch_stun_packet_attribute_add_fingerprint(packet);
+	bytes = switch_stun_packet_length(packet);
+	switch_assert(bytes <= buflen);
+
+	return bytes;
+}
+
+static switch_status_t reverse_ice_username(const char *ice_user, char *incoming, switch_size_t incoming_len)
+{
+	const char *colon;
+	switch_size_t left_len;
+	switch_size_t right_len;
+
+	if (zstr(ice_user) || !incoming || !incoming_len || !(colon = strchr(ice_user, ':'))) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	left_len = (switch_size_t)(colon - ice_user);
+	right_len = strlen(colon + 1);
+	if (!left_len || !right_len || left_len + right_len + 2 > incoming_len) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	memcpy(incoming, colon + 1, right_len);
+	incoming[right_len] = ':';
+	memcpy(incoming + right_len + 1, ice_user, left_len);
+	incoming[right_len + left_len + 1] = '\0';
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t copy_sockaddr_tuple(switch_sockaddr_t *addr, char *host, switch_size_t host_len,
+	switch_port_t *port)
+{
+	if (!addr || !host || !host_len || !port) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	if (!switch_get_addr(host, host_len, addr)) {
+		return SWITCH_STATUS_FALSE;
+	}
+	*port = switch_sockaddr_get_port(addr);
+	return SWITCH_STATUS_SUCCESS;
+}
 
 static switch_status_t copy_sdp_attribute(const char *sdp, const char *attribute, char *value, switch_size_t value_len)
 {
@@ -506,6 +570,113 @@ FCT_BGN()
 			fst_check_string_equals(answer_local_ufrag, initial_local_ufrag);
 			fst_check_string_equals(answer_local_pwd, initial_local_pwd);
 			fst_check(has_addr == SWITCH_TRUE);
+
+			cleanup_session_media_and_sdp(session, sdp_session, parser);
+		}
+		FCT_TEST_END();
+
+		FCT_TEST_BGN(rtcp_mux_prflx_late_srflx_preserves_inflight_dtls)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_media_handle_t *smh = NULL;
+			switch_rtp_t *rtp = NULL;
+			void *sdp_session = NULL;
+			sdp_parser_t *parser = NULL;
+			switch_status_t status;
+			switch_rtp_pvt_transport_snapshot_t before;
+			switch_rtp_pvt_transport_snapshot_t nominated;
+			switch_rtp_pvt_transport_snapshot_t after;
+			char ice_user[256] = "";
+			char incoming_user[256] = "";
+			char local_pwd[256] = "";
+			char remote_pwd[256] = "";
+			char nominated_host[80] = "";
+			char after_host[80] = "";
+			char *chosen_addr = NULL;
+			switch_port_t chosen_port = 0;
+			switch_port_t nominated_port = 0;
+			switch_port_t after_port = 0;
+			switch_bool_t has_addr = SWITCH_FALSE;
+			uint8_t stun_packet[512];
+			switch_size_t stun_len;
+
+			status = make_session_and_rtp_with_sdp_ex(&session, &rtp, &sdp_session, &parser,
+				NULL, "PCMU", SWITCH_TRUE, SWITCH_FALSE);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && session && !rtp && sdp_session && parser);
+			channel = switch_core_session_get_channel(session);
+			smh = switch_core_session_get_media_handle(session);
+			fst_requires(channel != NULL && smh != NULL);
+
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap", "true");
+			switch_channel_set_variable(channel, "rtp_ice_prflx_bootstrap_ms", "5000");
+			switch_channel_set_variable(channel, "rtp_ice_role", "controlled");
+			status = switch_core_media_activate_rtp(session);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			rtp = switch_core_media_get_rtp_session(session, SWITCH_MEDIA_TYPE_AUDIO);
+			fst_requires(rtp != NULL);
+
+			status = switch_rtp_pvt_get_ice_state(rtp, IPR_RTP,
+				ice_user, sizeof(ice_user), local_pwd, sizeof(local_pwd),
+				remote_pwd, sizeof(remote_pwd), &has_addr);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && has_addr == SWITCH_FALSE);
+			fst_requires(reverse_ice_username(ice_user, incoming_user,
+				sizeof(incoming_user)) == SWITCH_STATUS_SUCCESS);
+			status = switch_rtp_pvt_get_transport_snapshot(rtp, IPR_RTP, &before);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires((before.ice_type & ICE_CONTROLLED) != 0);
+			fst_requires(before.dtls_state == DS_HANDSHAKE);
+			fst_requires(before.dtls_ssl != NULL && before.socket != NULL);
+			fst_check(before.rtp_chosen == SWITCH_FALSE);
+			fst_check(before.rtcp_chosen == SWITCH_FALSE);
+
+			stun_len = build_authenticated_ice_request(stun_packet, sizeof(stun_packet),
+				incoming_user, local_pwd);
+			status = switch_rtp_pvt_handle_ice_from(rtp, IPR_RTP, "192.0.2.10", 54302,
+				stun_packet, stun_len);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			status = switch_rtp_pvt_get_transport_snapshot(rtp, IPR_RTP, &nominated);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(nominated.ice_ready == SWITCH_TRUE && nominated.ice_rready == SWITCH_TRUE);
+			fst_requires(nominated.rtp_chosen == SWITCH_TRUE);
+			fst_check(nominated.rtcp_chosen == SWITCH_FALSE);
+			fst_check(nominated.dtls_state == DS_HANDSHAKE);
+			fst_check(nominated.dtls_ssl == before.dtls_ssl);
+			fst_check(nominated.socket == before.socket);
+			status = switch_core_media_get_chosen_ice_candidate(session, SWITCH_MEDIA_TYPE_AUDIO,
+				&chosen_addr, &chosen_port);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && chosen_addr != NULL);
+			fst_check_string_equals(chosen_addr, "192.0.2.10");
+			fst_check(chosen_port == 54302);
+			status = copy_sockaddr_tuple(switch_rtp_session_get_remote_addr(rtp), nominated_host,
+				sizeof(nominated_host), &nominated_port);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_check_string_equals(nominated_host, "192.0.2.10");
+			fst_check(nominated_port == 54302);
+
+			status = switch_core_media_trickle_remote_candidate_and_recheck(
+				session, smh, sdp_session, SDP_TYPE_REQUEST, "0", 0,
+				"candidate:265031753 1 udp 1685921533 198.51.100.20 54302 typ srflx raddr 192.0.2.10 rport 54302", 0);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			status = switch_rtp_pvt_get_transport_snapshot(rtp, IPR_RTP, &after);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_check(after.ice_ready == nominated.ice_ready);
+			fst_check(after.ice_rready == nominated.ice_rready);
+			fst_check(after.rtp_chosen == nominated.rtp_chosen);
+			fst_check(after.rtcp_chosen == nominated.rtcp_chosen);
+			fst_check(after.dtls_state == DS_HANDSHAKE);
+			fst_check(after.dtls_ssl == before.dtls_ssl);
+			fst_check(after.socket == before.socket);
+			status = switch_core_media_get_chosen_ice_candidate(session, SWITCH_MEDIA_TYPE_AUDIO,
+				&chosen_addr, &chosen_port);
+			fst_requires(status == SWITCH_STATUS_SUCCESS && chosen_addr != NULL);
+			fst_check_string_equals(chosen_addr, "192.0.2.10");
+			fst_check(chosen_port == 54302);
+			status = copy_sockaddr_tuple(switch_rtp_session_get_remote_addr(rtp), after_host,
+				sizeof(after_host), &after_port);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_check_string_equals(after_host, nominated_host);
+			fst_check(after_port == nominated_port);
 
 			cleanup_session_media_and_sdp(session, sdp_session, parser);
 		}

--- a/tests/unit/switch_trickle_ice.c
+++ b/tests/unit/switch_trickle_ice.c
@@ -626,7 +626,8 @@ FCT_BGN()
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
 			fst_requires((before.ice_type & ICE_CONTROLLED) != 0);
 			fst_requires(before.dtls_state == DS_HANDSHAKE);
-			fst_requires(before.dtls_ssl != NULL && before.socket != NULL);
+			fst_requires(before.dtls_context != NULL && before.dtls_ssl != NULL &&
+				before.socket != NULL);
 			fst_check(before.rtp_chosen == SWITCH_FALSE);
 			fst_check(before.rtcp_chosen == SWITCH_FALSE);
 
@@ -641,6 +642,7 @@ FCT_BGN()
 			fst_requires(nominated.rtp_chosen == SWITCH_TRUE);
 			fst_check(nominated.rtcp_chosen == SWITCH_FALSE);
 			fst_check(nominated.dtls_state == DS_HANDSHAKE);
+			fst_check(nominated.dtls_context == before.dtls_context);
 			fst_check(nominated.dtls_ssl == before.dtls_ssl);
 			fst_check(nominated.socket == before.socket);
 			status = switch_core_media_get_chosen_ice_candidate(session, SWITCH_MEDIA_TYPE_AUDIO,
@@ -665,6 +667,7 @@ FCT_BGN()
 			fst_check(after.rtp_chosen == nominated.rtp_chosen);
 			fst_check(after.rtcp_chosen == nominated.rtcp_chosen);
 			fst_check(after.dtls_state == DS_HANDSHAKE);
+			fst_check(after.dtls_context == before.dtls_context);
 			fst_check(after.dtls_ssl == before.dtls_ssl);
 			fst_check(after.socket == before.socket);
 			status = switch_core_media_get_chosen_ice_candidate(session, SWITCH_MEDIA_TYPE_AUDIO,


### PR DESCRIPTION
## Summary

Preserve the nominated ICE path and in-flight DTLS association when a late host or server-reflexive candidate arrives after peer-reflexive nomination under RTCP mux.

## Root cause

The trickle ICE recheck required both RTP and RTCP selected flags even when RTCP was muxed onto RTP. It therefore treated the valid RTP selection as incomplete, cleared the nominated tuple, selected the late advertised candidate, and recreated DTLS during the handshake.

## Fix

Treat the RTP selection as complete when RTCP mux is active while retaining the existing two-component requirement for non-mux sessions. Add focused regression coverage for authenticated peer-reflexive nomination followed by a late trickle recheck.
