### PR TITLE
TELCORE-102: Correct cloned RTP frame buffer capacity

### DIFF
--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -241,7 +241,7 @@ static switch_frame_t *find_free_frame(switch_frame_buffer_t *fb, switch_frame_t
 		np->frame->packetlen = data_offset + datalen;
 		np->frame->data = packet + data_offset;
 		np->frame->datalen = datalen;
-		np->frame->buflen = SWITCH_RTP_MAX_BUF_LEN;
+		np->frame->buflen = SWITCH_RTP_MAX_BUF_LEN - data_offset;
 	} else {
 		np->frame->packet = NULL;
 		np->frame->packetlen = 0;

--- a/tests/unit/switch_utils.c
+++ b/tests/unit/switch_utils.c
@@ -105,9 +105,41 @@ FST_TEST_BEGIN(frame_buffer_dup_without_data_rebuilds_base_header)
 	fst_check(clone->packetlen == SWITCH_RTP_HEADER_LEN);
 	fst_check(clone->datalen == 0);
 	fst_check(clone->data == (uint8_t *) clone->packet + SWITCH_RTP_HEADER_LEN);
+	fst_check(clone->buflen == SWITCH_RTP_MAX_BUF_LEN - SWITCH_RTP_HEADER_LEN);
 	fst_check(cloned_packet->header.cc == 0);
 	fst_check(cloned_packet->header.x == 0);
 	fst_check(cloned_packet->header.p == 0);
+
+	switch_frame_buffer_free(fb, &clone);
+	switch_frame_buffer_destroy(&fb);
+}
+FST_TEST_END()
+
+FST_TEST_BEGIN(frame_buffer_dup_reports_capacity_after_rtp_header)
+{
+	switch_frame_buffer_t *fb = NULL;
+	switch_frame_t orig = { 0 };
+	switch_frame_t *clone = NULL;
+	switch_rtp_packet_t packet = { 0 };
+	switch_size_t data_offset = SWITCH_RTP_HEADER_LEN + 8;
+	uint8_t *payload = (uint8_t *)&packet + data_offset;
+	uint32_t payload_len = 32;
+
+	memset(payload, 0xa5, payload_len);
+	orig.packet = &packet;
+	orig.data = payload;
+	orig.datalen = payload_len;
+	orig.packetlen = (uint32_t)data_offset + payload_len;
+	orig.buflen = SWITCH_RTP_MAX_BUF_LEN - (uint32_t)data_offset;
+
+	fst_requires(switch_frame_buffer_create(&fb, 1) == SWITCH_STATUS_SUCCESS);
+	fst_requires(switch_frame_buffer_dup(fb, &orig, &clone) == SWITCH_STATUS_SUCCESS);
+	fst_requires(clone != NULL);
+	fst_check(clone->packetlen == data_offset + payload_len);
+	fst_check(clone->datalen == payload_len);
+	fst_check(clone->data == (uint8_t *)clone->packet + data_offset);
+	fst_check(clone->buflen == SWITCH_RTP_MAX_BUF_LEN - data_offset);
+	fst_check(!memcmp(clone->data, payload, payload_len));
 
 	switch_frame_buffer_free(fb, &clone);
 	switch_frame_buffer_destroy(&fb);


### PR DESCRIPTION
## Summary

Correct the writable capacity reported by raw RTP frames cloned through the frame buffer.

- Report capacity from frame data rather than from the packet allocation base.
- Subtract the RTP header and extension offset from SWITCH_RTP_MAX_BUF_LEN.
- Add regression coverage for the base-header fallback and a larger extension-like offset.

## Root cause

The clone allocates SWITCH_RTP_MAX_BUF_LEN bytes, then points frame data inside that allocation at packet plus data_offset. It previously advertised the full allocation size as buflen. Downstream writers could therefore treat bytes before frame data as writable capacity and copy beyond the end of the allocation.
