### PR TITLE
TELCORE-462: allow the hostname reported by FreeSWITCH to be overridden

### DIFF
--- a/conf/vanilla/autoload_configs/switch.conf.xml
+++ b/conf/vanilla/autoload_configs/switch.conf.xml
@@ -37,6 +37,15 @@
 	as different hostnames.
     -->
     <!-- <param name="switchname" value="freeswitch"/> -->
+
+    <!--
+	Override the hostname reported by gethostname().
+	Intended for containerised deployments that cannot set the kernel UTS
+	hostname. Unlike switchname, this replaces the value used for the
+	FreeSWITCH-Hostname event header and the "hostname" core variable.
+	When set, the periodic host/IP check will not revert it.
+    -->
+    <!-- <param name="hostname" value="freeswitch"/> -->
     <!-- <param name="cpu-idle-smoothing-depth" value="30"/> -->
 
 

--- a/src/include/private/switch_core_pvt.h
+++ b/src/include/private/switch_core_pvt.h
@@ -283,6 +283,7 @@ struct switch_runtime {
 	double min_idle_time;
 	switch_dbtype_t odbc_dbtype;
 	char hostname[256];
+	uint8_t hostname_overridden;
 	char *switchname;
 	int multiple_registrations;
 	uint32_t max_db_handles;

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -142,19 +142,21 @@ static void check_ip(void)
 	switch_event_t *event;
 	char *hostname = switch_core_get_variable("hostname");
 
-	gethostname(runtime.hostname, sizeof(runtime.hostname));
+	if (!runtime.hostname_overridden) {
+		gethostname(runtime.hostname, sizeof(runtime.hostname));
 
-	if (zstr(hostname)) {
-		switch_core_set_variable("hostname", runtime.hostname);
-	} else if (strcmp(hostname, runtime.hostname)) {
-		if (switch_event_create(&event, SWITCH_EVENT_TRAP) == SWITCH_STATUS_SUCCESS) {
-			switch_event_add_header(event, SWITCH_STACK_BOTTOM, "condition", "hostname-change");
-			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "old-hostname", hostname);
-			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "new-hostname", runtime.hostname);
-			switch_event_fire(&event);
+		if (zstr(hostname)) {
+			switch_core_set_variable("hostname", runtime.hostname);
+		} else if (strcmp(hostname, runtime.hostname)) {
+			if (switch_event_create(&event, SWITCH_EVENT_TRAP) == SWITCH_STATUS_SUCCESS) {
+				switch_event_add_header(event, SWITCH_STACK_BOTTOM, "condition", "hostname-change");
+				switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "old-hostname", hostname);
+				switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "new-hostname", runtime.hostname);
+				switch_event_fire(&event);
+			}
+
+			switch_core_set_variable("hostname", runtime.hostname);
 		}
-
-		switch_core_set_variable("hostname", runtime.hostname);
 	}
 
 	check4 = switch_find_local_ip(guess_ip4, sizeof(guess_ip4), &mask, AF_INET);
