### PR TITLE
TELCORE-423: unlock the codec mutex read_frame actually locked

### DIFF
--- a/src/mod/applications/mod_conference/.gitignore
+++ b/src/mod/applications/mod_conference/.gitignore
@@ -3,3 +3,5 @@ test/images/logo-*.png
 test/images/signalwire-scaled-*.png
 test/test_image
 test/test_member
+test/test_member_media_reset
+test/test_record_teardown

--- a/src/mod/applications/mod_conference/Makefile.am
+++ b/src/mod/applications/mod_conference/Makefile.am
@@ -21,7 +21,7 @@ noinst_LTLIBRARIES = libmodconference.la
 libmodconference_la_SOURCES  = $(mod_conference_la_SOURCES)
 libmodconference_la_CFLAGS   = $(AM_CFLAGS) -I.
 
-noinst_PROGRAMS = test/test_image test/test_member test/test_record_teardown
+noinst_PROGRAMS = test/test_image test/test_member test/test_record_teardown test/test_member_media_reset
 
 test_test_image_SOURCES = test/test_image.c
 test_test_image_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
@@ -37,5 +37,10 @@ test_test_record_teardown_SOURCES = test/test_record_teardown.c
 test_test_record_teardown_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
 test_test_record_teardown_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS)
 test_test_record_teardown_LDADD = libmodconference.la
+
+test_test_member_media_reset_SOURCES = test/test_member_media_reset.c
+test_test_member_media_reset_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
+test_test_member_media_reset_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS)
+test_test_member_media_reset_LDADD = libmodconference.la
 
 TESTS = $(noinst_PROGRAMS)

