### PR TITLE
TELCORE-363: guard CBR ptime autofix against G722 RTP-clock mismatch

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -264,6 +264,7 @@ SWITCH_DECLARE(switch_rtp_t *) switch_core_media_get_rtp_session(switch_core_ses
 
 SWITCH_DECLARE(const char *)switch_core_media_get_codec_string(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_parse_rtp_bugs(switch_rtp_bug_flag_t *flag_pole, const char *str);
+SWITCH_DECLARE(switch_bool_t) switch_core_media_codec_ptime_autofix_ok(const switch_codec_implementation_t *imp);
 SWITCH_DECLARE(switch_status_t) switch_core_media_add_crypto(switch_core_session_t *session, switch_secure_settings_t *ssec, switch_rtp_crypto_direction_t direction);
 SWITCH_DECLARE(switch_t38_options_t *) switch_core_media_extract_t38_options(switch_core_session_t *session, const char *r_sdp);
 SWITCH_DECLARE(int) switch_core_media_toggle_hold(switch_core_session_t *session, int sendonly);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -11836,28 +11836,11 @@ SWITCH_DECLARE(switch_bool_t) switch_core_session_in_video_thread(switch_core_se
 }
 
 
-/* TELCORE-363: Decide whether the SCMF_AUTOFIX_TIMING "broken PTIME" autofix
- * may run for this codec implementation.
- *
- * The CBR autofix derives the remote ptime from RTP timestamp deltas:
- *
- *     codec_ms = (ts - last_ts) / (samples_per_second / 1000)
- *
- * That formula is only valid when the codec's RTP clock rate equals its
- * actual sampling rate. G722 famously violates this (RFC 3551 section 4.5.2):
- * it samples at 16 kHz but its RTP timestamp clock ticks at 8 kHz. Any
- * mixup between the two clocks (jitter-buffer PLC/acceleration rewriting
- * timestamps, recording resampler artifacts, etc.) makes a clean 20 ms
- * stream look like a 40 ms stream, so the autofix "corrects" our end from
- * the negotiated 20 ms row (spf=160) to the 40 ms row (spf=320). The write
- * timer then produces one 20 ms frame per 40 ms of RTP clock (80 ms wall
- * clock), i.e. only a quarter of the audio -- heard as choppy/compressed
- * speech while MOS stays perfect because no packet is ever lost.
- *
- * Guard: only allow the autofix when the RTP clock and the actual sample
- * clock agree. This keeps the legacy behaviour for every normal codec
- * (PCMU/PCMA/opus/...) and disables the rewrite only where its input math
- * is provably wrong. */
+/* TELCORE-363: the PTIME autofix computes remote ptime from RTP timestamp
+ * deltas / samples_per_second. That is only valid when the RTP clock equals
+ * the actual sampling rate. G722 (RFC 3551 4.5.2) uses an 8 kHz RTP clock at
+ * a 16 kHz sample rate, so the autofix can wrongly rewrite 20 ms -> 40 ms and
+ * quarter the produced audio. Only allow the autofix when the clocks match. */
 SWITCH_DECLARE(switch_bool_t) switch_core_media_codec_ptime_autofix_ok(const switch_codec_implementation_t *imp)
 {
 	if (!imp) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5119,7 +5119,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_read_frame(switch_core_session
 				}
 
 				/* check for timing issues */
-				if (smh->media_flags[SCMF_AUTOFIX_TIMING] && type == SWITCH_MEDIA_TYPE_AUDIO && engine->read_impl.samples_per_second) {
+				if (smh->media_flags[SCMF_AUTOFIX_TIMING] && type == SWITCH_MEDIA_TYPE_AUDIO && engine->read_impl.samples_per_second &&
+					switch_core_media_codec_ptime_autofix_ok(&engine->read_impl)) {
 					char is_vbr;
 					is_vbr = engine->read_impl.encoded_bytes_per_packet?0:1;
 
@@ -11834,6 +11835,41 @@ SWITCH_DECLARE(switch_bool_t) switch_core_session_in_video_thread(switch_core_se
 	return switch_thread_equal(switch_thread_self(), v_engine->thread_id) ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
+
+/* TELCORE-363: Decide whether the SCMF_AUTOFIX_TIMING "broken PTIME" autofix
+ * may run for this codec implementation.
+ *
+ * The CBR autofix derives the remote ptime from RTP timestamp deltas:
+ *
+ *     codec_ms = (ts - last_ts) / (samples_per_second / 1000)
+ *
+ * That formula is only valid when the codec's RTP clock rate equals its
+ * actual sampling rate. G722 famously violates this (RFC 3551 section 4.5.2):
+ * it samples at 16 kHz but its RTP timestamp clock ticks at 8 kHz. Any
+ * mixup between the two clocks (jitter-buffer PLC/acceleration rewriting
+ * timestamps, recording resampler artifacts, etc.) makes a clean 20 ms
+ * stream look like a 40 ms stream, so the autofix "corrects" our end from
+ * the negotiated 20 ms row (spf=160) to the 40 ms row (spf=320). The write
+ * timer then produces one 20 ms frame per 40 ms of RTP clock (80 ms wall
+ * clock), i.e. only a quarter of the audio -- heard as choppy/compressed
+ * speech while MOS stays perfect because no packet is ever lost.
+ *
+ * Guard: only allow the autofix when the RTP clock and the actual sample
+ * clock agree. This keeps the legacy behaviour for every normal codec
+ * (PCMU/PCMA/opus/...) and disables the rewrite only where its input math
+ * is provably wrong. */
+SWITCH_DECLARE(switch_bool_t) switch_core_media_codec_ptime_autofix_ok(const switch_codec_implementation_t *imp)
+{
+	if (!imp) {
+		return SWITCH_FALSE;
+	}
+
+	if (!imp->samples_per_second || !imp->actual_samples_per_second) {
+		return SWITCH_FALSE;
+	}
+
+	return imp->samples_per_second == imp->actual_samples_per_second ? SWITCH_TRUE : SWITCH_FALSE;
+}
 
 SWITCH_DECLARE(void) switch_core_media_parse_media_flags(switch_core_session_t *session)
 {

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 			   switch_ivr_play_say switch_core_codec switch_rtp switch_xml
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log switch_stun switch_trickle_ice switch_bundle
 
-noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup test_dtmf_sent_event
+noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup test_dtmf_sent_event switch_ptime_autofix
 
 # switch_mod_lumenvox is intentionally NOT built/run in CI yet: LumenVox servers
 # are not reachable from CI, so the ASR tests cannot run there. Re-enable by

--- a/tests/unit/switch_ptime_autofix.c
+++ b/tests/unit/switch_ptime_autofix.c
@@ -1,0 +1,168 @@
+/*
+ * TELCORE-363: choppy outbound G722 audio despite good MOS.
+ *
+ * Root cause
+ * ----------
+ * The SCMF_AUTOFIX_TIMING "broken PTIME" autofix in
+ * switch_core_media_read_frame() derives the remote ptime from RTP timestamp
+ * deltas divided by implementation->samples_per_second. For G722 the RTP
+ * clock (8 kHz, RFC 3551 section 4.5.2) differs from the actual sampling rate
+ * (16 kHz), so timestamp artifacts (elastic jitter buffer PLC/acceleration,
+ * recording resampler) make a clean 20 ms stream look like 40 ms. The autofix
+ * then rewrote codec_ms from the negotiated 20 ms row (spf=160) to the 40 ms
+ * row (spf=320) and re-initialized the write timer, producing only a quarter
+ * of the audio: 518 packets in ~38.7 s (~13 pps instead of 50 pps), heard as
+ * choppy/"sped-up" audio while MOS stayed at 4.5 because no packet was lost.
+ *
+ * Fix under test
+ * --------------
+ * switch_core_media_codec_ptime_autofix_ok() only allows the autofix when the
+ * codec's RTP clock rate equals its actual sampling rate. This test verifies
+ * the guard's decision for real codec implementations:
+ *
+ *   - G722  (8000 RTP clock / 16000 actual)  -> autofix must be DISALLOWED
+ *   - PCMU  (8000 / 8000)                    -> autofix stays allowed
+ *   - PCMA  (8000 / 8000)                    -> autofix stays allowed
+ *   - OPUS  (48000 / 48000)                  -> autofix stays allowed
+ *   - NULL / zeroed implementations          -> disallowed (defensive)
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(switch_ptime_autofix)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_spandsp");
+			fst_requires_module("mod_opus");
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(test_g722_autofix_disallowed)
+		{
+			switch_codec_t codec = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+
+			status = switch_core_codec_init(&codec,
+											"G722",
+											"mod_spandsp",
+											NULL,
+											8000,
+											20,
+											1, SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+											&codec_settings, fst_pool);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(codec.implementation != NULL);
+
+			/* Confirm the RFC 3551 quirk this guard exists for: the RTP clock
+			 * and the actual sampling rate must differ for G722. */
+			fst_check_int_equals(codec.implementation->samples_per_second, 8000);
+			fst_check_int_equals(codec.implementation->actual_samples_per_second, 16000);
+
+			/* The CBR ptime autofix must never run for G722: its timestamp
+			 * math divides by the wrong clock and rewrites 20 ms -> 40 ms,
+			 * quartering the produced audio (TELCORE-363). */
+			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(codec.implementation) == SWITCH_FALSE,
+					   "G722 (8k RTP clock / 16k sample rate) must be excluded from the ptime autofix");
+
+			switch_core_codec_destroy(&codec);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(test_pcmu_pcma_autofix_allowed)
+		{
+			switch_codec_t codec = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+			const char *names[] = { "PCMU", "PCMA" };
+			int i;
+
+			for (i = 0; i < 2; i++) {
+				memset(&codec, 0, sizeof(codec));
+
+				status = switch_core_codec_init(&codec,
+												names[i],
+												NULL,
+												NULL,
+												8000,
+												20,
+												1, SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+												&codec_settings, fst_pool);
+				fst_requires(status == SWITCH_STATUS_SUCCESS);
+				fst_requires(codec.implementation != NULL);
+
+				fst_check_int_equals(codec.implementation->samples_per_second,
+									 codec.implementation->actual_samples_per_second);
+
+				/* Legacy behaviour must be preserved for normal codecs: the
+				 * autofix still protects against genuinely broken remote
+				 * ptime senders. */
+				fst_xcheck(switch_core_media_codec_ptime_autofix_ok(codec.implementation) == SWITCH_TRUE,
+						   "codec with matching RTP/sample clocks must keep the ptime autofix enabled");
+
+				switch_core_codec_destroy(&codec);
+			}
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(test_opus_autofix_allowed)
+		{
+			switch_codec_t codec = { 0 };
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			switch_status_t status;
+
+			status = switch_core_codec_init(&codec,
+											"OPUS",
+											"mod_opus",
+											NULL,
+											48000,
+											20,
+											1, SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+											&codec_settings, fst_pool);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(codec.implementation != NULL);
+
+			fst_check_int_equals(codec.implementation->samples_per_second,
+								 codec.implementation->actual_samples_per_second);
+
+			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(codec.implementation) == SWITCH_TRUE,
+					   "OPUS (48k/48k) must keep the ptime autofix enabled");
+
+			switch_core_codec_destroy(&codec);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(test_defensive_inputs)
+		{
+			switch_codec_implementation_t zeroed = { 0 };
+			switch_codec_implementation_t partial = { 0 };
+
+			/* NULL implementation must never allow the autofix. */
+			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(NULL) == SWITCH_FALSE,
+					   "NULL implementation must be rejected");
+
+			/* Fully zeroed implementation (no clock info) must be rejected. */
+			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(&zeroed) == SWITCH_FALSE,
+					   "zeroed implementation must be rejected");
+
+			/* Missing actual_samples_per_second must be rejected rather than
+			 * treated as matching. */
+			partial.samples_per_second = 8000;
+			partial.actual_samples_per_second = 0;
+			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(&partial) == SWITCH_FALSE,
+					   "implementation without actual sample rate must be rejected");
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()

--- a/tests/unit/switch_ptime_autofix.c
+++ b/tests/unit/switch_ptime_autofix.c
@@ -1,30 +1,8 @@
 /*
- * TELCORE-363: choppy outbound G722 audio despite good MOS.
- *
- * Root cause
- * ----------
- * The SCMF_AUTOFIX_TIMING "broken PTIME" autofix in
- * switch_core_media_read_frame() derives the remote ptime from RTP timestamp
- * deltas divided by implementation->samples_per_second. For G722 the RTP
- * clock (8 kHz, RFC 3551 section 4.5.2) differs from the actual sampling rate
- * (16 kHz), so timestamp artifacts (elastic jitter buffer PLC/acceleration,
- * recording resampler) make a clean 20 ms stream look like 40 ms. The autofix
- * then rewrote codec_ms from the negotiated 20 ms row (spf=160) to the 40 ms
- * row (spf=320) and re-initialized the write timer, producing only a quarter
- * of the audio: 518 packets in ~38.7 s (~13 pps instead of 50 pps), heard as
- * choppy/"sped-up" audio while MOS stayed at 4.5 because no packet was lost.
- *
- * Fix under test
- * --------------
- * switch_core_media_codec_ptime_autofix_ok() only allows the autofix when the
- * codec's RTP clock rate equals its actual sampling rate. This test verifies
- * the guard's decision for real codec implementations:
- *
- *   - G722  (8000 RTP clock / 16000 actual)  -> autofix must be DISALLOWED
- *   - PCMU  (8000 / 8000)                    -> autofix stays allowed
- *   - PCMA  (8000 / 8000)                    -> autofix stays allowed
- *   - OPUS  (48000 / 48000)                  -> autofix stays allowed
- *   - NULL / zeroed implementations          -> disallowed (defensive)
+ * TELCORE-363: tests for switch_core_media_codec_ptime_autofix_ok().
+ * The PTIME autofix must be disallowed for codecs whose RTP clock differs
+ * from the actual sample rate (G722: 8 kHz clock / 16 kHz samples), and
+ * stay allowed for matching-clock codecs (PCMU/PCMA/OPUS).
  */
 
 #include <switch.h>
@@ -63,14 +41,10 @@ FST_CORE_BEGIN("./conf")
 			fst_requires(status == SWITCH_STATUS_SUCCESS);
 			fst_requires(codec.implementation != NULL);
 
-			/* Confirm the RFC 3551 quirk this guard exists for: the RTP clock
-			 * and the actual sampling rate must differ for G722. */
+			/* G722: 8 kHz RTP clock, 16 kHz sample rate (RFC 3551 4.5.2) */
 			fst_check_int_equals(codec.implementation->samples_per_second, 8000);
 			fst_check_int_equals(codec.implementation->actual_samples_per_second, 16000);
 
-			/* The CBR ptime autofix must never run for G722: its timestamp
-			 * math divides by the wrong clock and rewrites 20 ms -> 40 ms,
-			 * quartering the produced audio (TELCORE-363). */
 			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(codec.implementation) == SWITCH_FALSE,
 					   "G722 (8k RTP clock / 16k sample rate) must be excluded from the ptime autofix");
 
@@ -103,9 +77,6 @@ FST_CORE_BEGIN("./conf")
 				fst_check_int_equals(codec.implementation->samples_per_second,
 									 codec.implementation->actual_samples_per_second);
 
-				/* Legacy behaviour must be preserved for normal codecs: the
-				 * autofix still protects against genuinely broken remote
-				 * ptime senders. */
 				fst_xcheck(switch_core_media_codec_ptime_autofix_ok(codec.implementation) == SWITCH_TRUE,
 						   "codec with matching RTP/sample clocks must keep the ptime autofix enabled");
 
@@ -146,16 +117,12 @@ FST_CORE_BEGIN("./conf")
 			switch_codec_implementation_t zeroed = { 0 };
 			switch_codec_implementation_t partial = { 0 };
 
-			/* NULL implementation must never allow the autofix. */
 			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(NULL) == SWITCH_FALSE,
 					   "NULL implementation must be rejected");
 
-			/* Fully zeroed implementation (no clock info) must be rejected. */
 			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(&zeroed) == SWITCH_FALSE,
 					   "zeroed implementation must be rejected");
 
-			/* Missing actual_samples_per_second must be rejected rather than
-			 * treated as matching. */
 			partial.samples_per_second = 8000;
 			partial.actual_samples_per_second = 0;
 			fst_xcheck(switch_core_media_codec_ptime_autofix_ok(&partial) == SWITCH_FALSE,


### PR DESCRIPTION
## Problem

Outbound G722 audio was choppy/"sped-up" despite perfect MOS (4.5). Call `44b623b1-fbd5-4783-bd07-0e875c11f317` on `b2bua.tel-mn1-kube-prod-875` (2026-08-10 04:25 UTC, Netic AI → Retell): the Telnyx→Retell G722 leg carried only 518 packets in ~38.7s (~13 pps, ts-delta 320) instead of ~1935 (50 pps, ts-delta 160) — a quarter of the audio. No packet loss, contiguous sequence numbers, so MOS never noticed.

## Root cause

The `SCMF_AUTOFIX_TIMING` broken-PTIME autofix derives remote ptime from RTP timestamp deltas divided by `implementation->samples_per_second`. G722 violates the assumption behind that math (RFC 3551 §4.5.2): its RTP clock ticks at 8 kHz while it samples at 16 kHz. Timestamp artifacts (elastic JB PLC/acceleration from TELCORE-248, recording resampler at 11025 Hz) make a clean 20 ms stream look like 40 ms, so the autofix "corrected" our end from the negotiated 20 ms row (spf=160) to the 40 ms row (spf=320) and reset the write timer — producing one 20 ms frame per ~80 ms wall clock.

`rtp-autofix-timing` is not set in any b2bua profile, and the FreeSWITCH default is ON, so this path was live in production.

## Fix

New `switch_core_media_codec_ptime_autofix_ok()`: the autofix may only run when the codec RTP clock rate equals its actual sampling rate. Wired into the CBR timing check in `switch_core_media_read_frame()`.

- G722 (8k/16k) → autofix disabled; negotiated ptime is never rewritten
- PCMU/PCMA/OPUS/every matching-clock codec → legacy behavior unchanged
- NULL/zeroed implementations → rejected defensively

## Tests

`tests/unit/switch_ptime_autofix.c` (wired into `tests/unit/Makefile.am`):
- G722 disallowed — asserts the real mod_spandsp implementation carries the 8000/16000 clock split and is excluded
- PCMU/PCMA allowed (legacy broken-ptime protection preserved)
- OPUS 48k/48k allowed
- Defensive: NULL, zeroed, and partial implementations rejected

## Linear

https://linear.app/telnyx/issue/TELCORE-363