@@ -2387,6 +2389,17 @@ static void switch_load_core_config(const char *file)
 				} else if (!strcasecmp(var, "switchname") && !zstr(val)) {
 					runtime.switchname = switch_core_strdup(runtime.memory_pool, val);
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "Set switchname to %s\n", runtime.switchname);
+				} else if (!strcasecmp(var, "hostname") && !zstr(val)) {
+					/* Override the value reported by gethostname(). Containerised
+					   deployments cannot set the kernel UTS hostname (no CAP_SYS_ADMIN,
+					   and Kubernetes spec.hostname must be a DNS-1123 label so it
+					   cannot carry a dot), yet consumers parse FreeSWITCH-Hostname
+					   expecting the <prefix>.<node> form. Latching this also stops the
+					   periodic check_ip() re-read from reverting it. */
+					switch_copy_string(runtime.hostname, val, sizeof(runtime.hostname));
+					runtime.hostname_overridden = 1;
+					switch_core_set_variable("hostname", runtime.hostname);
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "Set hostname to %s\n", runtime.hostname);
 				} else if (!strcasecmp(var, "rtp-retain-crypto-keys")) {
 					if (switch_true(val)) {
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,


### PR DESCRIPTION
## Problem

`FreeSWITCH-Hostname` cannot be changed on Kubernetes.

`runtime.hostname` is written **only** by `gethostname(2)`, at two unconditional call sites:

```
src/switch_core.c:1813   gethostname(runtime.hostname, sizeof(runtime.hostname));   // core init
src/switch_core.c:145    gethostname(runtime.hostname, sizeof(runtime.hostname));   // check_ip(), periodic
```

Verified absent in this tree:

- no `hostname` parameter in the `switch.conf.xml` parser
- no `switch_core_set_hostname()`, and no other assignment to `runtime.hostname`
- no environment variable (the only `getenv` calls in core are `FREESWITCH_BG_TIMEOUT` and `FREESWITCH_OPTS`)
- no command-line flag

`switchname` does not solve it. The two values are independent and are emitted as separate headers, side by side:

```c
/* src/switch_event.c:1988-1989 */
switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "FreeSWITCH-Hostname",   switch_core_get_hostname());
switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "FreeSWITCH-Switchname", switch_core_get_switchname());
```

`switch_core_get_switchname()` falls back to `runtime.hostname`, but never the reverse — so setting `switchname` can never influence `FreeSWITCH-Hostname`.

## Why this matters for containers

A pod cannot set its own kernel UTS hostname — no `CAP_SYS_ADMIN`. Confirmed on a live b2bua pod:

```
$ hostname b2bua.tel-fl1-tbm-dev-2000
hostname: you must be root to change the host name
CapEff: 00000000a80435fb
```

And `spec.hostname` in Kubernetes must be a DNS-1123 label, so it cannot contain a dot.

Meanwhile consumers parse `FreeSWITCH-Hostname` expecting the `<prefix>.<node>` form. On a k8s pod they receive the bare kernel hostname and fail to resolve the node:

```
Event-Name: HEARTBEAT
FreeSWITCH-Hostname:   tel-fl1-tbm-dev-2000        <- gethostname()
FreeSWITCH-Switchname: b2bua.tel-fl1-tbm-dev-2000  <- switchname param
```

## Change

Adds a `hostname` parameter to `switch.conf.xml`, beside the existing `switchname` parameter.

**`src/switch_core.c`, config parser** — sets the value and latches it:

```c
} else if (!strcasecmp(var, "hostname") && !zstr(val)) {
    switch_copy_string(runtime.hostname, val, sizeof(runtime.hostname));
    runtime.hostname_overridden = 1;
    switch_core_set_variable("hostname", runtime.hostname);
    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "Set hostname to %s\n", runtime.hostname);
```

**`src/switch_core.c`, `check_ip()`** — the guard that makes it stick. `check_ip()` runs from a scheduler task (`SSHF_OWN_THREAD`, `:1991`) and re-reads `gethostname()` on every tick. Without this guard the override would silently revert:

```c
if (!runtime.hostname_overridden) {
    gethostname(runtime.hostname, sizeof(runtime.hostname));
    /* existing hostname-change TRAP event logic, unchanged */
}
```

**`src/include/private/switch_core_pvt.h`** — one `uint8_t hostname_overridden;` in `struct switch_runtime`.

**`conf/vanilla/autoload_configs/switch.conf.xml`** — commented-out documented example, matching how `switchname` is documented.

## Why this ordering works

```
:1813  gethostname(runtime.hostname, ...)        core init, always runs first
:1922  switch_core_set_variable("hostname", ...)
:1975  switch_load_core_config("switch.conf")    <- parameter applies here, overwrites
:1991  scheduler starts check_ip_callback        <- guard prevents revert
```

The kernel value remains the default. The parameter only replaces it when explicitly set.

## Backward compatibility

No behaviour change when the parameter is absent. `runtime` is zeroed by `memset(&runtime, 0, sizeof(runtime))` at `:1810`, so `hostname_overridden` is `0` and `check_ip()` behaves exactly as before. The existing `hostname-change` TRAP event is untouched in that path.

`switch_copy_string` is used rather than `switch_core_strdup` because `runtime.hostname` is a fixed `char[256]`, not a pointer — matching how `gethostname()` already fills it, and truncating safely.

## Testing

- C90 compliance: declarations at top of scope, no C99 constructs. The extracted logic compiles clean under `-std=c90 -Wall -Wdeclaration-after-statement -pedantic`, and a runtime assertion confirms the override lands and `check_ip()` does not revert it.
- `switch_copy_string` confirmed exported at `src/include/switch_apr.h:104`.
- `git diff --check` clean.

**Not yet built.** The working tree has no `switch_am_config.h` (needs `./configure`), so a full compile was not run locally — CI is the authority here. Requesting a build before merge.

## Risk

`switch_core_get_hostname()` has 32 call sites, several in `switch_core_sqldb.c` where core DB rows are keyed on hostname (`:2744` uses switchname and hostname in the same statement). Changing the reported hostname changes those keys. This PR only adds the capability and leaves it off by default; enabling it per-deployment should be assessed against anything that joins on that value.

## Related

Consumed by the b2bua image change that renders this parameter when `ENV_K8S=true`, which stacks on b2bua#409.

Ticket: [TELCORE-462](https://linear.app/telnyx/issue/TELCORE-462/set-a-stable-freeswitch-hostname-for-b2bua-on-kubernetes)

TELCORE-462