--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -1805,6 +1805,12 @@ int conference_member_setup_media(conference_member_t *member, conference_obj_t 
 
 	switch_mutex_lock(member->audio_out_mutex);
 
+	/* Held across the destroy/re-init below. This runs on the input thread while
+	 * conference_function() can be in switch_core_session_read_frame() on the same
+	 * session; switch_core_codec_destroy() zeroes the codec without taking
+	 * codec_read_mutex, which read_frame() holds over every codec access. */
+	switch_core_session_lock_codec_read(member->session);
+
 	switch_core_session_get_read_impl(member->session, &read_impl);
 
 	if (switch_core_codec_ready(&member->read_codec)) {
@@ -1898,6 +1904,7 @@ int conference_member_setup_media(conference_member_t *member, conference_obj_t 
 		goto codec_done1;
 	}
 
+	switch_core_session_unlock_codec_read(member->session);
 	switch_mutex_unlock(member->audio_out_mutex);
 
 	return 0;
@@ -1908,6 +1915,7 @@ int conference_member_setup_media(conference_member_t *member, conference_obj_t 
 	switch_core_codec_destroy(&member->write_codec);
  done:
 
+	switch_core_session_unlock_codec_read(member->session);
 	switch_mutex_unlock(member->audio_out_mutex);
 
 	return -1;

--- a/src/mod/applications/mod_conference/test/test_member_media_reset.c
+++ b/src/mod/applications/mod_conference/test/test_member_media_reset.c
@@ -1,0 +1,172 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * test_member_media_reset.c -- conference_member_setup_media() vs the session read path
+ *
+ * setup_media() destroys and re-initialises member->read_codec in place. It runs on
+ * the member input thread (conference_loop.c:915, member->reset_media /
+ * CF_CONFERENCE_RESET_MEDIA) while conference_function() can be in
+ * switch_core_session_read_frame() on the same session holding that codec's mutex.
+ * switch_core_codec_destroy() zeroes the codec, mutex pointer included, without
+ * taking codec_read_mutex, so setup_media() holds codec_read_mutex across the
+ * destroy/re-init.
+ *
+ * Covered here: setup_media() still succeeds on a reset (only the second and later
+ * calls take the destroy path), releases codec_read_mutex on every exit path, and
+ * leaves the session read path working. Not covered: the race itself, which is
+ * timing-dependent; the core side of it is in
+ * tests/unit/test_read_frame_codec_teardown.c.
+ *
+ * The reader runs on its own thread and the check is the frame, not a hang.
+ * codec_read_mutex is SWITCH_MUTEX_NESTED (switch_core_session.c:2674), so a leaking
+ * thread re-acquires it, and read_frame() only trylocks it (switch_core_io.c:93),
+ * returning runtime.dummy_cng_frame on failure. A missing unlock therefore shows up
+ * as SFF_CNG. The null endpoint's silence is generated SLN and carries no SFF_CNG.
+ *
+ * setup_media() is linked from libmodconference rather than #include-ing
+ * conference_member.c the way test_member.c and test_image.c do: that include is not
+ * a tracked build dependency, so those objects go stale when conference_member.c
+ * changes.
+ */
+#include <switch.h>
+#include <stdlib.h>
+#include <mod_conference.h>
+
+#include <test/switch_test.h>
+
+static switch_core_session_t *g_session = NULL;
+static volatile int g_read_done = 0;
+static volatile switch_status_t g_read_status = SWITCH_STATUS_FALSE;
+static volatile int g_read_was_cng = 0;
+
+/* Reads one frame and records whether it was real audio or the CNG placeholder
+ * read_frame() returns when it cannot take codec_read_mutex. */
+static void *SWITCH_THREAD_FUNC reader_thread(switch_thread_t *thread, void *obj)
+{
+	switch_frame_t *frame = NULL;
+
+	g_read_status = switch_core_session_read_frame(g_session, &frame, SWITCH_IO_FLAG_NONE, 0);
+	g_read_was_cng = (!frame || switch_test_flag(frame, SFF_CNG));
+	g_read_done = 1;
+
+	return NULL;
+}
+
+/* True if a read from another thread completed within ~2s. */
+static int read_frame_off_thread(switch_memory_pool_t *pool)
+{
+	switch_threadattr_t *thd_attr = NULL;
+	switch_thread_t *thread = NULL;
+	int i;
+
+	g_read_done = 0;
+	g_read_status = SWITCH_STATUS_FALSE;
+	g_read_was_cng = 0;
+
+	switch_threadattr_create(&thd_attr, pool);
+	switch_threadattr_detach_set(thd_attr, 1);
+	switch_thread_create(&thread, thd_attr, reader_thread, NULL, pool);
+
+	for (i = 0; i < 200 && !g_read_done; i++) {
+		switch_yield(10000);
+	}
+
+	return g_read_done;
+}
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(conference_member_media_reset)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_loopback");
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(setup_media_survives_a_reset)
+		{
+			conference_member_t smember = { 0 };
+			conference_member_t *member = &smember;
+			conference_obj_t conference = { 0 };
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_call_cause_t cause = SWITCH_CAUSE_NONE;
+			switch_codec_implementation_t read_impl = { 0 };
+			switch_status_t status;
+			int rc;
+
+			status = switch_ivr_originate(NULL, &session, &cause,
+										  "null/+15553334444",
+										  0, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(session);
+			channel = switch_core_session_get_channel(session);
+			fst_requires(switch_core_session_get_read_impl(session, &read_impl) == SWITCH_STATUS_SUCCESS);
+
+			member->session = session;
+			member->channel = channel;
+			member->pool = switch_core_session_get_pool(session);
+			switch_mutex_init(&member->audio_out_mutex, SWITCH_MUTEX_NESTED, member->pool);
+
+			conference.rate = read_impl.actual_samples_per_second;
+			conference.channels = read_impl.number_of_channels;
+			conference.pool = member->pool;
+
+			/* 1. Join-time setup: nothing to destroy yet. */
+			rc = conference_member_setup_media(member, &conference);
+			fst_requires(rc == 0);
+			fst_check(switch_core_codec_ready(&member->read_codec));
+
+			/* 2. Install the member codec as conference_function() does
+			 *    (mod_conference.c:2476), so the read path runs through the codec
+			 *    setup_media() rebuilds. */
+			fst_requires(switch_core_session_set_read_codec(session, &member->read_codec) == SWITCH_STATUS_SUCCESS);
+
+			/* 3. Baseline read. A real frame here is what makes step 5 meaningful. */
+			g_session = session;
+			fst_requires(read_frame_off_thread(member->pool));
+			fst_requires(SWITCH_READ_ACCEPTABLE(g_read_status));
+			fst_requires(!g_read_was_cng);
+
+			/* 4. The reset path: destroy + re-init under codec_read_mutex. */
+			rc = conference_member_setup_media(member, &conference);
+			fst_requires(rc == 0);
+			fst_check(switch_core_codec_ready(&member->read_codec));
+
+			/* 5. Still real audio. A leaked codec_read_mutex gives the CNG
+			 *    placeholder; a destroyed-but-published codec fails the status. */
+			fst_check(read_frame_off_thread(member->pool));
+			fst_check(SWITCH_READ_ACCEPTABLE(g_read_status));
+			fst_check(!g_read_was_cng);
+
+			/* Cleanup: put the session back on its own codec first. */
+			switch_core_session_set_read_codec(session, NULL);
+			switch_core_codec_destroy(&member->read_codec);
+			switch_core_codec_destroy(&member->write_codec);
+			if (member->read_resampler) {
+				switch_resample_destroy(&member->read_resampler);
+			}
+			if (member->audio_buffer) {
+				switch_buffer_destroy(&member->audio_buffer);
+			}
+			if (member->mux_buffer) {
+				switch_buffer_destroy(&member->mux_buffer);
+			}
+			if (member->resample_buffer) {
+				switch_buffer_destroy(&member->resample_buffer);
+			}
+
+			switch_channel_hangup(channel, SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()

--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -76,6 +76,10 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 	switch_frame_t *fork_frame = NULL;
 	unsigned int flag = 0;
 	int i;
+	/* The mutex actually locked below. switch_core_codec_destroy() memsets the codec,
+	 * mutex pointer included, without holding codec_read_mutex, so re-reading
+	 * session->read_codec->mutex to unlock can yield NULL. */
+	switch_mutex_t *read_codec_mutex = NULL;
 
 	switch_assert(session != NULL);
 
@@ -134,7 +138,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 		return SWITCH_STATUS_FALSE;
 	}
 
-	switch_mutex_lock(session->read_codec->mutex);
+	read_codec_mutex = session->read_codec->mutex;
+	switch_mutex_lock(read_codec_mutex);
 
   top:
 
@@ -185,7 +190,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 	}
 
 	if (session->endpoint_interface->io_routines->read_frame) {
-		switch_mutex_unlock(session->read_codec->mutex);
+		switch_mutex_unlock(read_codec_mutex);
+		read_codec_mutex = NULL;
 		switch_mutex_unlock(session->codec_read_mutex);
 		if ((status = session->endpoint_interface->io_routines->read_frame(session, frame, flags, stream_id)) == SWITCH_STATUS_SUCCESS) {
 			for (ptr = session->event_hooks.read_frame; ptr; ptr = ptr->next) {
@@ -217,7 +223,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 					switch_yield(session->read_impl.microseconds_per_packet);
 					return SWITCH_STATUS_SUCCESS;
 				}
-				switch_mutex_lock(session->read_codec->mutex);
+				read_codec_mutex = session->read_codec->mutex;
+				switch_mutex_lock(read_codec_mutex);
 				(*frame)->codec = session->read_codec;
 				status = SWITCH_STATUS_SUCCESS;
 				is_inuse = 1;
@@ -248,7 +255,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 			return SWITCH_STATUS_FALSE;
 		}
 
-		switch_mutex_lock(session->read_codec->mutex);
+		read_codec_mutex = session->read_codec->mutex;
+		switch_mutex_lock(read_codec_mutex);
 		if (!switch_core_codec_ready(session->read_codec)) {
 			*frame = NULL;
 			status = SWITCH_STATUS_FALSE;
@@ -1084,7 +1092,10 @@ cnt_with_cng:
 		}
 	}
 
-	switch_mutex_unlock(session->read_codec->mutex);
+	/* Not session->read_codec->mutex: the codec may have been zeroed since. */
+	if (read_codec_mutex) {
+		switch_mutex_unlock(read_codec_mutex);
+	}
 	switch_mutex_unlock(session->codec_read_mutex);
 
 

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -44,6 +44,7 @@ switch_estimators
 switch_jitter_buffer
 test_sofia
 test_dtmf_sent_event
+test_read_frame_codec_teardown
 switch_mod_lumenvox
 conf_lumenvox/[0-9]*/**
 .deps/

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -6,6 +6,11 @@ noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer
 
 noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup test_dtmf_sent_event
 
+# Regression: switch_core_session_read_frame() must not unlock the codec mutex by
+# re-dereferencing session->read_codec, which a concurrent switch_core_codec_destroy()
+# may have zeroed.
+noinst_PROGRAMS += test_read_frame_codec_teardown
+
 # switch_mod_lumenvox is intentionally NOT built/run in CI yet: LumenVox servers
 # are not reachable from CI, so the ASR tests cannot run there. Re-enable by
 # appending switch_mod_lumenvox to the line above. See TELCORE-249.

--- a/tests/unit/test_read_frame_codec_teardown.c
+++ b/tests/unit/test_read_frame_codec_teardown.c
@@ -1,0 +1,179 @@
+/*
+ * Regression test: switch_core_session_read_frame() unlocking a destroyed read codec.
+ *
+ * Production stack (1.10.12-telv112.0.b466):
+ *   __GI___pthread_mutex_unlock_usercnt()   pthread_mutex_unlock.c:51
+ *   fspr_thread_mutex_unlock()              libfreeswitch.so.1
+ *   switch_mutex_unlock()                   switch_apr.c:322
+ *   switch_core_session_read_frame()        switch_core_io.c:1088   <-- crash
+ *   switch_ivr_parse_event()                switch_ivr.c:563
+ *   switch_ivr_parse_next_event()           switch_ivr.c:828
+ *   switch_ivr_parse_all_events()           switch_ivr.c:966
+ *   conference_loop_output()                conference_loop.c:1645
+ *   conference_function()                   mod_conference.c:2542
+ *
+ * read_frame() locks session->read_codec->mutex at switch_core_io.c:137/221/251 and
+ * unlocks by re-evaluating that expression at :1087. switch_core_codec_destroy()
+ * memsets the codec (switch_core_codec.c:963) after releasing codec->mutex and
+ * without holding codec_read_mutex, so the re-read can be NULL.
+ *
+ * Two mod_conference threads, one session, both on &member.read_codec
+ * (mod_conference.c:1955, installed at :2476):
+ *
+ *   conference_function()   -> switch_ivr_parse_all_events() -> read_frame()
+ *   conference_loop_input() -> conference_member_setup_media()   conference_loop.c:915
+ *                              -> switch_core_codec_destroy(&member->read_codec) + memset
+ *
+ * setup_media() runs on member->reset_media, i.e. CF_CONFERENCE_RESET_MEDIA
+ * (switch_core_media.c:4202/:16318). member->read_mutex is taken only by
+ * conference_loop_input(), and switch_core_codec_destroy() does not take
+ * codec_read_mutex.
+ *
+ * Distinct from the TEL-6515 fix (test_inuse_race.c), which serialises a read_codec
+ * pointer swap behind codec_read_mutex: here the codec is destroyed in place and the
+ * pointer never changes.
+ *
+ * The production interleave - the destroying thread completing its memset between
+ * read_frame() taking the codec mutex and re-reading it to unlock - is a few
+ * instructions wide, so this test freezes the end state instead. A SMBF_READ_PING
+ * media bug callback runs from the done: block of read_frame()
+ * (switch_core_io.c:~1048), inside the region holding the codec mutex and ~20 lines
+ * before the unlock, and memsets the session read codec there. A baseline read first
+ * asserts the callback is reached.
+ *
+ * Unfixed: SIGSEGV in __pthread_mutex_unlock_usercnt.
+ * Fixed:   read_frame() unlocks the pointer it locked and returns.
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+
+static switch_core_session_t *g_session = NULL;
+
+/* Proves the injection point was reached. */
+static volatile int g_ping_count = 0;
+
+/* Arm/disarm the simulated teardown, and the saved codec used to restore it. */
+static volatile int g_tear_down_codec = 0;
+static switch_codec_t *g_torn_codec = NULL;
+static switch_codec_t g_saved_codec;
+
+/*
+ * Stands in for the conference input thread. Runs at switch_core_io.c:~1048, while
+ * the caller holds session->read_codec->mutex and session->codec_read_mutex.
+ */
+static switch_bool_t teardown_bug_callback(switch_media_bug_t *bug, void *user_data, switch_abc_type_t type)
+{
+	if (type != SWITCH_ABC_TYPE_READ_PING) {
+		return SWITCH_TRUE;
+	}
+
+	g_ping_count++;
+
+	if (g_tear_down_codec) {
+		switch_codec_t *codec = switch_core_session_get_read_codec(g_session);
+
+		g_tear_down_codec = 0;
+
+		if (codec) {
+			/* The state switch_core_codec_destroy() leaves behind: memset(codec, 0,
+			 * sizeof(*codec)) at switch_core_codec.c:963, after unlocking codec->mutex.
+			 * Saved so the session can still be torn down if the tree is fixed. */
+			g_saved_codec = *codec;
+			g_torn_codec = codec;
+			memset(codec, 0, sizeof(*codec));
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] read codec %p zeroed mid-read_frame\n", (void *) codec);
+		}
+	}
+
+	return SWITCH_TRUE;
+}
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(read_frame_codec_teardown)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_loopback");
+			g_session = NULL;
+			g_ping_count = 0;
+			g_tear_down_codec = 0;
+			g_torn_codec = NULL;
+			memset(&g_saved_codec, 0, sizeof(g_saved_codec));
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(test_read_frame_codec_destroyed_under_reader)
+		{
+			switch_core_session_t *session = NULL;
+			switch_channel_t *channel = NULL;
+			switch_call_cause_t cause = SWITCH_CAUSE_NONE;
+			switch_media_bug_t *bug = NULL;
+			switch_frame_t *frame = NULL;
+			switch_status_t status;
+			int i;
+
+			/* 1. A session whose read codec is owned by the endpoint's private data,
+			 *    like mod_conference's member->read_codec. */
+			status = switch_ivr_originate(NULL, &session, &cause,
+										  "null/+15553334444",
+										  0, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(session);
+
+			g_session = session;
+			channel = switch_core_session_get_channel(session);
+			fst_requires(switch_core_session_get_read_codec(session));
+
+			/* 2. READ_PING bug: callback runs from the done: block of read_frame(),
+			 *    inside the codec-mutex region. */
+			status = switch_core_media_bug_add(session, "read_codec_teardown", NULL,
+											   teardown_bug_callback, NULL, 0,
+											   SMBF_READ_PING | SMBF_NO_PAUSE,
+											   &bug);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+			fst_requires(bug);
+
+			/* 3. Baseline: the injection point must be reached, or step 5 proves nothing. */
+			for (i = 0; i < 10 && g_ping_count == 0; i++) {
+				status = switch_core_session_read_frame(session, &frame, SWITCH_IO_FLAG_NONE, 0);
+				fst_check(SWITCH_READ_ACCEPTABLE(status));
+			}
+			fst_requires(g_ping_count > 0);
+
+			/* 4. Arm the teardown. */
+			g_tear_down_codec = 1;
+
+			/* 5. read_frame() exits through even_more_done: and unlocks the codec mutex
+			 *    of a codec zeroed underneath it. Unfixed: SIGSEGV here. */
+			status = switch_core_session_read_frame(session, &frame, SWITCH_IO_FLAG_NONE, 0);
+
+			/* Reached only on a fixed tree. Not crashing is the assertion; the checks
+			 * below confirm the injection happened and a usable frame came back.
+			 * SWITCH_STATUS_SUCCESS is legitimate: the frame was already read when the
+			 * codec was torn down, and even_more_done: substitutes the dummy CNG frame. */
+			fst_requires(g_torn_codec);
+			fst_check(frame != NULL);
+
+			/* Restore the codec so the session can be hung up normally. */
+			*g_torn_codec = g_saved_codec;
+			g_torn_codec = NULL;
+
+			switch_core_media_bug_remove(session, &bug);
+			switch_channel_hangup(channel, SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+			g_session = NULL;
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()


### PR DESCRIPTION
## Crash

```
#0  __GI___pthread_mutex_unlock_usercnt()   pthread_mutex_unlock.c:51
#1  fspr_thread_mutex_unlock()              libfreeswitch.so.1
#2  switch_mutex_unlock()                   switch_apr.c:322
#3  switch_core_session_read_frame()        switch_core_io.c:1088   <-- crash
#4  switch_ivr_parse_event()                switch_ivr.c:563
#7  conference_loop_output()                conference_loop.c:1645
#8  conference_function()                   mod_conference.c:2542
```

tel-mn1-kube-prod-876, 1.10.12-telv112.0.b466, 630 calls recovered.

## Root cause

`switch_core_session_read_frame()` takes the codec mutex by dereferencing the session — `switch_mutex_lock(session->read_codec->mutex)` at `switch_core_io.c:137/221/251` — but releases it by re-evaluating the same expression at `switch_core_io.c:1087`. Those name the same object only if nothing destroyed the codec in between, and something does: `switch_core_codec_destroy()` ends with `memset(codec, 0, sizeof(*codec))` (`switch_core_codec.c:963`), performs that memset *after* releasing `codec->mutex`, and never takes `codec_read_mutex`. The re-read yields NULL and `fspr_thread_mutex_unlock()` faults on it.

mod_conference drives exactly that from two threads on one session. Both work on the same stack-allocated `conference_member_t` (`mod_conference.c:1955`) whose `&member.read_codec` is the session read codec (`mod_conference.c:2476`):

| `conference_function()` thread | `conference_loop_input()` thread |
| --- | --- |
| `switch_ivr_parse_all_events()` (conference_loop.c:1645) | `conference_member_setup_media()` (conference_loop.c:915) |
| → `switch_core_session_read_frame()` | → `switch_core_codec_destroy(&member->read_codec)` |
| locks `read_codec->mutex` | + `memset(&member->read_codec, 0, ...)` |
| unlocks `read_codec->mutex` ← NULL by now | |

The input thread re-runs `conference_member_setup_media()` whenever `member->reset_media` is set, i.e. on `CF_CONFERENCE_RESET_MEDIA` (media renegotiation, set at `switch_core_media.c:4202`/`:16318`). Nothing serialises the two: `member->read_mutex` is taken only by `conference_loop_input()`, and `switch_core_codec_destroy()` is invisible to `codec_read_mutex`.

**Not TELCORE-223.** That drain has been in prod since 2026-06-26 and is in this build; it guards `conference->pool`/`rwlock` against record threads, and nothing in this stack touches those. **Not TEL-6515 either** (`test_inuse_race.c`): that serialises a read_codec *pointer swap* behind `codec_read_mutex`, whereas here the codec object is destroyed in place, so the pointer never changes and the guard never engages.

## The fix, in two parts

**1. `switch_core_io.c` — unlock what was locked.** Hold the acquired mutex in a local and release that. Every relock site refreshes the local; the pre-endpoint-read unlock clears it, so the tail unlock can never release a mutex the call does not hold. This also fixes the quieter half of the defect: on a destroy-then-reinit the old code unlocked a *different* mutex than the one held, leaking the real one locked forever.

**Scope of that guarantee — it is not a general lifetime fix.** The cached pointer is only guaranteed to outlive the destroy when the codec was initialised with a caller-supplied pool: `switch_core_codec_init_with_bitrate()` sets `SWITCH_CODEC_FLAG_FREE_POOL` only when `pool == NULL` (`switch_core_codec.c:82-88`); `switch_core_codec_destroy()` destroys the pool only under that flag and never destroys the mutex itself; and `pthread_mutex_destroy()` on an fspr mutex runs only as a pool cleanup (`libs/apr/locks/unix/thread_mutex.c:80`). So for a caller-pool codec the mutex survives the memset intact. That covers this crash — mod_conference passes `member->pool`, which *is* the session pool (`mod_conference.c:2447`), owned by the very thread inside `read_frame()`. It does **not** cover a `FREE_POOL` codec such as the one `switch_core_session_set_codec_slin()` installs (`switch_core_session.c:97`, used in-tree only by mod_fsk): there `destroy()` tears down the pool and the mutex with it. That path is already unsound today — a reader would be *acquiring* an alreadydestroyed mutex — and this PR neither fixes nor worsens it.

**2. `mod_conference` — fix the ordering, not just the symptom.** `conference_member_setup_media()` now holds `switch_core_session_lock_codec_read()` across the whole destroy/re-init, making it mutually exclusive with the reader. `switch_core_codec_destroy()` cannot do this itself: it gets a bare codec, and `codec->session` is populated only when the caller supplied a pool (`switch_core_codec.c:13-14`), so it is NULL for exactly the codecs that need it most.

Doing this via the codec stack instead — unset, destroy, re-init, re-publish — was tried first and is wrong: `set_read_codec()` pushes/pops a stack so unsetting pops whatever is on top, not necessarily ours, and there is no accessor for the installed read codec to check first (`switch_core_session_get_read_codec()` returns `real_read_codec` when set).

Visible effect: while `setup_media()` holds `codec_read_mutex`, a concurrent `read_frame()` fails its trylock (`switch_core_io.c:93`) and returns `runtime.dummy_cng_frame` — a frame or two of silence during a media reset, against a segfault today, and the same behaviour the core already has for its own codec teardown (TEL-6515).

## Tests

**`tests/unit/test_read_frame_codec_teardown.c`** — the crash repro. Deterministic, no threads to race: a `SMBF_READ_PING` media-bug callback fires from the `done:` block of read_frame, inside the codec-mutex region ~20 lines before the faulting unlock, and memsets the session read codec there — the exact end state `switch_core_codec_destroy()` leaves. A baseline read asserts the callback is really reached, so it cannot pass vacuously. Unpatched it reproduces frames 0-3 verbatim (`mutex=0x8` is `NULL + offsetof(fspr_thread_mutex_t, mutex)`):

```
#0  ___pthread_mutex_unlock (mutex=0x8)   nptl/pthread_mutex_unlock.c
#1  fspr_thread_mutex_unlock ()           locks/unix/thread_mutex.c:121
#2  switch_mutex_unlock ()                src/switch_apr.c:321
#3  switch_core_session_read_frame ()     src/switch_core_io.c:1087
```

**`src/mod/applications/mod_conference/test/test_member_media_reset.c`** — covers the bookkeeping the new lock can break, which nothing else exercised (`test_member.c` only tests `conference_member_set_logo()`). Runs `setup_media()` twice (only the second takes the destroy path) and reads a frame from a *separate thread* after each. The separate thread is the point: `codec_read_mutex` is `SWITCH_MUTEX_NESTED` so a leaking thread re-acquires it happily, and `read_frame()` only trylocks it — a missing unlock yields silence, not a hang. Asserting the frame is not the CNG placeholder catches it, verified by deleting the unlock and watching the test fail at the first read.

It links `conference_member_setup_media()` from `libmodconference` rather than `#include`-ing `conference_member.c` the way `test_member.c`/`test_image.c` do — that include is not a tracked build dependency, so those objects go stale when `conference_member.c` changes and keep testing the old code. (Hit this while verifying; worth fixing for the existing two separately.)

Verified both directions on this base: repro commit alone → SIGSEGV (exit 139); with the fix → PASSED. Full run: 4 mod_conference tests plus `test_read_frame_codec_teardown`, `test_inuse_race`, `test_write_frame_foreign_codec`, `switch_core_codec`, `switch_core_session`, `switch_hold`, `switch_ivr_play_say`, `switch_ivr_originate` — 52 tests, all pass.

## Still open

`switch_mutex_lock()` at `:137/:226/:258` still dereferences `session->read_codec->mutex` after the readiness check, so a memset landing in that gap faults inside `pthread_mutex_lock` instead — a different stack from the one reported. With part 2 in place mod_conference can no longer produce it; another module destroying a session read codec still could. Left for a separate change.

## Heads-up: the base does not compile with `-Werror`

Unrelated to this PR, and it will likely show up as a red build here:

```
src/switch_core_media.c:4812:63: error: 'status' may be used uninitialized [-Werror=maybe-uninitialized]
```

From `cb76e91721` (TELCORE-102, #620), the tip of `deploy-development`. It is a genuine path, not a compiler artifact: in the BUNDLE audio-drain arm, a popped frame with `data != NULL` and `datalen == 0` satisfies `datalen <= SWITCH_RTP_MAX_BUF_LEN` so the `BREAK` branch is skipped, then `if (engine->read_frame.datalen)` is false, so nothing assigns `status` before the fall-through reaches the `status != SUCCESS && status != BREAK` test. One-line fix (`else { status = SWITCH_STATUS_BREAK; }` at `src/switch_core_media.c:4749`) kept out of this PR since it belongs to TELCORE-102.
