### PR TITLE
TELCORE-454..459: fix five BUNDLE read/drain defects found alongside TELCORE-453

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -246,8 +246,9 @@ SWITCH_DECLARE(switch_media_handle_t *) switch_core_session_get_media_handle(swi
 /* tests/unit only: struct switch_media_handle_s and struct switch_rtp_engine_s are
  * private to switch_core_media.c, so the BUNDLE read state is otherwise unreachable. */
 SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_read_fb(switch_core_session_t *session, switch_media_type_t type);
-SWITCH_DECLARE(switch_status_t) switch_core_media_test_lock_read(switch_core_session_t *session, switch_media_type_t type);
-SWITCH_DECLARE(void) switch_core_media_test_unlock_read(switch_core_session_t *session, switch_media_type_t type);
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_hold_session_write_lock(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_test_release_session_write_lock(switch_core_session_t *session);
+SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_pop_read_fb(switch_core_session_t *session, switch_media_type_t type);
 SWITCH_DECLARE(void) switch_core_media_test_flush_queued_read_frames(switch_core_session_t *session, switch_media_type_t type);
 SWITCH_DECLARE(void) switch_core_media_test_set_read_fb_frame(switch_core_session_t *session, switch_media_type_t type, switch_frame_t *frame);
 SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_get_read_fb_frame(switch_core_session_t *session, switch_media_type_t type);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -253,6 +253,7 @@ SWITCH_DECLARE(void) switch_core_media_test_set_read_fb_frame(switch_core_sessio
 SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_get_read_fb_frame(switch_core_session_t *session, switch_media_type_t type);
 SWITCH_DECLARE(void) switch_core_media_test_arm_drain(switch_core_session_t *session, switch_thread_t *thread);
 SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch_core_session_t *session);
+SWITCH_DECLARE(int) switch_core_media_test_get_drain_state(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_test_drain_thread_stop(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_bundle_drain(switch_core_session_t *session, switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_core_media_test_drain_thread_start(switch_core_session_t *session);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -241,6 +241,25 @@ typedef struct switch_fork_state_s {
 SWITCH_DECLARE(switch_status_t) switch_media_handle_create(switch_media_handle_t **smhp, switch_core_session_t *session, switch_core_media_params_t *params);
 SWITCH_DECLARE(void) switch_media_handle_destroy(switch_core_session_t *session);
 SWITCH_DECLARE(switch_media_handle_t *) switch_core_session_get_media_handle(switch_core_session_t *session);
+
+#ifdef SWITCH_CORE_MEDIA_TEST_HOOKS
+/* tests/unit only: struct switch_media_handle_s and struct switch_rtp_engine_s are
+ * private to switch_core_media.c, so the BUNDLE read state is otherwise unreachable. */
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_read_fb(switch_core_session_t *session, switch_media_type_t type);
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_lock_read(switch_core_session_t *session, switch_media_type_t type);
+SWITCH_DECLARE(void) switch_core_media_test_unlock_read(switch_core_session_t *session, switch_media_type_t type);
+SWITCH_DECLARE(void) switch_core_media_test_flush_queued_read_frames(switch_core_session_t *session, switch_media_type_t type);
+SWITCH_DECLARE(void) switch_core_media_test_set_read_fb_frame(switch_core_session_t *session, switch_media_type_t type, switch_frame_t *frame);
+SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_get_read_fb_frame(switch_core_session_t *session, switch_media_type_t type);
+SWITCH_DECLARE(void) switch_core_media_test_arm_drain(switch_core_session_t *session, switch_thread_t *thread);
+SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_test_drain_thread_stop(switch_core_session_t *session);
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_bundle_drain(switch_core_session_t *session, switch_rtp_t *rtp_session);
+SWITCH_DECLARE(void) switch_core_media_test_drain_thread_start(switch_core_session_t *session);
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_engine_read(switch_core_session_t *session, switch_media_type_t type, switch_rtp_t *rtp_session);
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_push_read_fb(switch_core_session_t *session, switch_media_type_t type, switch_frame_t *frame);
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_try_session_write_lock(switch_core_session_t *session);
+#endif
 SWITCH_DECLARE(switch_status_t) switch_core_session_clear_media_handle(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_session_media_handle_ready(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_media_handle_set_media_flag(switch_media_handle_t *smh, switch_core_media_flag_t flag);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -254,6 +254,9 @@ SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_get_read_fb_frame(switch
 SWITCH_DECLARE(void) switch_core_media_test_arm_drain(switch_core_session_t *session, switch_thread_t *thread);
 SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch_core_session_t *session);
 SWITCH_DECLARE(int) switch_core_media_test_get_drain_state(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_test_lock_bundle(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_test_unlock_bundle(switch_core_session_t *session);
+SWITCH_DECLARE(int) switch_core_media_test_demux_media_type(switch_core_session_t *session, const char *mid, uint32_t ssrc, int pt);
 SWITCH_DECLARE(void) switch_core_media_test_drain_thread_stop(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_bundle_drain(switch_core_session_t *session, switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_core_media_test_drain_thread_start(switch_core_session_t *session);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -30,6 +30,10 @@
  *
  */
 
+/* Makes the switch_core_media_test_* prototypes visible below so the definitions
+ * are checked against the header rather than silently drifting from it. */
+#define SWITCH_CORE_MEDIA_TEST_HOOKS
+
 #include <switch.h>
 #include <switch_ssl.h>
 #include <switch_stun.h>
@@ -4790,6 +4794,10 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_read_frame(switch_core_session
 
 				stable_packet = veng->bundle_audio_read_packet;
 				engine->read_frame = *audio_fb_frame;
+				/* Same reason as the video branch: read_frame is embedded in the
+				 * session-pool media handle, so it must not inherit the clone's
+				 * SFF_DYNAMIC. read_frame.data is repointed at pool memory below. */
+				switch_clear_flag((&engine->read_frame), SFF_DYNAMIC);
 
 				/* Audio drained from the shared BUNDLE socket must re-enter the normal
 				 * audio write path as payload, not as a raw forwarded RTP packet.
@@ -14366,10 +14374,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					status = SWITCH_STATUS_FALSE;
 					goto end;
 				}
-				switch_core_media_flush_queued_read_frames(v_engine);
-				/* Start the continuous drain thread. Stop first so BUNDLE restart
-				 * joins any exited-but-not-cleared drain thread and flushes stale audio. */
+				/* Stop first so BUNDLE restart joins any exited-but-not-cleared drain
+				 * thread, and flush only once it is gone -- flushing while it still
+				 * runs just lets it refill the queue behind us. */
 				bundle_drain_thread_stop(session);
+				switch_core_media_flush_queued_read_frames(v_engine);
 				switch_mutex_lock(smh->bundle_drain_mutex);
 				bundle_drain_thread_start(session);
 				switch_mutex_unlock(smh->bundle_drain_mutex);
@@ -22649,8 +22658,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_get_chosen_ice_candidate(switc
 
 /* struct switch_media_handle_s and struct switch_rtp_engine_s are private to this
  * file, so tests cannot reach the BUNDLE read state or the static helpers that
- * operate on it. These accessors exist only for tests/unit and are compiled out
- * otherwise. */
+ * operate on it. These accessors exist for tests/unit, but they are NOT compiled
+ * out of a release build -- they ship in libfreeswitch, the way
+ * switch_rtp_test_rewrite_mid_extension() does. Guarding them properly needs a
+ * configure-time switch; until then, treat them as internal and do not call them
+ * from a module. */
 
 static switch_rtp_engine_t *test_engine(switch_core_session_t *session, switch_media_type_t type)
 {
@@ -22773,8 +22785,13 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_bundle_drain(swit
 
 SWITCH_DECLARE(void) switch_core_media_test_drain_thread_start(switch_core_session_t *session)
 {
-	if (session) {
+	if (session && session->media_handle) {
+		/* bundle_drain_thread_start() documents that the caller holds this, and the
+		 * production call site does; without it the cond wait inside it would run on
+		 * an unheld mutex. */
+		switch_mutex_lock(session->media_handle->bundle_drain_mutex);
 		bundle_drain_thread_start(session);
+		switch_mutex_unlock(session->media_handle->bundle_drain_mutex);
 	}
 }
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -22581,6 +22581,175 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_get_chosen_ice_candidate(switc
 	return SWITCH_STATUS_SUCCESS;
 }
 
+/* struct switch_media_handle_s and struct switch_rtp_engine_s are private to this
+ * file, so tests cannot reach the BUNDLE read state or the static helpers that
+ * operate on it. These accessors exist only for tests/unit and are compiled out
+ * otherwise. */
+
+static switch_rtp_engine_t *test_engine(switch_core_session_t *session, switch_media_type_t type)
+{
+	if (!session || !session->media_handle || type >= SWITCH_MEDIA_TYPE_TOTAL) {
+		return NULL;
+	}
+	return &session->media_handle->engines[type];
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_read_fb(switch_core_session_t *session, switch_media_type_t type)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+	switch_media_handle_t *smh;
+
+	if (!engine) return SWITCH_STATUS_FALSE;
+	smh = session->media_handle;
+
+	if (!smh->read_mutex[type]) {
+		switch_mutex_init(&smh->read_mutex[type], SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
+	}
+
+	if (!engine->read_fb && switch_frame_buffer_create(&engine->read_fb, 10) != SWITCH_STATUS_SUCCESS) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_lock_read(switch_core_session_t *session, switch_media_type_t type)
+{
+	if (!test_engine(session, type) || !session->media_handle->read_mutex[type]) return SWITCH_STATUS_FALSE;
+	switch_mutex_lock(session->media_handle->read_mutex[type]);
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_unlock_read(switch_core_session_t *session, switch_media_type_t type)
+{
+	if (!test_engine(session, type) || !session->media_handle->read_mutex[type]) return;
+	switch_mutex_unlock(session->media_handle->read_mutex[type]);
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_flush_queued_read_frames(switch_core_session_t *session, switch_media_type_t type)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+
+	if (engine) {
+		switch_core_media_flush_queued_read_frames(engine);
+	}
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_set_read_fb_frame(switch_core_session_t *session, switch_media_type_t type, switch_frame_t *frame)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+
+	if (engine) {
+		engine->read_fb_frame = frame;
+	}
+}
+
+SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_get_read_fb_frame(switch_core_session_t *session, switch_media_type_t type)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+
+	return engine ? engine->read_fb_frame : NULL;
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_arm_drain(switch_core_session_t *session, switch_thread_t *thread)
+{
+	switch_rtp_engine_t *v_engine = test_engine(session, SWITCH_MEDIA_TYPE_VIDEO);
+
+	if (!v_engine) return;
+
+	switch_mutex_lock(session->media_handle->bundle_drain_mutex);
+	v_engine->bundle_drain_thread = thread;
+	v_engine->bundle_drain_state = BUNDLE_DRAIN_RUNNING;
+	switch_mutex_unlock(session->media_handle->bundle_drain_mutex);
+}
+
+SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch_core_session_t *session)
+{
+	switch_rtp_engine_t *v_engine = test_engine(session, SWITCH_MEDIA_TYPE_VIDEO);
+
+	return v_engine ? v_engine->bundle_drain_thread : NULL;
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_drain_thread_stop(switch_core_session_t *session)
+{
+	if (session) {
+		bundle_drain_thread_stop(session);
+	}
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_bundle_drain(switch_core_session_t *session, switch_rtp_t *rtp_session)
+{
+	switch_rtp_engine_t *a_engine, *v_engine;
+	switch_media_handle_t *smh;
+
+	if (!session || !(smh = session->media_handle)) return SWITCH_STATUS_FALSE;
+
+	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
+	v_engine = &smh->engines[SWITCH_MEDIA_TYPE_VIDEO];
+
+	a_engine->rtp_session = rtp_session;
+	v_engine->bundled_with_audio = 1;
+	smh->bundle.state = SWITCH_BUNDLE_STATE_ACCEPTED;
+
+	if (!v_engine->read_fb && switch_frame_buffer_create(&v_engine->read_fb, 10) != SWITCH_STATUS_SUCCESS) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_drain_thread_start(switch_core_session_t *session)
+{
+	if (session) {
+		bundle_drain_thread_start(session);
+	}
+}
+
+/* Satisfies the gates switch_core_media_read_frame() applies before it reaches the
+ * bundled-video branch: a ready read codec and a live rtp_session on the engine. */
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_engine_read(switch_core_session_t *session, switch_media_type_t type,
+																		   switch_rtp_t *rtp_session)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+
+	if (!engine) return SWITCH_STATUS_FALSE;
+
+	engine->rtp_session = rtp_session;
+
+	if (!switch_core_codec_ready(&engine->read_codec) &&
+		switch_core_codec_init(&engine->read_codec, "PCMU", NULL, NULL, 8000, 20, 1,
+							   SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+							   NULL, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
+		return SWITCH_STATUS_FALSE;
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_push_read_fb(switch_core_session_t *session, switch_media_type_t type,
+																	switch_frame_t *frame)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+
+	if (!engine || !engine->read_fb) return SWITCH_STATUS_FALSE;
+
+	return switch_frame_buffer_trypush(engine->read_fb, frame);
+}
+
+/* Returns SUCCESS when the session write lock could be taken, meaning nobody holds
+ * a read lock on it. Releases it again on success. */
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_try_session_write_lock(switch_core_session_t *session)
+{
+	if (!session || !session->rwlock) return SWITCH_STATUS_FALSE;
+
+	if (switch_thread_rwlock_trywrlock(session->rwlock) == SWITCH_STATUS_SUCCESS) {
+		switch_thread_rwlock_unlock(session->rwlock);
+		return SWITCH_STATUS_SUCCESS;
+	}
+
+	return SWITCH_STATUS_FALSE;
+}
+
 /* For Emacs:
  * Local Variables:
  * mode:c

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4714,6 +4714,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_read_frame(switch_core_session
 
 			engine->read_fb_frame = (switch_frame_t *) pop;
 			engine->read_frame = *engine->read_fb_frame;
+			/* The clone is heap allocated, but what the caller receives is
+			 * &engine->read_frame, embedded in the session-pool media handle.
+			 * Copying the flag wholesale would tell switch_frame_free() to free an
+			 * interior pointer into the pool and release the clone's packet out
+			 * from under engine->read_fb_frame. */
+			switch_clear_flag((&engine->read_frame), SFF_DYNAMIC);
 			engine->read_frame.codec = &engine->read_codec;
 			engine->read_frame.pmap = NULL;
 			if (engine->cur_payload_map) {

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -479,6 +479,7 @@ struct switch_media_handle_s {
 
 	switch_mutex_t *mutex;
 	switch_mutex_t *sdp_mutex;
+	switch_mutex_t *bundle_mutex;
 	switch_mutex_t *control_mutex;
 	switch_mutex_t *bundle_drain_mutex;  /* protects drain thread start/stop */
 
@@ -2997,6 +2998,7 @@ SWITCH_DECLARE(switch_status_t) switch_media_handle_create(switch_media_handle_t
 
 		switch_mutex_init(&session->media_handle->mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 		switch_mutex_init(&session->media_handle->sdp_mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
+		switch_mutex_init(&session->media_handle->bundle_mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 		switch_mutex_init(&session->media_handle->control_mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 		switch_mutex_init(&session->media_handle->bundle_drain_mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 		switch_thread_cond_create(&session->media_handle->engines[SWITCH_MEDIA_TYPE_VIDEO].bundle_audio_read_cond, switch_core_session_get_pool(session));
@@ -4239,6 +4241,28 @@ static void bundle_audio_queue_cleanup_locked(switch_core_session_t *session, sw
  * 2. The alternative (feeding back into RTP internals) would require exposing
  *    JB internals and risks deadlocks on the shared RTP session.
  * 3. Raw packet delivery with queue timing provides adequate ordering. */
+/* Resolves the BUNDLE m-line for a received packet and copies out the only field
+ * either caller needs. Both the traversal and the m-line it returns live in
+ * smh->bundle, which the SIP thread re-initialises wholesale on every received
+ * SDP, so the lookup and the read of media_type have to happen together. */
+static switch_bool_t bundle_demux_media_type(switch_media_handle_t *smh, const char *mid, uint32_t ssrc,
+											 switch_payload_t pt, switch_media_type_t *type_out)
+{
+	switch_bundle_mline_t *mline;
+	switch_bool_t found = SWITCH_FALSE;
+
+	switch_mutex_lock(smh->bundle_mutex);
+
+	if ((mline = switch_bundle_group_demux_rtp(&smh->bundle, mid, ssrc, pt, NULL))) {
+		*type_out = mline->media_type;
+		found = SWITCH_TRUE;
+	}
+
+	switch_mutex_unlock(smh->bundle_mutex);
+
+	return found;
+}
+
 static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread, void *obj)
 {
 	switch_core_session_t *session = (switch_core_session_t *) obj;
@@ -4293,7 +4317,7 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 		   && v_engine->bundled_with_audio) {
 
 		switch_status_t st;
-		switch_bundle_mline_t *mline;
+		switch_media_type_t demux_type = SWITCH_MEDIA_TYPE_AUDIO;
 		const char *mid;
 
 		/* Zero out the local frame for each read */
@@ -4353,14 +4377,12 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 
 		/* Demux: determine if audio or video */
 		mid = switch_rtp_get_received_mid(a_engine->rtp_session);
-		mline = switch_bundle_group_demux_rtp(&smh->bundle, mid, drain_frame.ssrc,
-											 drain_frame.payload, NULL);
 
-		if (!mline) {
+		if (!bundle_demux_media_type(smh, mid, drain_frame.ssrc, drain_frame.payload, &demux_type)) {
 			continue;
 		}
 
-		if (mline->media_type == SWITCH_MEDIA_TYPE_VIDEO) {
+		if (demux_type == SWITCH_MEDIA_TYPE_VIDEO) {
 			/* Clone and queue to video read_fb. BUNDLE video read_fb stores
 			 * malloc-backed frame clones, not frame-buffer-owned clones. */
 			switch_frame_t *dupframe = NULL;
@@ -4369,7 +4391,7 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 				switch_frame_buffer_trypush(v_engine->read_fb, dupframe) != SWITCH_STATUS_SUCCESS) {
 				switch_frame_free(&dupframe);
 			}
-		} else if (mline->media_type == SWITCH_MEDIA_TYPE_AUDIO) {
+		} else if (demux_type == SWITCH_MEDIA_TYPE_AUDIO) {
 			/* Clone and queue to audio read_fb for the audio read path.
 			 * Serialize fb access with stop/teardown so the drain thread cannot
 			 * duplicate into a buffer while another thread is disabling BUNDLE. */
@@ -4553,7 +4575,7 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 static switch_bool_t switch_core_media_route_bundled_rtp(switch_media_handle_t *smh, switch_rtp_engine_t *engine, switch_media_type_t type)
 {
 	switch_rtp_engine_t *v_engine;
-	switch_bundle_mline_t *mline;
+	switch_media_type_t demux_type = SWITCH_MEDIA_TYPE_AUDIO;
 	const char *mid;
 
 	if (!smh || !engine || type != SWITCH_MEDIA_TYPE_AUDIO || smh->bundle.state != SWITCH_BUNDLE_STATE_ACCEPTED) {
@@ -4566,17 +4588,16 @@ static switch_bool_t switch_core_media_route_bundled_rtp(switch_media_handle_t *
 	}
 
 	mid = switch_rtp_get_received_mid(engine->rtp_session);
-	mline = switch_bundle_group_demux_rtp(&smh->bundle, mid, engine->read_frame.ssrc, engine->read_frame.payload, NULL);
 
-	if (!mline) {
+	if (!bundle_demux_media_type(smh, mid, engine->read_frame.ssrc, engine->read_frame.payload, &demux_type)) {
 		return SWITCH_TRUE;
 	}
 
-	if (mline->media_type == SWITCH_MEDIA_TYPE_AUDIO) {
+	if (demux_type == SWITCH_MEDIA_TYPE_AUDIO) {
 		return SWITCH_FALSE;
 	}
 
-	if (mline->media_type == SWITCH_MEDIA_TYPE_VIDEO) {
+	if (demux_type == SWITCH_MEDIA_TYPE_VIDEO) {
 		switch_frame_t *dupframe = NULL;
 
 		if (!engine->read_frame.buflen) {
@@ -8397,6 +8418,12 @@ static void switch_core_media_bundle_populate_from_sdp(switch_media_handle_t *sm
 
 	channel = switch_core_session_get_channel(smh->session);
 	policy = switch_core_media_bundle_policy(smh);
+
+	/* The group is rebuilt from scratch here -- init() memsets it and the loop
+	 * below repopulates it -- while the drain thread and the audio read path
+	 * traverse it per packet. Hold them off for the rebuild. */
+	switch_mutex_lock(smh->bundle_mutex);
+
 	switch_bundle_group_init(&smh->bundle, policy);
 
 	for (attr = sdp->sdp_attributes; attr; attr = attr->a_next) {
@@ -8513,6 +8540,7 @@ static void switch_core_media_bundle_populate_from_sdp(switch_media_handle_t *sm
 	} else {
 		switch_channel_set_variable(channel, "rtp_group_bundle", NULL);
 	}
+	switch_mutex_unlock(smh->bundle_mutex);
 }
 
 SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *session, const char *r_sdp, uint8_t *proceed, switch_sdp_type_t sdp_type)
@@ -22746,6 +22774,30 @@ SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch
 	switch_rtp_engine_t *v_engine = test_engine(session, SWITCH_MEDIA_TYPE_VIDEO);
 
 	return v_engine ? v_engine->bundle_drain_thread : NULL;
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_lock_bundle(switch_core_session_t *session)
+{
+	if (session && session->media_handle) {
+		switch_mutex_lock(session->media_handle->bundle_mutex);
+	}
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_unlock_bundle(switch_core_session_t *session)
+{
+	if (session && session->media_handle) {
+		switch_mutex_unlock(session->media_handle->bundle_mutex);
+	}
+}
+
+/* Drives the same helper the drain thread and the audio read path use. */
+SWITCH_DECLARE(int) switch_core_media_test_demux_media_type(switch_core_session_t *session, const char *mid, uint32_t ssrc, int pt)
+{
+	switch_media_type_t type = SWITCH_MEDIA_TYPE_AUDIO;
+
+	if (!session || !session->media_handle) return -1;
+
+	return bundle_demux_media_type(session->media_handle, mid, ssrc, (switch_payload_t) pt, &type) ? (int) type : -1;
 }
 
 SWITCH_DECLARE(int) switch_core_media_test_get_drain_state(switch_core_session_t *session)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -22753,19 +22753,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_test_prepare_read_fb(switch_co
 	return SWITCH_STATUS_SUCCESS;
 }
 
-SWITCH_DECLARE(switch_status_t) switch_core_media_test_lock_read(switch_core_session_t *session, switch_media_type_t type)
-{
-	if (!test_engine(session, type) || !session->media_handle->read_mutex[type]) return SWITCH_STATUS_FALSE;
-	switch_mutex_lock(session->media_handle->read_mutex[type]);
-	return SWITCH_STATUS_SUCCESS;
-}
-
-SWITCH_DECLARE(void) switch_core_media_test_unlock_read(switch_core_session_t *session, switch_media_type_t type)
-{
-	if (!test_engine(session, type) || !session->media_handle->read_mutex[type]) return;
-	switch_mutex_unlock(session->media_handle->read_mutex[type]);
-}
-
 SWITCH_DECLARE(void) switch_core_media_test_flush_queued_read_frames(switch_core_session_t *session, switch_media_type_t type)
 {
 	switch_rtp_engine_t *engine = test_engine(session, type);
@@ -22808,6 +22795,40 @@ SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch
 	switch_rtp_engine_t *v_engine = test_engine(session, SWITCH_MEDIA_TYPE_VIDEO);
 
 	return v_engine ? v_engine->bundle_drain_thread : NULL;
+}
+
+/* Holds the session write lock, so switch_core_session_read_lock() -- a trylock --
+ * fails for the drain thread while the channel is still UP. Hanging the channel up
+ * instead makes the failure indistinguishable from the thread running normally and
+ * exiting, since the loop condition then fails immediately too. */
+SWITCH_DECLARE(switch_status_t) switch_core_media_test_hold_session_write_lock(switch_core_session_t *session)
+{
+	if (!session || !session->rwlock) return SWITCH_STATUS_FALSE;
+
+	return switch_thread_rwlock_trywrlock(session->rwlock);
+}
+
+SWITCH_DECLARE(void) switch_core_media_test_release_session_write_lock(switch_core_session_t *session)
+{
+	if (session && session->rwlock) {
+		switch_thread_rwlock_unlock(session->rwlock);
+	}
+}
+
+/* Lets a test observe that the flush actually drained the queue, not just that it
+ * left the in-flight frame alone. */
+SWITCH_DECLARE(switch_frame_t *) switch_core_media_test_pop_read_fb(switch_core_session_t *session, switch_media_type_t type)
+{
+	switch_rtp_engine_t *engine = test_engine(session, type);
+	void *pop = NULL;
+
+	if (!engine || !engine->read_fb) return NULL;
+
+	if (switch_frame_buffer_trypop(engine->read_fb, &pop) != SWITCH_STATUS_SUCCESS) {
+		return NULL;
+	}
+
+	return (switch_frame_t *) pop;
 }
 
 SWITCH_DECLARE(void) switch_core_media_test_lock_bundle(switch_core_session_t *session)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -2847,7 +2847,8 @@ SWITCH_DECLARE(void) switch_core_media_set_stats(switch_core_session_t *session)
 
 
 
-static void switch_core_media_flush_queued_read_frames(switch_media_handle_t *smh, switch_media_type_t type);
+static void switch_core_media_flush_queued_read_frames(switch_rtp_engine_t *engine);
+static void switch_core_media_release_queued_read_frame(switch_rtp_engine_t *engine);
 static void bundle_audio_queue_flush(switch_frame_buffer_t *audio_fb);
 static void bundle_audio_queue_cleanup_locked(switch_core_session_t *session, switch_media_handle_t *smh, switch_rtp_engine_t *v_engine);
 
@@ -2897,7 +2898,11 @@ SWITCH_DECLARE(void) switch_media_handle_destroy(switch_core_session_t *session)
 
 	if (a_engine->write_fb) switch_frame_buffer_destroy(&a_engine->write_fb);
 
-	switch_core_media_flush_queued_read_frames(smh, SWITCH_MEDIA_TYPE_VIDEO);
+	/* The flush no longer frees the in-flight frame, so release it here. Safe:
+	 * switch_core_media_deactivate_rtp() above joined the drain thread and the
+	 * video helper thread, so no reader is holding it. */
+	switch_core_media_flush_queued_read_frames(v_engine);
+	switch_core_media_release_queued_read_frame(v_engine);
 	if (v_engine->read_fb) switch_frame_buffer_destroy(&v_engine->read_fb);
 
 	/* cleanup audio drain frame buffer.
@@ -4010,39 +4015,26 @@ static void switch_core_media_release_queued_read_frame(switch_rtp_engine_t *eng
 	}
 }
 
-/* Frees engine->read_fb_frame, which the bundled video read path is still
- * referencing through engine->read_frame after it returns to its caller, so this
- * must hold the same read mutex that path takes.  Called from the signalling
- * thread while the drain thread is still producing and the reader consuming. */
-static void switch_core_media_flush_queued_read_frames(switch_media_handle_t *smh, switch_media_type_t type)
+/* Drains the queue only.  It must NOT free engine->read_fb_frame: the bundled
+ * video read path leaves engine->read_frame aliasing that clone and hands the
+ * caller &engine->read_frame, then releases read_mutex before returning, so a
+ * caller is still using the block after this function could take that mutex.
+ * The reader owns the in-flight frame until its next pop (:release at the top of
+ * the branch), and switch_media_handle_destroy() owns it after teardown.
+ * Frames still in the queue were never handed out, so freeing them here is safe
+ * without a lock -- the frame buffer is itself thread safe. */
+static void switch_core_media_flush_queued_read_frames(switch_rtp_engine_t *engine)
 {
-	switch_rtp_engine_t *engine;
 	void *pop = NULL;
 
-	if (!smh || type >= SWITCH_MEDIA_TYPE_TOTAL) {
+	if (!engine || !engine->read_fb) {
 		return;
 	}
-
-	engine = &smh->engines[type];
-
-	if (!engine->read_fb) {
-		return;
-	}
-
-	if (smh->read_mutex[type]) {
-		switch_mutex_lock(smh->read_mutex[type]);
-	}
-
-	switch_core_media_release_queued_read_frame(engine);
 
 	while (switch_frame_buffer_trypop(engine->read_fb, &pop) == SWITCH_STATUS_SUCCESS && pop) {
 		switch_frame_t *frame = (switch_frame_t *) pop;
 		switch_frame_free(&frame);
 		pop = NULL;
-	}
-
-	if (smh->read_mutex[type]) {
-		switch_mutex_unlock(smh->read_mutex[type]);
 	}
 }
 
@@ -14347,7 +14339,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					status = SWITCH_STATUS_FALSE;
 					goto end;
 				}
-				switch_core_media_flush_queued_read_frames(smh, SWITCH_MEDIA_TYPE_VIDEO);
+				switch_core_media_flush_queued_read_frames(v_engine);
 				/* Start the continuous drain thread. Stop first so BUNDLE restart
 				 * joins any exited-but-not-cleared drain thread and flushes stale audio. */
 				bundle_drain_thread_stop(session);
@@ -14358,7 +14350,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				if (v_engine->bundled_with_audio) {
 					/* Stop drain thread before disabling BUNDLE */
 					bundle_drain_thread_stop(session);
-					switch_core_media_flush_queued_read_frames(smh, SWITCH_MEDIA_TYPE_VIDEO);
+					switch_core_media_flush_queued_read_frames(v_engine);
 					if (v_engine->bundle_write_state) {
 						switch_rtp_write_state_reset(v_engine->bundle_write_state);
 					}
@@ -22675,8 +22667,10 @@ SWITCH_DECLARE(void) switch_core_media_test_unlock_read(switch_core_session_t *s
 
 SWITCH_DECLARE(void) switch_core_media_test_flush_queued_read_frames(switch_core_session_t *session, switch_media_type_t type)
 {
-	if (test_engine(session, type)) {
-		switch_core_media_flush_queued_read_frames(session->media_handle, type);
+	switch_rtp_engine_t *engine = test_engine(session, type);
+
+	if (engine) {
+		switch_core_media_flush_queued_read_frames(engine);
 	}
 }
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4466,13 +4466,22 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 	switch_mutex_lock(smh->bundle_drain_mutex);
 	thd = v_engine->bundle_drain_thread;
 	if (!thd) {
-		v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
-		bundle_audio_queue_cleanup_locked(session, smh, v_engine);
+		/* A concurrent stop already took the handle and is inside its join; leaving
+		 * the state and the audio queue to it, since marking INACTIVE here would
+		 * publish a teardown that has not happened yet. */
+		if (v_engine->bundle_drain_state != BUNDLE_DRAIN_STOPPING) {
+			v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
+			bundle_audio_queue_cleanup_locked(session, smh, v_engine);
+		}
 		switch_mutex_unlock(smh->bundle_drain_mutex);
 		return;
 	}
 
-
+	/* Take ownership of the handle before dropping the mutex. Leaving it visible
+	 * across the join lets a second stop latch the same handle and join it twice,
+	 * then store NULL over whatever bundle_drain_thread_start() has since put
+	 * there. */
+	v_engine->bundle_drain_thread = NULL;
 	v_engine->bundle_drain_state = BUNDLE_DRAIN_STOPPING;
 	switch_mutex_unlock(smh->bundle_drain_mutex);
 
@@ -4497,10 +4506,13 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 		switch_thread_join(&st, thd);
 	}
 
+	/* The handle was cleared before the join, so only finish the teardown if no
+	 * replacement thread was started while we were joining. */
 	switch_mutex_lock(smh->bundle_drain_mutex);
-	v_engine->bundle_drain_thread = NULL;
-	bundle_audio_queue_cleanup_locked(session, smh, v_engine);
-	v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
+	if (!v_engine->bundle_drain_thread) {
+		bundle_audio_queue_cleanup_locked(session, smh, v_engine);
+		v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
+	}
 	switch_mutex_unlock(smh->bundle_drain_mutex);
 
 }

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4255,6 +4255,13 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 		return NULL;
 	}
 
+	/* Hold the session for the life of the thread, the way video_write_thread()
+	 * and video_helper_thread() do. Without it this thread dereferences session,
+	 * its channel and its media handle with nothing keeping the session alive. */
+	if (switch_core_session_read_lock(session) != SWITCH_STATUS_SUCCESS) {
+		return NULL;
+	}
+
 	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
 	v_engine = &smh->engines[SWITCH_MEDIA_TYPE_VIDEO];
 
@@ -4266,6 +4273,7 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 	switch_mutex_lock(smh->bundle_drain_mutex);
 	if (v_engine->bundle_drain_state != BUNDLE_DRAIN_STARTING) {
 		switch_mutex_unlock(smh->bundle_drain_mutex);
+		switch_core_session_rwunlock(session);
 		return NULL;
 	}
 	v_engine->bundle_drain_state = BUNDLE_DRAIN_RUNNING;
@@ -4384,6 +4392,8 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 		v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
 	}
 	switch_mutex_unlock(smh->bundle_drain_mutex);
+
+	switch_core_session_rwunlock(session);
 	return NULL;
 }
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -2847,7 +2847,7 @@ SWITCH_DECLARE(void) switch_core_media_set_stats(switch_core_session_t *session)
 
 
 
-static void switch_core_media_flush_queued_read_frames(switch_rtp_engine_t *engine);
+static void switch_core_media_flush_queued_read_frames(switch_media_handle_t *smh, switch_media_type_t type);
 static void bundle_audio_queue_flush(switch_frame_buffer_t *audio_fb);
 static void bundle_audio_queue_cleanup_locked(switch_core_session_t *session, switch_media_handle_t *smh, switch_rtp_engine_t *v_engine);
 
@@ -2897,7 +2897,7 @@ SWITCH_DECLARE(void) switch_media_handle_destroy(switch_core_session_t *session)
 
 	if (a_engine->write_fb) switch_frame_buffer_destroy(&a_engine->write_fb);
 
-	switch_core_media_flush_queued_read_frames(v_engine);
+	switch_core_media_flush_queued_read_frames(smh, SWITCH_MEDIA_TYPE_VIDEO);
 	if (v_engine->read_fb) switch_frame_buffer_destroy(&v_engine->read_fb);
 
 	/* cleanup audio drain frame buffer.
@@ -4010,12 +4010,27 @@ static void switch_core_media_release_queued_read_frame(switch_rtp_engine_t *eng
 	}
 }
 
-static void switch_core_media_flush_queued_read_frames(switch_rtp_engine_t *engine)
+/* Frees engine->read_fb_frame, which the bundled video read path is still
+ * referencing through engine->read_frame after it returns to its caller, so this
+ * must hold the same read mutex that path takes.  Called from the signalling
+ * thread while the drain thread is still producing and the reader consuming. */
+static void switch_core_media_flush_queued_read_frames(switch_media_handle_t *smh, switch_media_type_t type)
 {
+	switch_rtp_engine_t *engine;
 	void *pop = NULL;
 
-	if (!engine || !engine->read_fb) {
+	if (!smh || type >= SWITCH_MEDIA_TYPE_TOTAL) {
 		return;
+	}
+
+	engine = &smh->engines[type];
+
+	if (!engine->read_fb) {
+		return;
+	}
+
+	if (smh->read_mutex[type]) {
+		switch_mutex_lock(smh->read_mutex[type]);
 	}
 
 	switch_core_media_release_queued_read_frame(engine);
@@ -4024,6 +4039,10 @@ static void switch_core_media_flush_queued_read_frames(switch_rtp_engine_t *engi
 		switch_frame_t *frame = (switch_frame_t *) pop;
 		switch_frame_free(&frame);
 		pop = NULL;
+	}
+
+	if (smh->read_mutex[type]) {
+		switch_mutex_unlock(smh->read_mutex[type]);
 	}
 }
 
@@ -14300,7 +14319,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 					status = SWITCH_STATUS_FALSE;
 					goto end;
 				}
-				switch_core_media_flush_queued_read_frames(v_engine);
+				switch_core_media_flush_queued_read_frames(smh, SWITCH_MEDIA_TYPE_VIDEO);
 				/* Start the continuous drain thread. Stop first so BUNDLE restart
 				 * joins any exited-but-not-cleared drain thread and flushes stale audio. */
 				bundle_drain_thread_stop(session);
@@ -14311,7 +14330,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 				if (v_engine->bundled_with_audio) {
 					/* Stop drain thread before disabling BUNDLE */
 					bundle_drain_thread_stop(session);
-					switch_core_media_flush_queued_read_frames(v_engine);
+					switch_core_media_flush_queued_read_frames(smh, SWITCH_MEDIA_TYPE_VIDEO);
 					if (v_engine->bundle_write_state) {
 						switch_rtp_write_state_reset(v_engine->bundle_write_state);
 					}
@@ -22628,10 +22647,8 @@ SWITCH_DECLARE(void) switch_core_media_test_unlock_read(switch_core_session_t *s
 
 SWITCH_DECLARE(void) switch_core_media_test_flush_queued_read_frames(switch_core_session_t *session, switch_media_type_t type)
 {
-	switch_rtp_engine_t *engine = test_engine(session, type);
-
-	if (engine) {
-		switch_core_media_flush_queued_read_frames(engine);
+	if (test_engine(session, type)) {
+		switch_core_media_flush_queued_read_frames(session->media_handle, type);
 	}
 }
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4247,15 +4247,26 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 		return NULL;
 	}
 
-	/* Hold the session for the life of the thread, the way video_write_thread()
-	 * and video_helper_thread() do. Without it this thread dereferences session,
-	 * its channel and its media handle with nothing keeping the session alive. */
-	if (switch_core_session_read_lock(session) != SWITCH_STATUS_SUCCESS) {
-		return NULL;
-	}
-
 	a_engine = &smh->engines[SWITCH_MEDIA_TYPE_AUDIO];
 	v_engine = &smh->engines[SWITCH_MEDIA_TYPE_VIDEO];
+
+	/* Hold the session for the life of the thread, the way video_write_thread()
+	 * and video_helper_thread() do. Without it this thread dereferences session,
+	 * its channel and its media handle with nothing keeping the session alive.
+	 *
+	 * This is a trylock that also fails on an already-down channel, and it runs
+	 * after start() published STARTING, so the failure has to unwind that state.
+	 * Left at STARTING it strands the drain: start() refuses on state != INACTIVE,
+	 * and the audio read path's STARTING branch spins on switch_yield(1000) inside
+	 * a loop whose other condition, SCMF_RUNNING, is never cleared. */
+	if (switch_core_session_read_lock(session) != SWITCH_STATUS_SUCCESS) {
+		switch_mutex_lock(smh->bundle_drain_mutex);
+		if (v_engine->bundle_drain_state == BUNDLE_DRAIN_STARTING) {
+			v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
+		}
+		switch_mutex_unlock(smh->bundle_drain_mutex);
+		return NULL;
+	}
 
 
 	/* Promote STARTING -> RUNNING under the drain mutex. stop() can legally
@@ -22707,6 +22718,13 @@ SWITCH_DECLARE(switch_thread_t *) switch_core_media_test_get_drain_thread(switch
 	switch_rtp_engine_t *v_engine = test_engine(session, SWITCH_MEDIA_TYPE_VIDEO);
 
 	return v_engine ? v_engine->bundle_drain_thread : NULL;
+}
+
+SWITCH_DECLARE(int) switch_core_media_test_get_drain_state(switch_core_session_t *session)
+{
+	switch_rtp_engine_t *engine = test_engine(session, SWITCH_MEDIA_TYPE_VIDEO);
+
+	return engine ? (int) engine->bundle_drain_state : -1;
 }
 
 SWITCH_DECLARE(void) switch_core_media_test_drain_thread_stop(switch_core_session_t *session)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4025,8 +4025,11 @@ static void switch_core_media_release_queued_read_frame(switch_rtp_engine_t *eng
  * video read path leaves engine->read_frame aliasing that clone and hands the
  * caller &engine->read_frame, then releases read_mutex before returning, so a
  * caller is still using the block after this function could take that mutex.
- * The reader owns the in-flight frame until its next pop (:release at the top of
- * the branch), and switch_media_handle_destroy() owns it after teardown.
+ * The reader owns the in-flight frame until its next pop (the release at the top
+ * of the branch), and switch_media_handle_destroy() owns it after teardown.  That
+ * relies on there being a single video reader per session -- read_mutex[type] is a
+ * trylock and is released before the frame is handed out, so it serialises the
+ * call, not the ownership handoff.  True of every in-tree reader today.
  * Frames still in the queue were never handed out, so freeing them here is safe
  * without a lock -- the frame buffer is itself thread safe. */
 static void switch_core_media_flush_queued_read_frames(switch_rtp_engine_t *engine)
@@ -4253,7 +4256,12 @@ static switch_bool_t bundle_demux_media_type(switch_media_handle_t *smh, const c
 
 	switch_mutex_lock(smh->bundle_mutex);
 
-	if ((mline = switch_bundle_group_demux_rtp(&smh->bundle, mid, ssrc, pt, NULL))) {
+	/* The state gate belongs in here with the traversal. Read outside the lock it
+	 * only says the group was accepted at some earlier instant -- a rebuild can
+	 * land in between and leave this walking a memset group. Callers keep their own
+	 * unlocked check as a fast path, but this is the one that decides. */
+	if (smh->bundle.state == SWITCH_BUNDLE_STATE_ACCEPTED &&
+		(mline = switch_bundle_group_demux_rtp(&smh->bundle, mid, ssrc, pt, NULL))) {
 		*type_out = mline->media_type;
 		found = SWITCH_TRUE;
 	}
@@ -4288,6 +4296,8 @@ static void *SWITCH_THREAD_FUNC bundle_drain_thread_func(switch_thread_t *thread
 	 * and the audio read path's STARTING branch spins on switch_yield(1000) inside
 	 * a loop whose other condition, SCMF_RUNNING, is never cleared. */
 	if (switch_core_session_read_lock(session) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+						  "BUNDLE drain thread could not hold the session; not draining\n");
 		switch_mutex_lock(smh->bundle_drain_mutex);
 		if (v_engine->bundle_drain_state == BUNDLE_DRAIN_STARTING) {
 			v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
@@ -4496,6 +4506,7 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 	switch_media_handle_t *smh = session->media_handle;
 	switch_rtp_engine_t *a_engine, *v_engine;
 	switch_thread_t *thd;
+	int waits = 0;
 
 	if (!smh) return;
 
@@ -4503,27 +4514,48 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 	v_engine = &smh->engines[SWITCH_MEDIA_TYPE_VIDEO];
 
 	switch_mutex_lock(smh->bundle_drain_mutex);
-	thd = v_engine->bundle_drain_thread;
-	if (!thd) {
-		if (v_engine->bundle_drain_state == BUNDLE_DRAIN_STOPPING) {
-			/* A concurrent stop took the handle and is inside its join. Callers rely
-			 * on "stop() returned means the thread is gone" -- deactivate_rtp()
-			 * destroys the RTP session the thread reads from, and
-			 * switch_media_handle_destroy() the frame buffer it pushes into -- so
-			 * wait for the owner instead of returning. Bounded at 5s like the other
-			 * waits on this cond. */
-			int waits = 0;
 
-			while (v_engine->bundle_drain_state == BUNDLE_DRAIN_STOPPING
-				   && v_engine->bundle_audio_read_cond && waits++ < 250) {
-				switch_thread_cond_timedwait(v_engine->bundle_audio_read_cond, smh->bundle_drain_mutex, 20000);
-			}
-		} else {
+	/* Re-latch every pass rather than deciding once. Waking only tells us the state
+	 * left STOPPING, not that no unjoined thread exists: the owner's caller can
+	 * start a replacement one mutex acquisition after its join returns
+	 * (switch_core_media_activate_rtp does exactly that), and this stop must join
+	 * that one rather than return as though the leg were quiet. */
+	for (;;) {
+		thd = v_engine->bundle_drain_thread;
+
+		if (thd) {
+			break;
+		}
+
+		if (v_engine->bundle_drain_state != BUNDLE_DRAIN_STOPPING) {
 			v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
 			bundle_audio_queue_cleanup_locked(session, smh, v_engine);
+			switch_mutex_unlock(smh->bundle_drain_mutex);
+			return;
 		}
-		switch_mutex_unlock(smh->bundle_drain_mutex);
-		return;
+
+		if (!v_engine->bundle_audio_read_cond) {
+			/* Nothing to wait on. Should not happen -- the cond is created with the
+			 * media handle -- but do not spin on the predicate if it ever does. */
+			switch_mutex_unlock(smh->bundle_drain_mutex);
+			return;
+		}
+
+		/* Deliberately unbounded. Callers rely on "stop() returned means the thread
+		 * is gone": deactivate_rtp() then destroys the RTP session the drain thread
+		 * reads from, and switch_media_handle_destroy() the frame buffer it pushes
+		 * into. A bounded wait would hand those callers a live thread, which is the
+		 * defect this wait exists to prevent. The owner's own switch_thread_join()
+		 * below is unbounded too, so this is no weaker than the guarantee a single
+		 * stop already gives, and the owner always resolves STOPPING once its join
+		 * returns. Log periodically so a drain thread that genuinely will not leave
+		 * is visible -- it can run dialplan via execute_on_media_timeout. */
+		if (++waits % 250 == 0) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+							  "BUNDLE drain stop still waiting on a concurrent join after %d ms\n", waits * 20);
+		}
+
+		switch_thread_cond_timedwait(v_engine->bundle_audio_read_cond, smh->bundle_drain_mutex, 20000);
 	}
 
 	/* Take ownership of the handle before dropping the mutex. Leaving it visible
@@ -8411,6 +8443,8 @@ static void switch_core_media_bundle_populate_from_sdp(switch_media_handle_t *sm
 	sdp_media_t *m;
 	switch_status_t bundle_group_status = SWITCH_STATUS_FALSE;
 	int mline_index = 0;
+	char mids[(SWITCH_BUNDLE_MAX_MIDS * (SWITCH_BUNDLE_MAX_MID_LEN + 1)) + 1] = "";
+	switch_bool_t accepted = SWITCH_FALSE;
 
 	if (!smh || !smh->session || !sdp) {
 		return;
@@ -8520,27 +8554,27 @@ static void switch_core_media_bundle_populate_from_sdp(switch_media_handle_t *sm
 		}
 	}
 
-	if (bundle_group_status == SWITCH_STATUS_SUCCESS) {
-		if (switch_bundle_group_validate(&smh->bundle) == SWITCH_STATUS_SUCCESS) {
-			char mids[(SWITCH_BUNDLE_MAX_MIDS * (SWITCH_BUNDLE_MAX_MID_LEN + 1)) + 1] = "";
-			uint32_t i;
+	if (bundle_group_status == SWITCH_STATUS_SUCCESS
+		&& switch_bundle_group_validate(&smh->bundle) == SWITCH_STATUS_SUCCESS) {
+		uint32_t i;
 
-			/* Compatibility/diagnostic output for an accepted group only. Media
-			 * decisions use smh->bundle and must never read this channel variable. */
-			for (i = 0; i < smh->bundle.offered_mid_count; i++) {
-				if (i) {
-					switch_snprintf(mids + strlen(mids), sizeof(mids) - strlen(mids), " ");
-				}
-				switch_snprintf(mids + strlen(mids), sizeof(mids) - strlen(mids), "%s", smh->bundle.offered_mids[i]);
+		/* Compatibility/diagnostic output for an accepted group only. Media
+		 * decisions use smh->bundle and must never read this channel variable. */
+		for (i = 0; i < smh->bundle.offered_mid_count; i++) {
+			if (i) {
+				switch_snprintf(mids + strlen(mids), sizeof(mids) - strlen(mids), " ");
 			}
-			switch_channel_set_variable(channel, "rtp_group_bundle", mids);
-		} else {
-			switch_channel_set_variable(channel, "rtp_group_bundle", NULL);
+			switch_snprintf(mids + strlen(mids), sizeof(mids) - strlen(mids), "%s", smh->bundle.offered_mids[i]);
 		}
-	} else {
-		switch_channel_set_variable(channel, "rtp_group_bundle", NULL);
+		accepted = SWITCH_TRUE;
 	}
+
+	/* Everything that reads the group is done. mids is a local, so the channel
+	 * variable below needs no protection -- and setting it under bundle_mutex would
+	 * hold a per-packet media lock across the channel profile mutex and a malloc. */
 	switch_mutex_unlock(smh->bundle_mutex);
+
+	switch_channel_set_variable(channel, "rtp_group_bundle", accepted ? mids : NULL);
 }
 
 SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *session, const char *r_sdp, uint8_t *proceed, switch_sdp_type_t sdp_type)

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4479,10 +4479,20 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 	switch_mutex_lock(smh->bundle_drain_mutex);
 	thd = v_engine->bundle_drain_thread;
 	if (!thd) {
-		/* A concurrent stop already took the handle and is inside its join; leaving
-		 * the state and the audio queue to it, since marking INACTIVE here would
-		 * publish a teardown that has not happened yet. */
-		if (v_engine->bundle_drain_state != BUNDLE_DRAIN_STOPPING) {
+		if (v_engine->bundle_drain_state == BUNDLE_DRAIN_STOPPING) {
+			/* A concurrent stop took the handle and is inside its join. Callers rely
+			 * on "stop() returned means the thread is gone" -- deactivate_rtp()
+			 * destroys the RTP session the thread reads from, and
+			 * switch_media_handle_destroy() the frame buffer it pushes into -- so
+			 * wait for the owner instead of returning. Bounded at 5s like the other
+			 * waits on this cond. */
+			int waits = 0;
+
+			while (v_engine->bundle_drain_state == BUNDLE_DRAIN_STOPPING
+				   && v_engine->bundle_audio_read_cond && waits++ < 250) {
+				switch_thread_cond_timedwait(v_engine->bundle_audio_read_cond, smh->bundle_drain_mutex, 20000);
+			}
+		} else {
 			v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
 			bundle_audio_queue_cleanup_locked(session, smh, v_engine);
 		}
@@ -4525,6 +4535,12 @@ static void bundle_drain_thread_stop(switch_core_session_t *session)
 	if (!v_engine->bundle_drain_thread) {
 		bundle_audio_queue_cleanup_locked(session, smh, v_engine);
 		v_engine->bundle_drain_state = BUNDLE_DRAIN_INACTIVE;
+	}
+	/* Release any stop waiting on this join. Broadcast, not signal: more than one
+	 * can be queued, and the other waiters on this cond re-check their own
+	 * predicates in a loop so a spurious wake is harmless. */
+	if (v_engine->bundle_audio_read_cond) {
+		switch_thread_cond_broadcast(v_engine->bundle_audio_read_cond);
 	}
 	switch_mutex_unlock(smh->bundle_drain_mutex);
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 			   switch_ivr_play_say switch_core_codec switch_rtp switch_xml
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log switch_stun switch_trickle_ice switch_bundle
 
-noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup test_dtmf_sent_event
+noinst_PROGRAMS += switch_hold switch_sip switch_mod_telnyx switch_mod_gstt switch_3pcc test_inuse_race switch_jb_deadlock switch_cjson switch_sockaddr test_rtp_set_flag_null_crash test_write_frame_foreign_codec test_video_bridge_engine_race switch_apr_cleanup test_dtmf_sent_event test_bundle_read_frame_lock
 
 # switch_mod_lumenvox is intentionally NOT built/run in CI yet: LumenVox servers
 # are not reachable from CI, so the ASR tests cannot run there. Re-enable by

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -1,33 +1,17 @@
-/*
- * The BUNDLE video read path hands callers a frame whose data/packet pointers
- * live inside engine->read_fb_frame:
+/* Regression tests for the BUNDLE read and drain defects found alongside
+ * TELCORE-453: TELCORE-454 (the flush freeing a frame a reader still holds),
+ * TELCORE-455 (bundle_drain_thread_stop leaving the handle joinable twice),
+ * TELCORE-456 (the drain thread holding no session read lock), TELCORE-457
+ * (SFF_DYNAMIC copied onto a pool-embedded frame) and TELCORE-459 (the BUNDLE
+ * group rebuilt under the SIP thread while the drain thread traverses it).
  *
- *   switch_core_media.c:4664   switch_core_media_release_queued_read_frame(engine);
- *   switch_core_media.c:4674   engine->read_fb_frame = (switch_frame_t *) pop;
- *   switch_core_media.c:4675   engine->read_frame = *engine->read_fb_frame;
+ * struct switch_media_handle_s and struct switch_rtp_engine_s are private to
+ * switch_core_media.c and the drain helpers are static, so these drive the
+ * switch_core_media_test_* seam declared in switch_core_media.h.
  *
- * That whole branch runs under smh->read_mutex[SWITCH_MEDIA_TYPE_VIDEO], taken at
- * switch_core_media.c:4642, and the frame stays referenced by engine->read_frame
- * after the caller returns.
- *
- * switch_core_media_flush_queued_read_frames() frees that same frame:
- *
- *   switch_core_media.c:4013   switch_core_media_release_queued_read_frame(engine);
- *                              -> switch_frame_free(&engine->read_fb_frame)
- *
- * and takes no lock at all. It is called from the signalling thread at
- * switch_core_media.c:14301 and :14312, both before bundle_drain_thread_stop(),
- * so the drain thread is still producing and the video reader is still consuming.
- *
- * Two threads therefore free the same malloc-backed clone, and the reader keeps
- * using engine->read_frame.data after the signalling thread has freed the block
- * behind it.
- *
- * The invariant: a caller that frees the queued read frame must hold the same
- * read mutex the reader holds while using it. This test holds that mutex and
- * asserts flush blocks. On the current tree flush ignores the mutex and completes
- * immediately, so the first check fails.
- */
+ * Every case asserts a steady state held open rather than racing for a window,
+ * so none of them is probabilistic. Each pins one production line; see the
+ * per-test comments. */
 
 #define SWITCH_CORE_MEDIA_TEST_HOOKS
 #include <switch.h>

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -379,6 +379,85 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEST_END()
 
+		/* Callers of bundle_drain_thread_stop() rely on "returned means the thread
+		 * is joined": switch_core_media_deactivate_rtp() destroys the RTP session
+		 * the drain thread blocks inside, and switch_media_handle_destroy()
+		 * destroys the frame buffer it pushes into. Since 4941a8254f takes the
+		 * handle exclusively, a second concurrent stop finds NULL -- it must WAIT
+		 * for the owner to finish the join, not return early. Concurrent stops are
+		 * reachable: sofia drops tech_pvt->sofia_mutex across
+		 * sofia_media_activate_rtp_unlocked(). */
+		FST_TEST_BEGIN(test_second_drain_thread_stop_waits_for_the_join)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_threadattr_t *thd_attr = NULL;
+			switch_thread_t *stopper = NULL, *parked = NULL;
+			struct parked_thread park = { 0, 0 };
+			struct stop_job job;
+			switch_status_t st;
+			int waited, second_returned_early;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+			pool = switch_core_session_get_pool(session);
+
+			switch_threadattr_create(&thd_attr, pool);
+			switch_threadattr_detach_set(thd_attr, 0);
+			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+
+			/* A stand-in drain thread that stays alive until released, so the first
+			 * stop is provably parked inside switch_thread_join(). */
+			fst_requires(switch_thread_create(&parked, thd_attr, parked_thread_fn, &park, pool) == SWITCH_STATUS_SUCCESS);
+			for (waited = 0; waited < 500 && !park.running; waited++) {
+				switch_yield(10000);
+			}
+			fst_requires(park.running == 1);
+			switch_core_media_test_arm_drain(session, parked);
+
+			job.session = session;
+			job.done = 0;
+			fst_requires(switch_thread_create(&stopper, thd_attr, stop_thread_fn, &job, pool) == SWITCH_STATUS_SUCCESS);
+
+			/* First stopper is now inside the join and owns the handle. */
+			switch_yield(300000);
+			fst_requires(job.done == 0);
+			fst_requires(switch_core_media_test_get_drain_thread(session) == NULL);
+
+			/* THE CRUX: a second stop must block until the thread is really gone. */
+			{
+				struct stop_job job2;
+				switch_thread_t *stopper2 = NULL;
+
+				job2.session = session;
+				job2.done = 0;
+				fst_requires(switch_thread_create(&stopper2, thd_attr, stop_thread_fn, &job2, pool) == SWITCH_STATUS_SUCCESS);
+				switch_yield(300000);
+				second_returned_early = job2.done;
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+								  "[TEST] second stop returned while the thread was still running = %d (expect 0)\n",
+								  second_returned_early);
+				fst_check(second_returned_early == 0);
+
+				/* Release, then both stops must complete. */
+				park.release = 1;
+				for (waited = 0; waited < 500 && !(job.done && job2.done); waited++) {
+					switch_yield(10000);
+				}
+				fst_check(job.done == 1);
+				fst_check(job2.done == 1);
+				switch_thread_join(&st, stopper2);
+			}
+
+			switch_thread_join(&st, stopper);
+			switch_thread_join(&st, parked);
+
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+
 		/* bundle_frame_dup() marks its clones SFF_DYNAMIC (switch_core_media.c:4072,
 		 * :4098) because they are malloc-backed and released with switch_frame_free().
 		 * The bundled-video read branch then copies the whole frame, flags included,

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -283,7 +283,7 @@ FST_CORE_BEGIN("./conf")
 			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
 
 			pool = switch_core_session_get_pool(session);
-			rtp = switch_rtp_new("127.0.0.1", 12340, "127.0.0.1", 12342, 8, 8000, 20 * 1000,
+			rtp = switch_rtp_new("127.0.0.1", 12380, "127.0.0.1", 12382, 8, 8000, 20 * 1000,
 								 rtp_flags, "soft", &err, pool);
 			fst_requires(rtp);
 			fst_requires(switch_rtp_ready(rtp));
@@ -502,6 +502,10 @@ FST_CORE_BEGIN("./conf")
 							  "[TEST] read_frame status=%d frame=%p\n", st, (void *) out);
 			fst_requires(st == SWITCH_STATUS_SUCCESS);
 			fst_requires(out != NULL);
+			/* Without this the dummy CNG frame the branch returns on a pop miss would
+			 * satisfy every assertion below and the test would be vacuous. */
+			fst_requires(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == clone);
+			fst_requires(out->data == clone->data);
 
 			/* THE CRUX: the frame handed out lives in the session pool, so it must
 			 * not advertise itself as heap-owned. */

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -326,6 +326,59 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEST_END()
 
+		/* bundle_drain_thread_func() takes the session read lock with a TRYlock that
+		 * also fails when the channel is already down, and it does that after
+		 * bundle_drain_thread_start() has published BUNDLE_DRAIN_STARTING. If the
+		 * failure path returns without unwinding that state, the drain state is
+		 * stranded at STARTING with a dead thread: start() then refuses forever
+		 * (state != INACTIVE) and an audio reader that lands on the STARTING branch
+		 * spins on switch_yield(1000) inside a loop whose only other condition,
+		 * SCMF_RUNNING, is never cleared anywhere in the tree.
+		 *
+		 * State values mirror the private defines: 0 INACTIVE, 1 STARTING. */
+		FST_TEST_BEGIN(test_drain_thread_unwinds_state_when_the_read_lock_fails)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_rtp_t *rtp = NULL;
+			switch_rtp_flag_t rtp_flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+			const char *err = NULL;
+			int waited, state;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+
+			pool = switch_core_session_get_pool(session);
+			rtp = switch_rtp_new("127.0.0.1", 12388, "127.0.0.1", 12390, 8, 8000, 20 * 1000,
+								 rtp_flags, "soft", &err, pool);
+			fst_requires(rtp);
+			fst_requires(switch_core_media_test_prepare_bundle_drain(session, rtp) == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_core_media_test_get_drain_state(session) == 0);
+
+			/* Make the read lock fail: switch_core_session_read_lock() rejects a
+			 * channel that is already down. */
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			fst_requires(switch_core_session_read_lock(session) != SWITCH_STATUS_SUCCESS);
+
+			switch_core_media_test_drain_thread_start(session);
+			fst_requires(switch_core_media_test_get_drain_thread(session) != NULL);
+
+			/* Let the thread reach its read-lock attempt and give up. */
+			for (waited = 0; waited < 200 && switch_core_media_test_get_drain_state(session) != 0; waited++) {
+				switch_yield(10000);
+			}
+
+			state = switch_core_media_test_get_drain_state(session);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] drain state after a failed read lock = %d (expect 0 INACTIVE)\n", state);
+			fst_check(state == 0);
+
+			switch_core_media_test_drain_thread_stop(session);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+
 		/* bundle_frame_dup() marks its clones SFF_DYNAMIC (switch_core_media.c:4072,
 		 * :4098) because they are malloc-backed and released with switch_frame_free().
 		 * The bundled-video read branch then copies the whole frame, flags included,

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -1,0 +1,418 @@
+/*
+ * The BUNDLE video read path hands callers a frame whose data/packet pointers
+ * live inside engine->read_fb_frame:
+ *
+ *   switch_core_media.c:4664   switch_core_media_release_queued_read_frame(engine);
+ *   switch_core_media.c:4674   engine->read_fb_frame = (switch_frame_t *) pop;
+ *   switch_core_media.c:4675   engine->read_frame = *engine->read_fb_frame;
+ *
+ * That whole branch runs under smh->read_mutex[SWITCH_MEDIA_TYPE_VIDEO], taken at
+ * switch_core_media.c:4642, and the frame stays referenced by engine->read_frame
+ * after the caller returns.
+ *
+ * switch_core_media_flush_queued_read_frames() frees that same frame:
+ *
+ *   switch_core_media.c:4013   switch_core_media_release_queued_read_frame(engine);
+ *                              -> switch_frame_free(&engine->read_fb_frame)
+ *
+ * and takes no lock at all. It is called from the signalling thread at
+ * switch_core_media.c:14301 and :14312, both before bundle_drain_thread_stop(),
+ * so the drain thread is still producing and the video reader is still consuming.
+ *
+ * Two threads therefore free the same malloc-backed clone, and the reader keeps
+ * using engine->read_frame.data after the signalling thread has freed the block
+ * behind it.
+ *
+ * The invariant: a caller that frees the queued read frame must hold the same
+ * read mutex the reader holds while using it. This test holds that mutex and
+ * asserts flush blocks. On the current tree flush ignores the mutex and completes
+ * immediately, so the first check fails.
+ */
+
+#define SWITCH_CORE_MEDIA_TEST_HOOKS
+#include <switch.h>
+#include <test/switch_test.h>
+
+static switch_core_session_t *originate_null_session(void)
+{
+	switch_core_session_t *session = NULL;
+	switch_call_cause_t cause = SWITCH_CAUSE_NONE;
+	switch_status_t status;
+
+	status = switch_ivr_originate(NULL, &session, &cause,
+								  "null/+15553334444",
+								  0, NULL, NULL, NULL, NULL, NULL, SOF_NONE, NULL, NULL);
+
+	if (status != SWITCH_STATUS_SUCCESS || !session) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+						  "[TEST] originate failed: status=%d cause=%d\n", status, cause);
+		return NULL;
+	}
+	return session;
+}
+
+static switch_status_t attach_media_handle(switch_core_session_t *session)
+{
+	switch_media_handle_t *media_handle = NULL;
+	switch_core_media_params_t *mparams;
+
+	mparams = switch_core_session_alloc(session, sizeof(*mparams));
+	mparams->num_codecs = 1;
+	mparams->inbound_codec_string = switch_core_session_strdup(session, "PCMU");
+	mparams->outbound_codec_string = switch_core_session_strdup(session, "PCMU");
+	mparams->rtpip = switch_core_session_strdup(session, "127.0.0.1");
+
+	return switch_media_handle_create(&media_handle, session, mparams);
+}
+
+/* A malloc-backed clone of the shape bundle_frame_dup() produces
+ * (switch_core_media.c:4062-4106): SFF_DYNAMIC, heap frame, heap data. */
+static switch_frame_t *make_dynamic_frame(void)
+{
+	switch_frame_t *frame = malloc(sizeof(*frame));
+
+	if (!frame) return NULL;
+
+	memset(frame, 0, sizeof(*frame));
+	frame->data = malloc(SWITCH_RECOMMENDED_BUFFER_SIZE);
+	if (!frame->data) {
+		free(frame);
+		return NULL;
+	}
+	frame->buflen = SWITCH_RECOMMENDED_BUFFER_SIZE;
+	frame->datalen = 160;
+	switch_set_flag(frame, SFF_DYNAMIC);
+
+	return frame;
+}
+
+/* Stands in for the drain thread: parks until released, so a stop() that reaches
+ * switch_thread_join() stays inside the join for as long as the test wants. */
+struct parked_thread {
+	volatile int release;
+	volatile int running;
+};
+
+static void *SWITCH_THREAD_FUNC parked_thread_fn(switch_thread_t *thread, void *obj)
+{
+	struct parked_thread *p = (struct parked_thread *) obj;
+
+	p->running = 1;
+	while (!p->release) {
+		switch_yield(5000);
+	}
+
+	return NULL;
+}
+
+struct stop_job {
+	switch_core_session_t *session;
+	volatile int done;
+};
+
+static void *SWITCH_THREAD_FUNC stop_thread_fn(switch_thread_t *thread, void *obj)
+{
+	struct stop_job *job = (struct stop_job *) obj;
+
+	switch_core_media_test_drain_thread_stop(job->session);
+	job->done = 1;
+
+	return NULL;
+}
+
+struct flush_job {
+	switch_core_session_t *session;
+	switch_media_type_t type;
+	volatile int done;
+};
+
+static void *SWITCH_THREAD_FUNC flush_thread(switch_thread_t *thread, void *obj)
+{
+	struct flush_job *job = (struct flush_job *) obj;
+
+	switch_core_media_test_flush_queued_read_frames(job->session, job->type);
+	job->done = 1;
+
+	return NULL;
+}
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(bundle_read_frame_lock)
+	{
+		FST_SETUP_BEGIN()
+		{
+			fst_requires_module("mod_loopback");
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(test_flush_queued_read_frames_respects_video_read_lock)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_threadattr_t *thd_attr = NULL;
+			switch_thread_t *thread = NULL;
+			switch_status_t st;
+			struct flush_job job;
+			switch_frame_t *frame = NULL;
+			int waited;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_core_media_test_prepare_read_fb(session, SWITCH_MEDIA_TYPE_VIDEO) == SWITCH_STATUS_SUCCESS);
+
+			frame = make_dynamic_frame();
+			fst_requires(frame);
+			switch_core_media_test_set_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO, frame);
+			fst_requires(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == frame);
+
+			/* Stand in for the video reader: it holds this mutex for the whole of
+			 * the BUNDLE branch and leaves engine->read_frame pointing into the
+			 * queued frame afterwards. */
+			fst_requires(switch_core_media_test_lock_read(session, SWITCH_MEDIA_TYPE_VIDEO) == SWITCH_STATUS_SUCCESS);
+
+			pool = switch_core_session_get_pool(session);
+			job.session = session;
+			job.type = SWITCH_MEDIA_TYPE_VIDEO;
+			job.done = 0;
+
+			switch_threadattr_create(&thd_attr, pool);
+			switch_threadattr_detach_set(thd_attr, 0);
+			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+			fst_requires(switch_thread_create(&thread, thd_attr, flush_thread, &job, pool) == SWITCH_STATUS_SUCCESS);
+
+			switch_yield(300000);
+
+			/* THE CRUX. The reader still holds the lock, so nothing may have freed
+			 * the frame it is using. */
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] flush completed while the video read lock was held = %d (expect 0)\n", job.done);
+			fst_check(job.done == 0);
+
+			switch_core_media_test_unlock_read(session, SWITCH_MEDIA_TYPE_VIDEO);
+
+			for (waited = 0; waited < 500 && !job.done; waited++) {
+				switch_yield(10000);
+			}
+			fst_check(job.done == 1);
+
+			switch_thread_join(&st, thread);
+
+			/* Once it does run, it must have released the frame. */
+			fst_check(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == NULL);
+
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+
+		/* bundle_drain_thread_stop() latches the thread handle at
+		 * switch_core_media.c:4448, drops bundle_drain_mutex at :4458, joins at
+		 * :4478 and only then clears the handle at :4482. A second stop arriving
+		 * in that window -- switch_core_media_activate_rtp() has no reentrancy
+		 * guard, and mod_sofia calls it both locked (sofia_media_activate_rtp)
+		 * and unlocked (sofia_media_activate_rtp_unlocked) -- reads the same
+		 * non-NULL handle and joins it a second time. The loser then stores NULL
+		 * over whatever handle the winner has since started, orphaning a live
+		 * drain thread that keeps using the session after it is destroyed.
+		 *
+		 * The invariant: once a stop has committed to tearing the thread down it
+		 * must publish that, so no concurrent stop can latch the same handle.
+		 * This test parks the drain thread inside the join and asserts the handle
+		 * is no longer visible. */
+		FST_TEST_BEGIN(test_drain_thread_stop_does_not_expose_a_joined_handle)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_threadattr_t *thd_attr = NULL;
+			switch_thread_t *parked = NULL, *stopper = NULL;
+			struct parked_thread park = { 0, 0 };
+			struct stop_job job;
+			switch_thread_t *visible = NULL;
+			switch_status_t st;
+			int waited;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+
+			pool = switch_core_session_get_pool(session);
+			switch_threadattr_create(&thd_attr, pool);
+			switch_threadattr_detach_set(thd_attr, 0);
+			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+			fst_requires(switch_thread_create(&parked, thd_attr, parked_thread_fn, &park, pool) == SWITCH_STATUS_SUCCESS);
+
+			for (waited = 0; waited < 500 && !park.running; waited++) {
+				switch_yield(10000);
+			}
+			fst_requires(park.running == 1);
+
+			switch_core_media_test_arm_drain(session, parked);
+			fst_requires(switch_core_media_test_get_drain_thread(session) == parked);
+
+			job.session = session;
+			job.done = 0;
+			fst_requires(switch_thread_create(&stopper, thd_attr, stop_thread_fn, &job, pool) == SWITCH_STATUS_SUCCESS);
+
+			/* The stopper is now inside switch_thread_join() on the parked thread. */
+			switch_yield(300000);
+			fst_requires(job.done == 0);
+
+			/* THE CRUX. A concurrent stop reads this handle and joins it too. */
+			visible = switch_core_media_test_get_drain_thread(session);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] drain thread handle still visible during join = %p (expect NULL)\n", (void *) visible);
+			fst_check(visible == NULL);
+
+			park.release = 1;
+
+			for (waited = 0; waited < 500 && !job.done; waited++) {
+				switch_yield(10000);
+			}
+			fst_check(job.done == 1);
+
+			switch_thread_join(&st, stopper);
+			fst_check(switch_core_media_test_get_drain_thread(session) == NULL);
+
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+
+		/* Every other session-attached thread in switch_core_media.c opens with
+		 * switch_core_session_read_lock() and closes with switch_core_session_rwunlock():
+		 * video_write_thread (:10811), audio_write_thread (:11248), text_helper_thread
+		 * (:11362), video_helper_thread (:11526), dtls_init_job (:22060).
+		 * bundle_drain_thread_func (:4227) takes none. Its only lifetime guarantee is
+		 * the switch_thread_join() in bundle_drain_thread_stop(), so any path that
+		 * misses that join leaves it running against a destroyed session -- and its
+		 * own thread handle is allocated from that session's pool.
+		 *
+		 * Measured as a controlled experiment, because the test itself holds a read
+		 * lock from originate: release that first, confirm the write lock is then
+		 * takeable (so the probe means something), start the drain thread, and confirm
+		 * it is no longer takeable. */
+		FST_TEST_BEGIN(test_drain_thread_holds_a_session_read_lock)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_rtp_t *rtp = NULL;
+			switch_rtp_flag_t rtp_flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+			const char *err = NULL;
+			switch_status_t before, during;
+			int waited;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+
+			pool = switch_core_session_get_pool(session);
+			rtp = switch_rtp_new("127.0.0.1", 12340, "127.0.0.1", 12342, 8, 8000, 20 * 1000,
+								 rtp_flags, "soft", &err, pool);
+			fst_requires(rtp);
+			fst_requires(switch_rtp_ready(rtp));
+
+			fst_requires(switch_core_media_test_prepare_bundle_drain(session, rtp) == SWITCH_STATUS_SUCCESS);
+
+			/* Drop the read lock originate handed us, or the probe below can never
+			 * succeed and the measurement would be meaningless. */
+			switch_core_session_rwunlock(session);
+
+			/* CONTROL: with no drain thread running the write lock must be takeable.
+			 * If this fails the probe proves nothing and the test is invalid. */
+			before = switch_core_media_test_try_session_write_lock(session);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] control: write lock takeable before drain starts = %d (expect 1)\n",
+							  before == SWITCH_STATUS_SUCCESS);
+			fst_requires(before == SWITCH_STATUS_SUCCESS);
+
+			switch_core_media_test_drain_thread_start(session);
+
+			for (waited = 0; waited < 500 && !switch_core_media_test_get_drain_thread(session); waited++) {
+				switch_yield(10000);
+			}
+			fst_requires(switch_core_media_test_get_drain_thread(session) != NULL);
+			switch_yield(200000);
+
+			/* THE CRUX: a running session-attached thread must hold a read lock. */
+			during = switch_core_media_test_try_session_write_lock(session);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] write lock still takeable while the drain thread runs = %d (expect 0)\n",
+							  during == SWITCH_STATUS_SUCCESS);
+			fst_check(during == SWITCH_STATUS_FALSE);
+
+			switch_core_media_test_drain_thread_stop(session);
+
+			fst_requires(switch_core_session_read_lock(session) == SWITCH_STATUS_SUCCESS);
+			switch_rtp_destroy(&rtp);
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+
+		/* bundle_frame_dup() marks its clones SFF_DYNAMIC (switch_core_media.c:4072,
+		 * :4098) because they are malloc-backed and released with switch_frame_free().
+		 * The bundled-video read branch then copies the whole frame, flags included,
+		 * onto engine->read_frame (:4675), which is embedded in switch_rtp_engine_t
+		 * inside the session-pool media handle -- and hands it to the caller.
+		 *
+		 * switch_frame_free() treats SFF_DYNAMIC as "this is heap, free it": it would
+		 * free() an interior pointer into the session pool and release the clone's
+		 * packet out from under engine->read_fb_frame. Nothing in tree frees a
+		 * returned read frame today, so this is latent rather than live, but the flag
+		 * stops being a usable ownership discriminator. */
+		FST_TEST_BEGIN(test_bundled_video_read_frame_is_not_marked_dynamic)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_rtp_t *rtp = NULL;
+			switch_rtp_flag_t rtp_flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
+			const char *err = NULL;
+			switch_frame_t *clone = NULL, *out = NULL;
+			switch_status_t st;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+
+			pool = switch_core_session_get_pool(session);
+			rtp = switch_rtp_new("127.0.0.1", 12360, "127.0.0.1", 12362, 8, 8000, 20 * 1000,
+								 rtp_flags, "soft", &err, pool);
+			fst_requires(rtp);
+			fst_requires(switch_rtp_ready(rtp));
+
+			fst_requires(switch_core_media_test_prepare_bundle_drain(session, rtp) == SWITCH_STATUS_SUCCESS);
+			fst_requires(switch_core_media_test_prepare_engine_read(session, SWITCH_MEDIA_TYPE_VIDEO, rtp) == SWITCH_STATUS_SUCCESS);
+
+			clone = make_dynamic_frame();
+			fst_requires(clone);
+			fst_requires(switch_test_flag(clone, SFF_DYNAMIC));
+			fst_requires(switch_core_media_test_push_read_fb(session, SWITCH_MEDIA_TYPE_VIDEO, clone) == SWITCH_STATUS_SUCCESS);
+
+			st = switch_core_media_read_frame(session, &out, SWITCH_IO_FLAG_NONE, 0, SWITCH_MEDIA_TYPE_VIDEO);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] read_frame status=%d frame=%p\n", st, (void *) out);
+			fst_requires(st == SWITCH_STATUS_SUCCESS);
+			fst_requires(out != NULL);
+
+			/* THE CRUX: the frame handed out lives in the session pool, so it must
+			 * not advertise itself as heap-owned. */
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] returned read frame carries SFF_DYNAMIC = %d (expect 0)\n",
+							  switch_test_flag(out, SFF_DYNAMIC) ? 1 : 0);
+			fst_check(!switch_test_flag(out, SFF_DYNAMIC));
+
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -120,22 +120,6 @@ static void *SWITCH_THREAD_FUNC stop_thread_fn(switch_thread_t *thread, void *ob
 	return NULL;
 }
 
-struct flush_job {
-	switch_core_session_t *session;
-	switch_media_type_t type;
-	volatile int done;
-};
-
-static void *SWITCH_THREAD_FUNC flush_thread(switch_thread_t *thread, void *obj)
-{
-	struct flush_job *job = (struct flush_job *) obj;
-
-	switch_core_media_test_flush_queued_read_frames(job->session, job->type);
-	job->done = 1;
-
-	return NULL;
-}
-
 FST_CORE_BEGIN("./conf")
 {
 	FST_SUITE_BEGIN(bundle_read_frame_lock)
@@ -151,61 +135,47 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEARDOWN_END()
 
-		FST_TEST_BEGIN(test_flush_queued_read_frames_respects_video_read_lock)
+		/* The bundled video read branch leaves engine->read_frame aliasing the
+		 * popped clone and hands the caller &engine->read_frame, then releases
+		 * read_mutex before returning. So a flush that frees engine->read_fb_frame
+		 * pulls the block out from under a caller that is still using it -- taking
+		 * the read mutex inside the flush does not help, because the caller is no
+		 * longer holding it. The invariant is that the flush must not touch the
+		 * in-flight frame at all; the reader owns it until its next pop, and
+		 * switch_media_handle_destroy() owns it after teardown.
+		 *
+		 * The queue-draining half of the flush is unchanged, so it needs no new
+		 * assertion here. */
+		FST_TEST_BEGIN(test_flush_queued_read_frames_leaves_the_in_flight_frame)
 		{
 			switch_core_session_t *session = NULL;
-			switch_memory_pool_t *pool = NULL;
-			switch_threadattr_t *thd_attr = NULL;
-			switch_thread_t *thread = NULL;
-			switch_status_t st;
-			struct flush_job job;
 			switch_frame_t *frame = NULL;
-			int waited;
+			switch_frame_t *queued = NULL;
 
 			session = originate_null_session();
 			fst_requires(session);
 			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
 			fst_requires(switch_core_media_test_prepare_read_fb(session, SWITCH_MEDIA_TYPE_VIDEO) == SWITCH_STATUS_SUCCESS);
 
+			/* Stands in for the frame a reader has already been handed. */
 			frame = make_dynamic_frame();
 			fst_requires(frame);
 			switch_core_media_test_set_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO, frame);
 			fst_requires(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == frame);
 
-			/* Stand in for the video reader: it holds this mutex for the whole of
-			 * the BUNDLE branch and leaves engine->read_frame pointing into the
-			 * queued frame afterwards. */
-			fst_requires(switch_core_media_test_lock_read(session, SWITCH_MEDIA_TYPE_VIDEO) == SWITCH_STATUS_SUCCESS);
+			/* Something still queued, so the flush has real work to do. */
+			queued = make_dynamic_frame();
+			fst_requires(queued);
+			fst_requires(switch_core_media_test_push_read_fb(session, SWITCH_MEDIA_TYPE_VIDEO, queued) == SWITCH_STATUS_SUCCESS);
 
-			pool = switch_core_session_get_pool(session);
-			job.session = session;
-			job.type = SWITCH_MEDIA_TYPE_VIDEO;
-			job.done = 0;
+			/* The realistic case: the reader has returned, so nothing holds the mutex. */
+			switch_core_media_test_flush_queued_read_frames(session, SWITCH_MEDIA_TYPE_VIDEO);
 
-			switch_threadattr_create(&thd_attr, pool);
-			switch_threadattr_detach_set(thd_attr, 0);
-			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
-			fst_requires(switch_thread_create(&thread, thd_attr, flush_thread, &job, pool) == SWITCH_STATUS_SUCCESS);
-
-			switch_yield(300000);
-
-			/* THE CRUX. The reader still holds the lock, so nothing may have freed
-			 * the frame it is using. */
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-							  "[TEST] flush completed while the video read lock was held = %d (expect 0)\n", job.done);
-			fst_check(job.done == 0);
-
-			switch_core_media_test_unlock_read(session, SWITCH_MEDIA_TYPE_VIDEO);
-
-			for (waited = 0; waited < 500 && !job.done; waited++) {
-				switch_yield(10000);
-			}
-			fst_check(job.done == 1);
-
-			switch_thread_join(&st, thread);
-
-			/* Once it does run, it must have released the frame. */
-			fst_check(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == NULL);
+							  "[TEST] in-flight frame after flush = %p (expect %p)\n",
+							  (void *) switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO),
+							  (void *) frame);
+			fst_check(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == frame);
 
 			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 			switch_core_session_rwunlock(session);

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -105,6 +105,23 @@ static void *SWITCH_THREAD_FUNC parked_thread_fn(switch_thread_t *thread, void *
 	return NULL;
 }
 
+struct demux_job {
+	switch_core_session_t *session;
+	volatile int started;
+	volatile int done;
+};
+
+static void *SWITCH_THREAD_FUNC demux_thread_fn(switch_thread_t *thread, void *obj)
+{
+	struct demux_job *job = (struct demux_job *) obj;
+
+	job->started = 1;
+	switch_core_media_test_demux_media_type(job->session, "0", 0x1234, 96);
+	job->done = 1;
+
+	return NULL;
+}
+
 struct stop_job {
 	switch_core_session_t *session;
 	volatile int done;
@@ -513,6 +530,65 @@ FST_CORE_BEGIN("./conf")
 							  "[TEST] returned read frame carries SFF_DYNAMIC = %d (expect 0)\n",
 							  switch_test_flag(out, SFF_DYNAMIC) ? 1 : 0);
 			fst_check(!switch_test_flag(out, SFF_DYNAMIC));
+
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
+			switch_core_session_rwunlock(session);
+		}
+		FST_TEST_END()
+
+		/* The SIP thread re-initialises smh->bundle wholesale on every received SDP
+		 * (switch_bundle_group_init memsets the group, then add_mline repopulates
+		 * it), while the drain thread and the audio read path traverse the same
+		 * group per packet and write SSRC bindings into it. Nothing serialised the
+		 * two. The demux must therefore not proceed while a writer holds the bundle
+		 * lock. Deterministic: the lock is held open, not raced for. */
+		FST_TEST_BEGIN(test_bundle_demux_serialises_against_the_writer)
+		{
+			switch_core_session_t *session = NULL;
+			switch_memory_pool_t *pool = NULL;
+			switch_threadattr_t *thd_attr = NULL;
+			switch_thread_t *reader = NULL;
+			struct demux_job job;
+			switch_status_t st;
+			int waited;
+
+			session = originate_null_session();
+			fst_requires(session);
+			fst_requires(attach_media_handle(session) == SWITCH_STATUS_SUCCESS);
+			pool = switch_core_session_get_pool(session);
+
+			/* Stands in for the SIP thread inside switch_core_media_bundle_populate_from_sdp(). */
+			switch_core_media_test_lock_bundle(session);
+
+			job.session = session;
+			job.done = 0;
+			job.started = 0;
+
+			switch_threadattr_create(&thd_attr, pool);
+			switch_threadattr_detach_set(thd_attr, 0);
+			switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
+			fst_requires(switch_thread_create(&reader, thd_attr, demux_thread_fn, &job, pool) == SWITCH_STATUS_SUCCESS);
+
+			for (waited = 0; waited < 500 && !job.started; waited++) {
+				switch_yield(10000);
+			}
+			/* Proves the reader really reached the demux, so job.done == 0 below
+			 * cannot mean "the thread never ran". */
+			fst_requires(job.started == 1);
+
+			switch_yield(300000);
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] demux completed while the bundle writer held the lock = %d (expect 0)\n", job.done);
+			fst_check(job.done == 0);
+
+			switch_core_media_test_unlock_bundle(session);
+
+			for (waited = 0; waited < 500 && !job.done; waited++) {
+				switch_yield(10000);
+			}
+			fst_check(job.done == 1);
+			switch_thread_join(&st, reader);
 
 			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 			switch_core_session_rwunlock(session);

--- a/tests/unit/test_bundle_read_frame_lock.c
+++ b/tests/unit/test_bundle_read_frame_lock.c
@@ -152,6 +152,7 @@ FST_CORE_BEGIN("./conf")
 			switch_core_session_t *session = NULL;
 			switch_frame_t *frame = NULL;
 			switch_frame_t *queued = NULL;
+			switch_frame_t *popped = NULL;
 
 			session = originate_null_session();
 			fst_requires(session);
@@ -164,7 +165,8 @@ FST_CORE_BEGIN("./conf")
 			switch_core_media_test_set_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO, frame);
 			fst_requires(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == frame);
 
-			/* Something still queued, so the flush has real work to do. */
+			/* Something queued, so the flush has real work to do -- and so this test
+			 * can tell "left the in-flight frame alone" from "did nothing at all". */
 			queued = make_dynamic_frame();
 			fst_requires(queued);
 			fst_requires(switch_core_media_test_push_read_fb(session, SWITCH_MEDIA_TYPE_VIDEO, queued) == SWITCH_STATUS_SUCCESS);
@@ -177,6 +179,13 @@ FST_CORE_BEGIN("./conf")
 							  (void *) switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO),
 							  (void *) frame);
 			fst_check(switch_core_media_test_get_read_fb_frame(session, SWITCH_MEDIA_TYPE_VIDEO) == frame);
+
+			/* THE OTHER HALF: the queue must be empty. Without this a flush whose body
+			 * is `return;` satisfies the assertion above and the test is vacuous. */
+			popped = switch_core_media_test_pop_read_fb(session, SWITCH_MEDIA_TYPE_VIDEO);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							  "[TEST] queued frame still in the buffer after flush = %p (expect NULL)\n", (void *) popped);
+			fst_check(popped == NULL);
 
 			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 			switch_core_session_rwunlock(session);
@@ -344,7 +353,7 @@ FST_CORE_BEGIN("./conf")
 			switch_rtp_t *rtp = NULL;
 			switch_rtp_flag_t rtp_flags[SWITCH_RTP_FLAG_INVALID] = { 0 };
 			const char *err = NULL;
-			int waited, state;
+			int waited, state, held_write_lock = 0;
 
 			session = originate_null_session();
 			fst_requires(session);
@@ -357,10 +366,15 @@ FST_CORE_BEGIN("./conf")
 			fst_requires(switch_core_media_test_prepare_bundle_drain(session, rtp) == SWITCH_STATUS_SUCCESS);
 			fst_requires(switch_core_media_test_get_drain_state(session) == 0);
 
-			/* Make the read lock fail: switch_core_session_read_lock() rejects a
-			 * channel that is already down. */
-			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
-			fst_requires(switch_core_session_read_lock(session) != SWITCH_STATUS_SUCCESS);
+			/* Make the read lock fail while leaving the channel UP. Hanging up instead
+			 * would make this vacuous: with the channel down the thread promotes to
+			 * RUNNING, the loop condition fails immediately and the tail sets INACTIVE
+			 * anyway, so state 0 would be satisfied by a thread that never attempted
+			 * the lock at all. Holding the session write lock makes the trylock fail
+			 * and nothing else. */
+			switch_core_session_rwunlock(session);
+			held_write_lock = 1;
+			fst_requires(switch_core_media_test_hold_session_write_lock(session) == SWITCH_STATUS_SUCCESS);
 
 			switch_core_media_test_drain_thread_start(session);
 			fst_requires(switch_core_media_test_get_drain_thread(session) != NULL);
@@ -375,8 +389,15 @@ FST_CORE_BEGIN("./conf")
 							  "[TEST] drain state after a failed read lock = %d (expect 0 INACTIVE)\n", state);
 			fst_check(state == 0);
 
+			switch_core_media_test_release_session_write_lock(session);
+			held_write_lock = 0;
+			fst_requires(switch_core_session_read_lock(session) == SWITCH_STATUS_SUCCESS);
+
 			switch_core_media_test_drain_thread_stop(session);
+			switch_rtp_destroy(&rtp);
+			switch_channel_hangup(switch_core_session_get_channel(session), SWITCH_CAUSE_NORMAL_CLEARING);
 			switch_core_session_rwunlock(session);
+			(void) held_write_lock;
 		}
 		FST_TEST_END()
 


### PR DESCRIPTION
Thirteen commits: a shared test seam, four failing reproductions, one fix per ticket, and three rounds of corrections that multi-agent review forced. Every fix is watched failing first.

## Tickets

| | |
|---|---|
| [TELCORE-454](https://linear.app/telnyx/issue/TELCORE-454/) | `flush_queued_read_frames()` frees the queued video read frame a reader still holds |
| [TELCORE-455](https://linear.app/telnyx/issue/TELCORE-455/) | `bundle_drain_thread_stop()` leaves the handle visible while joining, allowing a double join |
| [TELCORE-456](https://linear.app/telnyx/issue/TELCORE-456/) | `bundle_drain_thread_func()` holds no session read lock |
| [TELCORE-457](https://linear.app/telnyx/issue/TELCORE-457/) | Bundled read frame handed to callers flagged `SFF_DYNAMIC` |
| [TELCORE-459](https://linear.app/telnyx/issue/TELCORE-459/) | `smh->bundle` rebuilt on every received SDP while the drain thread traverses it |

One branch rather than five PRs because the reproductions share a single test binary: split up, every intermediate PR is red until the last lands. Separate commits still give per-issue review and per-issue revert.

## The seam

`struct switch_media_handle_s` and `struct switch_rtp_engine_s` are private to `switch_core_media.c`, and `bundle_drain_thread_{func,start,stop}` / `release_queued_read_frame` are static, so a unit test can neither construct the BUNDLE read state nor call the code that mishandles it. The `switch_core_media_test_*` accessors expose enough to drive the drain lifecycle, the bundled video read path and the BUNDLE group. Declarations sit behind `SWITCH_CORE_MEDIA_TEST_HOOKS`, which `switch_core_media.c` also defines so the definitions are prototype-checked against the header.

**They ship in `libfreeswitch`** — following `switch_rtp_test_rewrite_mid_extension()`, but that precedent is one pure function over a caller-owned buffer, and these mutate live session state. Gating them behind a configure switch is the correct resolution and is not done here. See Open questions.

## The fixes

**454** — the read path leaves `engine->read_frame` aliasing the popped heap clone, hands the caller `&engine->read_frame`, then releases `read_mutex` before returning. The first attempt took that mutex inside the flush, which serialises against the read *call* and not the *use*; it also guarded on a mutex that does not exist yet on first BUNDLE activation. The flush now drains the queue and nothing else, leaving the in-flight frame a single owner: the reader releases it at its next pop, `switch_media_handle_destroy()` after teardown. The `(smh, type)` signature reverted to `(engine)`.

**455** — the handle is cleared under `bundle_drain_mutex` before the join, so a concurrent stop cannot join it twice. That stop then re-latches in a loop rather than returning: waking only says the state left `STOPPING`, not that no unjoined thread exists, and the owner's caller can start a replacement one mutex acquisition after its join returns. The wait is deliberately unbounded — the owner's own `switch_thread_join()` is unbounded, so a bound is strictly weaker than the guarantee one stop already gives, and it would hand `deactivate_rtp()` a live thread whose RTP session it is about to destroy. It warns every 5s, because the drain thread can run dialplan via `execute_on_media_timeout`.

**456** — the drain thread was the only thread in the file touching `session`, `session->channel` and `session->media_handle` without holding the session; `video_write_thread()` and `video_helper_thread()` both read-lock. The read lock is a trylock that also fails on an already-down channel and runs after `STARTING` is published, so the failure unwinds that state — left stranded it wedges `start()` forever and spins the audio read path on a loop whose other condition, `SCMF_RUNNING`, is never cleared anywhere in tree.

**457** — both copy sites (bundled video and bundled audio) clear `SFF_DYNAMIC` after the wholesale struct copy. The frame handed out is `&engine->read_frame`, embedded in the session-pool media handle, and `switch_frame_free()` reads that flag as "heap, free it".

**459** — `switch_bundle_group_init()` memsets the group and the m-line loop repopulates it, on every received SDP from the SIP thread, while the drain thread and the audio read path traverse it per packet *and* write SSRC bindings into it. `switch_bundle_group_add_mline()` also published `mline_count++` before zeroing the slot, so a reader could pick up the previous negotiation's `media_type`. Both callers only needed `mline->media_type`, so the lookup, the `ACCEPTED` gate and that read moved into one helper under a new `smh->bundle_mutex`; the writer holds the same mutex across the rebuild. Locking only the lookup would not have helped — the m-line the old code returned stayed live in the caller's hands.

## Verification

Seven tests, each asserting a steady state held open rather than racing a window. All were watched failing first, and non-vacuity was re-proven by reverting each fix against a stubbed library and confirming only the matching test goes red.

```
PASSED (7/7 tests)
```

`switch_sdp` 11/11, `switch_bundle` 19/19, `switch_trickle_ice` 19/19, `switch_core_video` 5/5, `switch_core_session` 6/6, `switch_core_codec` 5/5, `switch_ivr_async` 3/3, `switch_hold` 1/1, `switch_jb_deadlock` 1/1. Stable across repeated runs, including under heavy load. Core builds clean.

## What review changed

Four independent reviewers ran twice over this branch. Round one found that three of the four original fixes were wrong — 456 introduced an unbounded spin holding `read_mutex[AUDIO]`, 454 narrowed rather than closed the use-after-free, 455 broke the "stop() returned means joined" contract, and 457 fixed one of two identical sites. Round two found the 455 timeout re-expressed the same defect, that 459's state gate sat outside its own lock, and that two tests still passed against reverted fixes. All of that is in the corrective commits.

## Untested, stated rather than implied

- The writer-side `bundle_mutex` — the test stands in for the SIP thread with a hook rather than driving `populate_from_sdp()`.
- The audio half of the `SFF_DYNAMIC` clear — reaching that branch needs the audio drain queue driven through direct-read admission, which the seam does not expose.
- The explicit release in `switch_media_handle_destroy()` — a leak, so it needs a sanitizer run this suite does not do.
- The stop-path broadcast — the 20ms `timedwait` predicate loop resolves without it.

## Open questions

- **The seam ships.** Three reviewers flagged it; two call it merge-blocking. `--enable-test-hooks` (or moving the hooks into a `noinst` object the tests link directly) is the fix and is real build work.
- `fst_requires` after `switch_thread_create` expands to `break`, so a failing assertion abandons threads pointing at dead stack and leaves `bundle_mutex` held; a forced failure was measured at 26.6s instead of 6s. Failure-path only — reporting still works — but it wants a cleanup label.

## Known defects in this neighbourhood, deliberately not addressed

- The drain thread's video push takes no mutex and re-checks no state, unlike the audio push. Pre-existing, and what would turn a stuck join into a use-after-free on `read_fb`.
- `execute_on_media_timeout` runs a dialplan application on the sole BUNDLE socket reader, which is what makes an unbounded join reachable at all.
- Because the group's state is `NONE` for the duration of a rebuild, `route_bundled_rtp()` declines and a bundled video packet takes the audio path for that window. Fixing it needs the group built off to the side and published rather than rebuilt in place.
- `switch_types.h:1757` documents `SFF_DYNAMIC` as `(1 << 5)`; the enum says `(1 << 6)` and `(1 << 5)` is `SFF_PROXY_PACKET`. The block is also wrong for `SFF_MARKER` and `SFF_WAIT_KEY_FRAME`. Nothing depends on the documented values.