### PR TITLE
TELCORE-445: Initialize status for empty media frames

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4748,6 +4748,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_read_frame(switch_core_session
 				engine->read_frame.pmap = NULL;
 				if (engine->read_frame.datalen) {
 					status = SWITCH_STATUS_SUCCESS;
+				} else {
+					status = SWITCH_STATUS_BREAK;
 				}
 				switch_frame_free(&audio_fb_frame);
 			} else if (apop == (void *)1) {


### PR DESCRIPTION
## Summary

- initialize the media read status to `SWITCH_STATUS_BREAK` when a successfully popped audio frame has zero data length
- preserve `SWITCH_STATUS_SUCCESS` for non-empty frames

## Validation

- GCC 13.4 targeted compile with `-O2 -Werror=maybe-uninitialized` (unpatched code reproduces the warning; patched code passes)
- Apple Clang 17 targeted compile
- `git diff --check`

The full local `--gcc13-check` compiled the affected C file and later stopped at an unrelated macOS GNU libstdc++/Homebrew libc++ link mismatch.

Linear: https://linear.app/telnyx/issue/TELCORE-445/fix-uninitialized-status-in-switch-core-media-read-frame
